### PR TITLE
fix: dedent inline Python and restore nested block indentation (#4)

### DIFF
--- a/hooks/_unused/post-push-review-check.sh
+++ b/hooks/_unused/post-push-review-check.sh
@@ -38,21 +38,21 @@ if [ -n "$PR_NUMBER" ]; then
     [ ! -f "$REVIEW_STATE" ] && echo '{}' > "$REVIEW_STATE"
 
     _REVIEW_STATE="$REVIEW_STATE" _PR="$PR_NUMBER" _BR="$BRANCH" _NOW="$NOW" python3 -c "
-    import json, os
-    f = os.environ['_REVIEW_STATE']
-    with open(f) as fh:
-        s = json.load(fh)
-    s[os.environ['_PR']] = {
-        'status': 'review_pending',
-        'branch': os.environ['_BR'],
-        'push_at': os.environ['_NOW'],
-        'blocking_count': -1,
-        'must_fix_count': -1,
-        'verified': False
-    }
-    with open(f, 'w') as fh:
-        json.dump(s, fh, indent=2)
-    " 2>/dev/null
+import json, os
+f = os.environ['_REVIEW_STATE']
+with open(f) as fh:
+    s = json.load(fh)
+s[os.environ['_PR']] = {
+    'status': 'review_pending',
+    'branch': os.environ['_BR'],
+    'push_at': os.environ['_NOW'],
+    'blocking_count': -1,
+    'must_fix_count': -1,
+    'verified': False
+}
+with open(f, 'w') as fh:
+    json.dump(s, fh, indent=2)
+" 2>/dev/null
 
     echo "" >&2
     echo "🔒 [Pessimistic Lock] PR #${PR_NUMBER} を review_pending に設定。" >&2
@@ -87,14 +87,14 @@ if [ -n "$PR_NUMBER" ]; then
 
         # Write auto-review-needed flag to state
         _REVIEW_STATE="$REVIEW_STATE" _PR="$PR_NUMBER" python3 -c "
-    import json, os
-    f = os.environ['_REVIEW_STATE']
-    with open(f) as fh:
-        s = json.load(fh)
-    s[os.environ['_PR']]['auto_review_needed'] = True
-    with open(f, 'w') as fh:
-        json.dump(s, fh, indent=2)
-    " 2>/dev/null
+import json, os
+f = os.environ['_REVIEW_STATE']
+with open(f) as fh:
+    s = json.load(fh)
+s[os.environ['_PR']]['auto_review_needed'] = True
+with open(f, 'w') as fh:
+    json.dump(s, fh, indent=2)
+" 2>/dev/null
     fi
 fi
 

--- a/hooks/block-merge-without-review.sh
+++ b/hooks/block-merge-without-review.sh
@@ -37,24 +37,24 @@ fi
 REVIEW_LOCK="$_STATE_BASE/pr-review-lock.json"
 if [ -f "$REVIEW_LOCK" ]; then
     LOCK_STATUS=$(_REVIEW_LOCK="$REVIEW_LOCK" _PR="$PR_NUM" python3 -c "
-    import json, os
-    with open(os.environ['_REVIEW_LOCK']) as f:
-        s = json.load(f)
-    pr = s.get(os.environ['_PR'], {})
-    if not pr.get('verified', False):
-        print('LOCKED')
-    else:
-        print('OK')
-    " 2>/dev/null || echo "OK")
+import json, os
+with open(os.environ['_REVIEW_LOCK']) as f:
+    s = json.load(f)
+pr = s.get(os.environ['_PR'], {})
+if not pr.get('verified', False):
+    print('LOCKED')
+else:
+    print('OK')
+" 2>/dev/null || echo "OK")
 
     if [ "$LOCK_STATUS" = "LOCKED" ]; then
         # Check if auto-review is needed (no claude-review workflow)
         AUTO_REVIEW=$(_REVIEW_LOCK="$REVIEW_LOCK" _PR="$PR_NUM" python3 -c "
-    import json, os
-    with open(os.environ['_REVIEW_LOCK']) as f:
-        s = json.load(f)
-    print('yes' if s.get(os.environ['_PR'], {}).get('auto_review_needed', False) else 'no')
-    " 2>/dev/null || echo "no")
+import json, os
+with open(os.environ['_REVIEW_LOCK']) as f:
+    s = json.load(f)
+print('yes' if s.get(os.environ['_PR'], {}).get('auto_review_needed', False) else 'no')
+" 2>/dev/null || echo "no")
 
         echo "🔒 [Pessimistic Lock] PR #${PR_NUM} は review_pending 状態です。マージ不可。" >&2
         echo "" >&2

--- a/hooks/context-budget-edit-write-gate.sh
+++ b/hooks/context-budget-edit-write-gate.sh
@@ -41,10 +41,10 @@ fi
 TRANSCRIPT_PATH=$(echo "$INPUT_JSON" | python3 -c "
 import json, sys
 try:
-data = json.load(sys.stdin)
-print(data.get('transcript_path', ''))
-except:
-print('')
+    data = json.load(sys.stdin)
+    print(data.get('transcript_path', ''))
+except Exception:
+    print('')
 " 2>/dev/null || echo "")
 
 if [[ -z "$TRANSCRIPT_PATH" ]] || [[ ! -f "$TRANSCRIPT_PATH" ]]; then
@@ -68,10 +68,10 @@ fi
 EDIT_FILE=$(echo "$INPUT_JSON" | python3 -c "
 import json, sys
 try:
-data = json.load(sys.stdin)
-print(data.get('tool_input', {}).get('file_path', ''))
-except:
-print('')
+    data = json.load(sys.stdin)
+    print(data.get('tool_input', {}).get('file_path', ''))
+except Exception:
+    print('')
 " 2>/dev/null || echo "")
 
 # Exempt: editing non-source files (config, docs, hooks, etc.)

--- a/hooks/context-budget-edit-write-gate.sh
+++ b/hooks/context-budget-edit-write-gate.sh
@@ -41,10 +41,10 @@ fi
 TRANSCRIPT_PATH=$(echo "$INPUT_JSON" | python3 -c "
 import json, sys
 try:
-    data = json.load(sys.stdin)
-    print(data.get('transcript_path', ''))
+data = json.load(sys.stdin)
+print(data.get('transcript_path', ''))
 except:
-    print('')
+print('')
 " 2>/dev/null || echo "")
 
 if [[ -z "$TRANSCRIPT_PATH" ]] || [[ ! -f "$TRANSCRIPT_PATH" ]]; then
@@ -55,10 +55,10 @@ fi
 STATE_FILE="$HOME/.claude/state/context-budget.json"
 if [[ -f "$STATE_FILE" ]]; then
   MODE=$(_STATE="$STATE_FILE" python3 -c "
-    import json, os
-    with open(os.environ['_STATE']) as f:
-        print(json.load(f).get('mode', 'auto'))
-    " 2>/dev/null || echo "auto")
+import json, os
+with open(os.environ['_STATE']) as f:
+    print(json.load(f).get('mode', 'auto'))
+" 2>/dev/null || echo "auto")
   if [[ "$MODE" == "planning" ]] || [[ "$MODE" == "research" ]]; then
     exit 0
   fi
@@ -68,10 +68,10 @@ fi
 EDIT_FILE=$(echo "$INPUT_JSON" | python3 -c "
 import json, sys
 try:
-    data = json.load(sys.stdin)
-    print(data.get('tool_input', {}).get('file_path', ''))
+data = json.load(sys.stdin)
+print(data.get('tool_input', {}).get('file_path', ''))
 except:
-    print('')
+print('')
 " 2>/dev/null || echo "")
 
 # Exempt: editing non-source files (config, docs, hooks, etc.)

--- a/hooks/enforce-review-reading.sh
+++ b/hooks/enforce-review-reading.sh
@@ -28,7 +28,7 @@ cmd=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 REVIEW_DATA=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
 import json, os
 with open(os.environ['_PENDING_FILE']) as f:
-    d = json.load(f)
+d = json.load(f)
 print(json.dumps(d))
 " 2>/dev/null || echo "{}")
 
@@ -54,19 +54,19 @@ fi
 OUTPUT=$(echo "$REVIEW_DATA" | jq -r '.output // ""' 2>/dev/null || echo "")
 if [[ -n "$OUTPUT" ]] && [[ "$OUTPUT" != "null" ]]; then
   _OUTPUT="$OUTPUT" _PR="$PR" python3 -c "
-    import json, os
-    output = os.environ['_OUTPUT']
-    # Truncate for context efficiency
-    if len(output) > 2000:
-        output = output[:2000] + '\n... (truncated, see full: gh api repos/.../pulls/' + os.environ['_PR'] + '/comments)'
-    result = {
-        'hookSpecificOutput': {
-            'hookEventName': 'PreToolUse',
-            'additionalContext': output
-        }
+import json, os
+output = os.environ['_OUTPUT']
+# Truncate for context efficiency
+if len(output) > 2000:
+    output = output[:2000] + '\n... (truncated, see full: gh api repos/.../pulls/' + os.environ['_PR'] + '/comments)'
+result = {
+    'hookSpecificOutput': {
+        'hookEventName': 'PreToolUse',
+        'additionalContext': output
     }
-    print(json.dumps(result))
-    " 2>/dev/null
+}
+print(json.dumps(result))
+" 2>/dev/null
 fi
 
 exit 0

--- a/hooks/enforce-review-reading.sh
+++ b/hooks/enforce-review-reading.sh
@@ -28,7 +28,7 @@ cmd=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 REVIEW_DATA=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
 import json, os
 with open(os.environ['_PENDING_FILE']) as f:
-d = json.load(f)
+    d = json.load(f)
 print(json.dumps(d))
 " 2>/dev/null || echo "{}")
 

--- a/hooks/inject-claude-review-on-checks.sh
+++ b/hooks/inject-claude-review-on-checks.sh
@@ -43,11 +43,11 @@ if echo "$(echo "$cmd" | head -1)" | grep -qE 'gh\s+pr\s+checks'; then
   # Read back the saved state and output as reminder
   if [[ -f "$PENDING_FILE" ]]; then
     OUTPUT=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
-    import json, os
-    with open(os.environ['_PENDING_FILE']) as f:
-        d = json.load(f)
-    print(d.get('output', ''))
-    " 2>/dev/null || echo "")
+import json, os
+with open(os.environ['_PENDING_FILE']) as f:
+    d = json.load(f)
+print(d.get('output', ''))
+" 2>/dev/null || echo "")
 
     if [[ -n "$OUTPUT" ]]; then
       echo "" >&2
@@ -66,20 +66,20 @@ fi
 if echo "$(echo "$cmd" | head -1)" | grep -qE 'gh\s+pr\s+merge'; then
   if [[ -f "$PENDING_FILE" ]]; then
     CRITICAL=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
-    import json, os
-    with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
-    print(d.get('critical', 0))
-    " 2>/dev/null || echo "0")
+import json, os
+with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
+print(d.get('critical', 0))
+" 2>/dev/null || echo "0")
     HIGH=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
-    import json, os
-    with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
-    print(d.get('high', 0))
-    " 2>/dev/null || echo "0")
+import json, os
+with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
+print(d.get('high', 0))
+" 2>/dev/null || echo "0")
     PR=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
-    import json, os
-    with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
-    print(d.get('pr', ''))
-    " 2>/dev/null || echo "")
+import json, os
+with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
+print(d.get('pr', ''))
+" 2>/dev/null || echo "")
 
     if [[ "$CRITICAL" -gt 0 ]] || [[ "$HIGH" -gt 0 ]]; then
       echo "" >&2
@@ -103,22 +103,22 @@ fi
 
 if [[ -f "$PENDING_FILE" ]]; then
   TOTAL=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
-    import json, os
-    with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
-    print(d.get('total', 0))
-    " 2>/dev/null || echo "0")
+import json, os
+with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
+print(d.get('total', 0))
+" 2>/dev/null || echo "0")
   CRITICAL=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
-    import json, os
-    with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
-    print(d.get('critical', 0))
-    " 2>/dev/null || echo "0")
+import json, os
+with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
+print(d.get('critical', 0))
+" 2>/dev/null || echo "0")
 
   if [[ "$TOTAL" -gt 0 ]] && [[ "$CRITICAL" -gt 0 ]]; then
     PR=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
-    import json, os
-    with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
-    print(d.get('pr', ''))
-    " 2>/dev/null || echo "")
+import json, os
+with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
+print(d.get('pr', ''))
+" 2>/dev/null || echo "")
     echo "[REMINDER] PR #${PR}: ${TOTAL}件のレビューコメント（CRITICAL=${CRITICAL}）が未対応です。" >&2
   fi
 fi

--- a/hooks/pr-merge-claude-review-gate.sh
+++ b/hooks/pr-merge-claude-review-gate.sh
@@ -165,9 +165,9 @@ r'(?i)\|\s*CRITICAL\s*\|',
 r'(?i)## critical',
 ]
 for pat in patterns:
-if re.search(pat, bodies):
-    print('YES')
-    sys.exit(0)
+    if re.search(pat, bodies):
+        print('YES')
+        sys.exit(0)
 print('NO')
 " 2>/dev/null || echo "NO")
 fi

--- a/hooks/pr-merge-claude-review-gate.sh
+++ b/hooks/pr-merge-claude-review-gate.sh
@@ -101,10 +101,10 @@ COMMENT_COUNT=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --jq 'length
 if [[ "$COMMENT_COUNT" -eq 0 ]]; then
   # Check if a code-reviewer fallback was already done
   FALLBACK_DONE=$(_REVIEW_FILE="$REVIEW_FILE" _PR="$PR_NUMBER" python3 -c "
-    import json, os
-    with open(os.environ['_REVIEW_FILE']) as f: s=json.load(f)
-    print(s.get(os.environ['_PR'], {}).get('fallback_review_done', False))
-    " 2>/dev/null || echo "False")
+import json, os
+with open(os.environ['_REVIEW_FILE']) as f: s=json.load(f)
+print(s.get(os.environ['_PR'], {}).get('fallback_review_done', False))
+" 2>/dev/null || echo "False")
 
   if [[ "$FALLBACK_DONE" != "True" ]]; then
     echo "" >&2
@@ -158,16 +158,16 @@ if [[ "$COMMENT_COUNT" -gt 0 ]]; then
 import sys, re
 bodies = sys.stdin.read()
 patterns = [
-    r'(?i)\bcritical\b.*(?:issue|bug|finding)',
-    r'(?i)critical\s+issues',
-    r'(?i)\|\s*critical\s*\|',
-    r'(?i)\|\s*CRITICAL\s*\|',
-    r'(?i)## critical',
+r'(?i)\bcritical\b.*(?:issue|bug|finding)',
+r'(?i)critical\s+issues',
+r'(?i)\|\s*critical\s*\|',
+r'(?i)\|\s*CRITICAL\s*\|',
+r'(?i)## critical',
 ]
 for pat in patterns:
-    if re.search(pat, bodies):
-        print('YES')
-        sys.exit(0)
+if re.search(pat, bodies):
+    print('YES')
+    sys.exit(0)
 print('NO')
 " 2>/dev/null || echo "NO")
 fi
@@ -175,18 +175,18 @@ fi
 # Also check if fallback review flagged critical
 if [[ "$HAS_CRITICAL" == "NO" ]]; then
   HAS_CRITICAL=$(_REVIEW_FILE="$REVIEW_FILE" _PR="$PR_NUMBER" python3 -c "
-    import json, os
-    with open(os.environ['_REVIEW_FILE']) as f: s=json.load(f)
-    print('YES' if s.get(os.environ['_PR'], {}).get('has_critical', False) else 'NO')
-    " 2>/dev/null || echo "NO")
+import json, os
+with open(os.environ['_REVIEW_FILE']) as f: s=json.load(f)
+print('YES' if s.get(os.environ['_PR'], {}).get('has_critical', False) else 'NO')
+" 2>/dev/null || echo "NO")
 fi
 
 if [[ "$HAS_CRITICAL" == "YES" ]]; then
   CRITICAL_ACK=$(_REVIEW_FILE="$REVIEW_FILE" _PR="$PR_NUMBER" python3 -c "
-    import json, os
-    with open(os.environ['_REVIEW_FILE']) as f: s=json.load(f)
-    print(s.get(os.environ['_PR'], {}).get('critical_acknowledged', False))
-    " 2>/dev/null || echo "False")
+import json, os
+with open(os.environ['_REVIEW_FILE']) as f: s=json.load(f)
+print(s.get(os.environ['_PR'], {}).get('critical_acknowledged', False))
+" 2>/dev/null || echo "False")
 
   if [[ "$CRITICAL_ACK" != "True" ]]; then
     echo "" >&2


### PR DESCRIPTION
## Summary
Fix Python IndentationError in 6 hook scripts caused by shell-level indentation leaking into python3 -c strings. Follow-up to PR #13 where tab-to-space conversion was incomplete.

### Commits (2)
1. `d96033e` — Dedent all inline Python blocks to column 0
2. `270fc25` — Restore nested block indentation (try/except, for, with)

### Review Pipeline (both passed)
- **code-reviewer**: BLOCK → fixed MEDIUM x3 (nested indent regression) → resubmitted
- **Codex CLI Route A**: No actionable issues found

### Root cause
PR #13 converted tabs to spaces but preserved the 4-space shell indentation inside Python code. The dedent fix then stripped ALL 4-space indents, including Python's own required body indentation for try/except/for/with blocks.

### Files (6)
block-merge-without-review.sh, context-budget-edit-write-gate.sh, enforce-review-reading.sh, inject-claude-review-on-checks.sh, pr-merge-claude-review-gate.sh, _unused/post-push-review-check.sh

Follow-up for #4