### PR TITLE
fix: commit guard whitelist, state dir dual-write, and review findings (#10, #7, #11)

### DIFF
--- a/hooks/block-manual-merge-ops.sh
+++ b/hooks/block-manual-merge-ops.sh
@@ -37,7 +37,7 @@ fi
 # Ref: Issue #10 — AI self-bypass via branch rename (2026-03-22)
 # -m/-M: rename branch to bypass prefix-based guards
 # -f/-F: force-set branch pointer to move commits across branches
-if echo "$CMD_FIRST" | grep -qE 'git\s+branch\s+-[mMfF]\b'; then
+if echo "$CMD_FIRST" | grep -qE 'git\s+branch\s+(-[mMfF]\b|--move\b|--force\b)'; then
     echo "[BLOCK] ブランチポインタの操作はコミットガードのバイパスにつながるため禁止。" >&2
     echo "理由: -m (rename) / -f (force move) でコミット制限を回避できてしまう。" >&2
     echo "正しい方法: subagent/TeamCreate でfeatureブランチにcommitしてください。" >&2

--- a/hooks/block-manual-merge-ops.sh
+++ b/hooks/block-manual-merge-ops.sh
@@ -33,6 +33,15 @@ if echo "$CMD_FIRST" | grep -qE 'git\s+pull\b'; then
     exit 0
 fi
 
+# BLOCK: git branch -m/-M (rename) — prevents commit guard bypass
+# Ref: Issue #10 — AI self-bypass via branch rename (2026-03-22)
+if echo "$CMD_FIRST" | grep -qE 'git\s+branch\s+-[mM]\b'; then
+    echo "[BLOCK] ブランチ名の変更はコミットガードのバイパスにつながるため禁止。" >&2
+    echo "理由: feat/→update/ 等のリネームでコミット制限を回避できてしまう。" >&2
+    echo "正しい方法: subagent/TeamCreate でfeatureブランチにcommitしてください。" >&2
+    exit 2
+fi
+
 # BLOCK: git cherry-pick (still risky — conflict-prone)
 if echo "$CMD_FIRST" | grep -qE 'git\s+cherry-pick\b'; then
     echo "[BLOCK] cherry-pickは自力で実行しない。Codex CLI経路Cに委任してください。" >&2

--- a/hooks/block-manual-merge-ops.sh
+++ b/hooks/block-manual-merge-ops.sh
@@ -33,11 +33,13 @@ if echo "$CMD_FIRST" | grep -qE 'git\s+pull\b'; then
     exit 0
 fi
 
-# BLOCK: git branch -m/-M (rename) — prevents commit guard bypass
+# BLOCK: git branch -m/-M (rename) and -f/-F (force move) — prevents commit guard bypass
 # Ref: Issue #10 — AI self-bypass via branch rename (2026-03-22)
-if echo "$CMD_FIRST" | grep -qE 'git\s+branch\s+-[mM]\b'; then
-    echo "[BLOCK] ブランチ名の変更はコミットガードのバイパスにつながるため禁止。" >&2
-    echo "理由: feat/→update/ 等のリネームでコミット制限を回避できてしまう。" >&2
+# -m/-M: rename branch to bypass prefix-based guards
+# -f/-F: force-set branch pointer to move commits across branches
+if echo "$CMD_FIRST" | grep -qE 'git\s+branch\s+-[mMfF]\b'; then
+    echo "[BLOCK] ブランチポインタの操作はコミットガードのバイパスにつながるため禁止。" >&2
+    echo "理由: -m (rename) / -f (force move) でコミット制限を回避できてしまう。" >&2
     echo "正しい方法: subagent/TeamCreate でfeatureブランチにcommitしてください。" >&2
     exit 2
 fi

--- a/hooks/git-commit-guard.sh
+++ b/hooks/git-commit-guard.sh
@@ -10,24 +10,32 @@ if ! echo "$cmd" | grep -qE 'git\s+commit\s+.*-m'; then
     exit 0
 fi
 
-# --- Rule 0: Block direct commits on feature branches from main session ---
-# TeamCreate workers and subagents are exempt (they SHOULD commit)
+# --- Rule 0: Block direct commits on non-base branches from main session ---
+# WHITELIST approach: only base branches (develop, main, master) allowed for main agent.
+# All other branches require delegation to subagent/TeamCreate.
+# This prevents bypass via creative branch naming (e.g., update/, hotfix/, etc.)
+# Ref: Issue #10 — AI self-bypass via branch rename (2026-03-22)
 if [[ "${CLAUDE_AGENT_DEPTH:-0}" -eq 0 ]] && [[ -z "${CLAUDE_AGENT_ID:-}" ]]; then
     current_branch=$(git branch --show-current 2>/dev/null || echo "")
-    if echo "$current_branch" | grep -qE '^(feat|fix|refactor|chore)/'; then
-        echo "🚫 [Delegation Required] メインエージェントはfeatureブランチに直接commitできません。" >&2
-        echo "" >&2
-        echo "ブランチ: $current_branch" >&2
-        echo "" >&2
-        echo "対応方法:" >&2
-        echo "  1. TeamCreate でワーカーに委任する" >&2
-        echo "  2. /review-loop で自動修正ループを起動する" >&2
-        echo "  3. Agent tool (team_name付き) でワーカーに作業させる" >&2
-        echo "" >&2
-        echo "理由: メインが直接featureブランチで作業すると、" >&2
-        echo "  未関係ファイルの混入、ruff format漏れ、コンテキスト消費が発生する。" >&2
-        exit 2
-    fi
+    # Whitelist: only base branches are allowed for main agent commits
+    case "$current_branch" in
+        develop|main|master|"") ;; # allowed (empty = detached HEAD, let other checks handle)
+        *)
+            echo "🚫 [Delegation Required] メインエージェントは非ベースブランチに直接commitできません。" >&2
+            echo "" >&2
+            echo "ブランチ: $current_branch" >&2
+            echo "" >&2
+            echo "対応方法:" >&2
+            echo "  1. Agent tool (subagent_type=general-purpose) でcommitを委任" >&2
+            echo "  2. TeamCreate でワーカーに委任する" >&2
+            echo "  3. /review-loop で自動修正ループを起動する" >&2
+            echo "" >&2
+            echo "理由: メインが直接featureブランチで作業すると、" >&2
+            echo "  未関係ファイルの混入やゲートバイパスが発生する。" >&2
+            echo "  ブランチ名変更によるバイパス防止のためホワイトリスト方式に変更済み。" >&2
+            exit 2
+            ;;
+    esac
 fi
 
 # --- Extract commit message ---

--- a/hooks/git-commit-guard.sh
+++ b/hooks/git-commit-guard.sh
@@ -15,11 +15,28 @@ fi
 # All other branches require delegation to subagent/TeamCreate.
 # This prevents bypass via creative branch naming (e.g., update/, hotfix/, etc.)
 # Ref: Issue #10 — AI self-bypass via branch rename (2026-03-22)
-if [[ "${CLAUDE_AGENT_DEPTH:-0}" -eq 0 ]] && [[ -z "${CLAUDE_AGENT_ID:-}" ]]; then
+#
+# Subagent detection: check BOTH env var AND JSON input for agent context.
+# CLAUDE_AGENT_DEPTH may not propagate to hook processes, so also check
+# agent_id in the stdin JSON (official Claude Code hook spec).
+IS_SUBAGENT="false"
+if [[ "${CLAUDE_AGENT_DEPTH:-0}" -ge 1 ]] || [[ -n "${CLAUDE_AGENT_ID:-}" ]]; then
+    IS_SUBAGENT="true"
+fi
+# Also check JSON input for agent_id (more reliable than env vars)
+if command -v jq &>/dev/null && [[ -n "$input" ]]; then
+    json_agent_id=$(echo "$input" | jq -r '.agent_id // ""' 2>/dev/null || echo "")
+    [[ -n "$json_agent_id" ]] && IS_SUBAGENT="true"
+fi
+if [[ "$IS_SUBAGENT" == "false" ]]; then
     current_branch=$(git branch --show-current 2>/dev/null || echo "")
     # Whitelist: only base branches are allowed for main agent commits
     case "$current_branch" in
-        develop|main|master|"") ;; # allowed (empty = detached HEAD, let other checks handle)
+        develop|main|master) ;; # allowed base branches
+        "")
+            echo "🚫 [Delegation Required] detached HEAD状態でのcommitはsubagentに委任してください。" >&2
+            exit 2
+            ;;
         *)
             echo "🚫 [Delegation Required] メインエージェントは非ベースブランチに直接commitできません。" >&2
             echo "" >&2

--- a/hooks/pr-ci-review-gate.sh
+++ b/hooks/pr-ci-review-gate.sh
@@ -367,7 +367,12 @@ with open(f_path, 'r+') as f:
 " 2>/dev/null
 
   # Reset review status for this branch (push invalidates prior reviews)
-  _STATE="$REVIEW_STATE" _BR="$BRANCH" python3 -c "
+  # Dual-reset: clear from BOTH project-scoped AND global state
+  # to prevent stale code_review=true from satisfying gates (Codex P2 finding)
+  GLOBAL_REVIEW="$HOME/.claude/state/review-status.json"
+  for _target in "$REVIEW_STATE" "$GLOBAL_REVIEW"; do
+    [[ ! -f "$_target" ]] && continue
+    _STATE="$_target" _BR="$BRANCH" python3 -c "
 import json, os, fcntl
 f_path = os.environ['_STATE']
 with open(f_path, 'r+') as f:
@@ -378,6 +383,7 @@ with open(f_path, 'r+') as f:
     json.dump(s, f, indent=2)
     fcntl.flock(f, fcntl.LOCK_UN)
 " 2>/dev/null
+  done
 
   # Classify tier to show appropriate requirements
   TIER=$(classify_review_tier "$BRANCH")

--- a/hooks/record-code-review.sh
+++ b/hooks/record-code-review.sh
@@ -45,17 +45,25 @@ if [[ "$IS_REVIEW" != "true" ]]; then
   exit 0
 fi
 
-# Determine state directory
+# Determine state directories — write to BOTH global and project-scoped
+# to prevent CWD-dependent state mismatch (Issue #7)
+GLOBAL_STATE_DIR="$HOME/.claude/state"
+mkdir -p "$GLOBAL_STATE_DIR"
+[ ! -f "$GLOBAL_STATE_DIR/review-status.json" ] && echo '{}' > "$GLOBAL_STATE_DIR/review-status.json"
+
+PROJECT_STATE_DIR=""
 if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
-  STATE_DIR="${CLAUDE_PROJECT_DIR}/.claude/state"
+  PROJECT_STATE_DIR="${CLAUDE_PROJECT_DIR}/.claude/state"
 elif git rev-parse --show-toplevel &>/dev/null; then
-  STATE_DIR="$(git rev-parse --show-toplevel)/.claude/state"
-else
-  STATE_DIR="$HOME/.claude/state"
+  PROJECT_STATE_DIR="$(git rev-parse --show-toplevel)/.claude/state"
 fi
-REVIEW_STATE="$STATE_DIR/review-status.json"
-mkdir -p "$STATE_DIR"
-[ ! -f "$REVIEW_STATE" ] && echo '{}' > "$REVIEW_STATE"
+if [[ -n "$PROJECT_STATE_DIR" ]] && [[ "$PROJECT_STATE_DIR" != "$GLOBAL_STATE_DIR" ]]; then
+  mkdir -p "$PROJECT_STATE_DIR"
+  [ ! -f "$PROJECT_STATE_DIR/review-status.json" ] && echo '{}' > "$PROJECT_STATE_DIR/review-status.json"
+fi
+
+# Primary state file (global — always consistent regardless of CWD)
+REVIEW_STATE="$GLOBAL_STATE_DIR/review-status.json"
 
 # Get current branch
 BRANCH=$(git branch --show-current 2>/dev/null || echo "")
@@ -80,6 +88,17 @@ s.setdefault(os.environ['_BR'], {})['code_review'] = True
 s[os.environ['_BR']]['code_review_at'] = os.environ['_NOW']
 with open(f_path, 'w') as f: json.dump(s, f, indent=2)
 " 2>/dev/null || true
+fi
+
+# Also write to project-scoped state if it exists (dual-write for CWD consistency)
+if [[ -n "$PROJECT_STATE_DIR" ]] && [[ "$PROJECT_STATE_DIR" != "$GLOBAL_STATE_DIR" ]]; then
+  PROJECT_REVIEW="$PROJECT_STATE_DIR/review-status.json"
+  if command -v jq &>/dev/null; then
+    tmp=$(mktemp)
+    jq --arg b "$BRANCH" --arg t "$NOW" \
+      '.[$b] = ((.[$b] // {}) + {"code_review": true, "code_review_at": $t})' \
+      "$PROJECT_REVIEW" > "$tmp" 2>/dev/null && mv "$tmp" "$PROJECT_REVIEW"
+  fi
 fi
 
 echo "✅ [review-gate] code-reviewer 完了を記録: branch=$BRANCH" >&2

--- a/hooks/record-code-review.sh
+++ b/hooks/record-code-review.sh
@@ -95,9 +95,29 @@ if [[ -n "$PROJECT_STATE_DIR" ]] && [[ "$PROJECT_STATE_DIR" != "$GLOBAL_STATE_DI
   PROJECT_REVIEW="$PROJECT_STATE_DIR/review-status.json"
   if command -v jq &>/dev/null; then
     tmp=$(mktemp)
-    jq --arg b "$BRANCH" --arg t "$NOW" \
+    if jq --arg b "$BRANCH" --arg t "$NOW" \
       '.[$b] = ((.[$b] // {}) + {"code_review": true, "code_review_at": $t})' \
-      "$PROJECT_REVIEW" > "$tmp" 2>/dev/null && mv "$tmp" "$PROJECT_REVIEW"
+      "$PROJECT_REVIEW" > "$tmp" 2>/dev/null; then
+      mv "$tmp" "$PROJECT_REVIEW"
+    else
+      rm -f "$tmp"
+      # Reset corrupted file and retry once
+      echo '{}' > "$PROJECT_REVIEW"
+      tmp=$(mktemp)
+      jq --arg b "$BRANCH" --arg t "$NOW" \
+        '.[$b] = {"code_review": true, "code_review_at": $t}' \
+        "$PROJECT_REVIEW" > "$tmp" 2>/dev/null && mv "$tmp" "$PROJECT_REVIEW" || rm -f "$tmp"
+    fi
+  else
+    # Fallback: python3 (same as global write path)
+    _STATE="$PROJECT_REVIEW" _BR="$BRANCH" _NOW="$NOW" python3 -c "
+import json, os
+f_path = os.environ['_STATE']
+with open(f_path) as f: s = json.load(f)
+s.setdefault(os.environ['_BR'], {})['code_review'] = True
+s[os.environ['_BR']]['code_review_at'] = os.environ['_NOW']
+with open(f_path, 'w') as f: json.dump(s, f, indent=2)
+" 2>/dev/null || true
   fi
 fi
 

--- a/rules/delegation.md
+++ b/rules/delegation.md
@@ -37,6 +37,12 @@ Claude Code が `review-status.json` に手動で `true` を書き込み、code-
 - `block-state-file-tampering-bash.sh` (Bash PreToolUse) — Bash経由の改ざんもブロック
 - レビュー記録は `record-code-review.sh` (PostToolUse hook) のみが行う
 
+## Codex MCP 使用禁止（2026-03-22追加）
+**Codex は CLI (`codex exec`, `codex-parallel.sh`, `codex-orchestrate.sh`) 経由でのみ使用する。**
+MCP (`mcp__codex__codex`) は正式な委任経路ではない。
+- サブエージェントが git commit 等の操作で Codex MCP にフォールバックすることを禁止
+- Ref: Issue #11 — subagent が MCP Codex を使用した事故 (2026-03-22)
+
 ## 核心ルール
 - 独立タスクは必ず並列実行。順次は依存関係がある場合のみ
 - **2タスク以上の独立実装 → Agent Team（TeamCreate）必須**


### PR DESCRIPTION
## Summary
Follow-up to PRs #3 and #9. Addresses Issues #10, #7, #11.

### Commits (3, all via subagent — no branch rename bypass)
1. `a603797` — Whitelist commit guard + dual-write state directory
2. `a4cbcd1` — Address code-reviewer CRITICAL/HIGH findings
3. `319e6c3` — Address Codex CLI P1/P2 findings + MCP prohibition rule

### Changes

**Issue #10: AI self-bypass prevention**
- git-commit-guard.sh: whitelist approach (only develop/main/master for main agent)
- git-commit-guard.sh: detect subagent via JSON agent_id (not just env var)
- git-commit-guard.sh: block detached HEAD commits
- block-manual-merge-ops.sh: block git branch -m/-M/-f/-F and --move/--force

**Issue #7: State directory consistency**
- record-code-review.sh: dual-write to global + project-scoped state
- record-code-review.sh: jq failure cleanup + python3 fallback for project write
- pr-ci-review-gate.sh POST_PUSH: dual-reset review state (global + project)

**Issue #11: Codex MCP prohibition**
- delegation.md: explicit rule prohibiting mcp__codex__codex usage

### Review Pipeline (both passed)
- code-reviewer agent: 1 CRITICAL (git branch -f bypass) + 1 HIGH (temp file leak) → both fixed
- Codex CLI Route A: P1 (--move/--force long flags) + P2 (stale global state) → both fixed

### Process compliance
- All commits made via subagent (not main agent)
- No branch renaming to bypass guards
- Code reviewer + Codex CLI review both completed before PR

Closes #10
Partial fix for #7
Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * Git ブランチの手動リネーム操作をブロックする保護機構を追加しました。
  * コミット操作をベースブランチに限定するルールに更新しました。

* **Chores**
  * レビュー状態管理を複数ファイル間で同期するように改善しました。
  * Codex MCP の使用ルールを明文化し、CLI 経由のみの利用に統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->