### PR TITLE
fix: rebase --continue whitelist and force push block (#16, #17)

### DIFF
--- a/hooks/block-manual-merge-ops.sh
+++ b/hooks/block-manual-merge-ops.sh
@@ -67,16 +67,30 @@ fi
 
 # Allow: git rebase --continue (only if a permitted rebase session is active)
 # Ref: Issue #16 — rebase --continue was blocked after permitted sync rebase
-if echo "$CMD_FIRST" | grep -qE 'git\s+rebase\s+--continue'; then
+# Note: _clear_rebase_state is NOT called here to support multi-conflict rebases
+# where --continue needs to be called multiple times. Cleanup relies on 1-hour expiry and --abort.
+if echo "$cmd" | grep -qE 'git\s+rebase\s+--continue'; then
     if _check_rebase_state; then
         local_target=$(jq -r '.rebase_target // "unknown"' "$REBASE_STATE_FILE" 2>/dev/null || echo "unknown")
         echo "[ALLOW] rebase --continue: 許可済み同期rebase (target: ${local_target}) の完了。" >&2
-        _clear_rebase_state
         exit 0
     else
         echo "[BLOCK] rebase --continue: 許可済みrebaseセッションが見つかりません。" >&2
         echo "理由: --continue は直前に許可された同期rebase (origin/main|master|develop) の" >&2
         echo "      完了操作にのみ許可されます。任意ブランチのrebase完了はCodex CLIに委任。" >&2
+        exit 2
+    fi
+fi
+
+# Allow: git rebase --skip (only if a permitted rebase session is active)
+if echo "$cmd" | grep -qE 'git\s+rebase\s+--skip'; then
+    if _check_rebase_state; then
+        echo "[ALLOW] rebase --skip: 許可済み同期rebaseセッション中のスキップ。" >&2
+        exit 0
+    else
+        echo "[BLOCK] rebase --skip: 許可済みrebaseセッションが見つかりません。" >&2
+        echo "理由: --skip は直前に許可された同期rebase (origin/main|master|develop) の" >&2
+        echo "      セッション中にのみ許可されます。" >&2
         exit 2
     fi
 fi

--- a/hooks/block-manual-merge-ops.sh
+++ b/hooks/block-manual-merge-ops.sh
@@ -4,17 +4,81 @@
 #
 # EXCEPTIONS (allowed without delegation):
 #   - --abort operations (cleanup)
+#   - --continue for permitted rebase sessions (tracked via state file)
 #   - Fast-forward merges from main/master into feature branches (daily sync)
 #   - git merge main/master/develop with --no-edit (routine sync)
+#
+# Rebase session tracking (Issue #16):
+#   When a sync rebase (origin/main|master|develop) is permitted, a state file
+#   records the session. --continue is allowed only when this state exists.
+#   The state file is protected by block-state-file-tampering.sh.
 set -euo pipefail
 
 input=$(cat)
 cmd=$(echo "$input" | jq -r '.tool_input.command // ""')
 CMD_FIRST=$(echo "$cmd" | head -1)
 
-# Allow --abort operations (cleanup is OK)
-if echo "$CMD_FIRST" | grep -qE 'git\s+(merge|cherry-pick|rebase)\s+--abort'; then
+# --- State file for rebase session tracking ---
+REBASE_STATE_FILE="${HOME}/.claude/state/rebase-session.json"
+mkdir -p "$(dirname "$REBASE_STATE_FILE")"
+
+_write_rebase_state() {
+    local target="$1"
+    local now_epoch
+    now_epoch=$(date +%s)
+    cat > "$REBASE_STATE_FILE" <<EOJSON
+{"rebase_in_progress":true,"rebase_target":"${target}","started_epoch":${now_epoch}}
+EOJSON
+}
+
+_clear_rebase_state() {
+    rm -f "$REBASE_STATE_FILE"
+}
+
+_check_rebase_state() {
+    if [ ! -f "$REBASE_STATE_FILE" ]; then
+        return 1
+    fi
+    local in_progress
+    in_progress=$(jq -r '.rebase_in_progress // false' "$REBASE_STATE_FILE" 2>/dev/null || echo "false")
+    if [ "$in_progress" != "true" ]; then
+        return 1
+    fi
+    # Expire after 1 hour to prevent stale state
+    local started_epoch now_epoch
+    started_epoch=$(jq -r '.started_epoch // 0' "$REBASE_STATE_FILE" 2>/dev/null || echo "0")
+    now_epoch=$(date +%s)
+    if [ $((now_epoch - started_epoch)) -gt 3600 ]; then
+        echo "[INFO] rebase session expired (>1h). Clearing stale state." >&2
+        _clear_rebase_state
+        return 1
+    fi
+    return 0
+}
+
+# Allow --abort operations (cleanup is OK) + clear rebase state
+if echo "$CMD_FIRST" | grep -qE 'git\s+(merge|cherry-pick)\s+--abort'; then
     exit 0
+fi
+if echo "$CMD_FIRST" | grep -qE 'git\s+rebase\s+--abort'; then
+    _clear_rebase_state
+    exit 0
+fi
+
+# Allow: git rebase --continue (only if a permitted rebase session is active)
+# Ref: Issue #16 — rebase --continue was blocked after permitted sync rebase
+if echo "$CMD_FIRST" | grep -qE 'git\s+rebase\s+--continue'; then
+    if _check_rebase_state; then
+        local_target=$(jq -r '.rebase_target // "unknown"' "$REBASE_STATE_FILE" 2>/dev/null || echo "unknown")
+        echo "[ALLOW] rebase --continue: 許可済み同期rebase (target: ${local_target}) の完了。" >&2
+        _clear_rebase_state
+        exit 0
+    else
+        echo "[BLOCK] rebase --continue: 許可済みrebaseセッションが見つかりません。" >&2
+        echo "理由: --continue は直前に許可された同期rebase (origin/main|master|develop) の" >&2
+        echo "      完了操作にのみ許可されます。任意ブランチのrebase完了はCodex CLIに委任。" >&2
+        exit 2
+    fi
 fi
 
 # Allow: git merge main/master/develop (routine branch sync)
@@ -23,8 +87,11 @@ if echo "$CMD_FIRST" | grep -qE 'git\s+merge\s+(origin/)?(main|master|develop)\b
     exit 0
 fi
 
-# Allow: git rebase main/master/develop (routine branch sync)
+# Allow: git rebase main/master/develop (routine branch sync) + record state
 if echo "$CMD_FIRST" | grep -qE 'git\s+rebase\s+(origin/)?(main|master|develop)\b'; then
+    # Extract the target (e.g., "origin/main", "develop")
+    rebase_target=$(echo "$CMD_FIRST" | grep -oE '(origin/)?(main|master|develop)' | head -1)
+    _write_rebase_state "$rebase_target"
     exit 0
 fi
 

--- a/hooks/block-state-file-tampering-bash.sh
+++ b/hooks/block-state-file-tampering-bash.sh
@@ -12,7 +12,7 @@ CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
 CMD_FIRST_LINE=$(echo "$CMD" | head -1)
 
 # 保護対象のファイル名パターン
-PROTECTED="review-status\.json|pr-review-lock\.json|context-budget\.json|factcheck-state\.json"
+PROTECTED="review-status\.json|pr-review-lock\.json|context-budget\.json|factcheck-state\.json|rebase-session\.json"
 
 # Bashコマンドが保護対象ファイルに書き込むか検出
 if echo "$CMD_FIRST_LINE" | grep -qE "$PROTECTED"; then

--- a/hooks/block-state-file-tampering.sh
+++ b/hooks/block-state-file-tampering.sh
@@ -27,6 +27,7 @@ PROTECTED_FILES=(
   "context-budget.json"
   "factcheck-state.json"
   "pr-gate-diagnostic.log"
+  "rebase-session.json"
 )
 
 for protected in "${PROTECTED_FILES[@]}"; do
@@ -43,6 +44,7 @@ for protected in "${PROTECTED_FILES[@]}"; do
   - review-status.json → code-reviewer実行後に record-code-review.sh が自動更新
   - pr-review-lock.json → pr-ci-review-gate.sh が POST_PUSH モードで自動設定
   - context-budget.json → context-budget-reset.sh がセッション開始時に初期化
+  - rebase-session.json → block-manual-merge-ops.sh が同期rebase許可時に自動記録
 
 📋 2026-03-21事故: AI が review-status.json に手動で true を書き込み、
    レビュー未実施のまま PR を作成。ゲートの存在意義を無にした。

--- a/hooks/git-push-guard.sh
+++ b/hooks/git-push-guard.sh
@@ -6,7 +6,32 @@ set -euo pipefail
 input=$(cat)
 cmd=$(echo "$input" | jq -r '.tool_input.command // ""')
 
-# --- 1. Protected branch check ---
+# --- 1. Force push to shared branches check (Issue #17) ---
+# Block --force / --force-with-lease to develop/main/master
+# Feature branches are allowed (user's own branch history cleanup is legitimate)
+if echo "$cmd" | grep -qE 'git\s+push\b.*(--(force|force-with-lease)\b|-f\b)' || \
+   echo "$cmd" | grep -qE 'git\s+push\s+-[a-zA-Z]*f'; then
+    for branch in develop main master; do
+        if echo "$cmd" | grep -qE "\b${branch}\b"; then
+            cat >&2 <<ERRMSG
+[BLOCK] 共有ブランチ '${branch}' への force push を検出
+
+理由: force push は履歴を書き換えます。
+  - 他のエンジニアの作業ベースが壊れる可能性
+  - レビュー済みコミット履歴が失われる可能性
+  - --force-with-lease も --force と同等に扱います
+
+対処法: ユーザーが手動で実行してください。
+  ! git push --force-with-lease origin ${branch}
+
+Ref: Issue #17 — AI からの force push はブロック、ユーザー手動実行に限定
+ERRMSG
+            exit 2
+        fi
+    done
+fi
+
+# --- 2. Protected branch direct push check ---
 for branch in develop main master; do
     if echo "$cmd" | grep -qE "git\s+push\s+.*\b${branch}\b" && \
        ! echo "$cmd" | grep -qE "(--delete|:${branch})"; then
@@ -20,7 +45,7 @@ for branch in develop main master; do
     fi
 done
 
-# --- 2. Local CI check before push (AP-10 prevention) ---
+# --- 3. Local CI check before push (AP-10 prevention) ---
 project_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 if [ -n "$project_root" ]; then
     ci_failed=false

--- a/hooks/git-push-guard.sh
+++ b/hooks/git-push-guard.sh
@@ -12,7 +12,7 @@ cmd=$(echo "$input" | jq -r '.tool_input.command // ""')
 if echo "$cmd" | grep -qE 'git\s+push\b.*(--(force|force-with-lease)\b|-f\b)' || \
    echo "$cmd" | grep -qE 'git\s+push\s+-[a-zA-Z]*f'; then
     for branch in develop main master; do
-        if echo "$cmd" | grep -qE "\b${branch}\b"; then
+        if echo "$cmd" | grep -qE "(^|[\s:+/])${branch}(\b|$)"; then
             cat >&2 <<ERRMSG
 [BLOCK] 共有ブランチ '${branch}' への force push を検出
 
@@ -22,7 +22,7 @@ if echo "$cmd" | grep -qE 'git\s+push\b.*(--(force|force-with-lease)\b|-f\b)' ||
   - --force-with-lease も --force と同等に扱います
 
 対処法: ユーザーが手動で実行してください。
-  ! git push --force-with-lease origin ${branch}
+  (Claude Code プロンプトで) ! git push --force-with-lease origin ${branch}
 
 Ref: Issue #17 — AI からの force push はブロック、ユーザー手動実行に限定
 ERRMSG


### PR DESCRIPTION
## Summary
- **Issue #16**: 許可済み同期rebase (`origin/main|master|develop`) のセッション中に `--continue` / `--skip` / `--abort` を許可。state ファイル (`rebase-session.json`) でセッション追跡、1時間自動失効。
- **Issue #17**: `develop`/`main`/`master` への `--force`/`--force-with-lease`/`-f` push をAIからブロック。feature ブランチは許可。ユーザー手動 (`!` prefix) でのみ実行可能。
- 改ざん防止: `rebase-session.json` を `block-state-file-tampering.sh` / `block-state-file-tampering-bash.sh` の保護対象に追加。

## Changed files
| File | Change |
|------|--------|
| `hooks/block-manual-merge-ops.sh` | rebase session tracking + --continue/--skip/--abort whitelist |
| `hooks/git-push-guard.sh` | force push detection for shared branches |
| `hooks/block-state-file-tampering.sh` | `rebase-session.json` を保護対象に追加 |
| `hooks/block-state-file-tampering-bash.sh` | 同上 (Bash経由) |

## Security analysis
- AI が `rebase-session.json` を直接書き込んで偽のセッションを作ることは `block-state-file-tampering` hook で不可能
- `+refspec` や `HEAD:branch` 形式の force push も検出
- `$cmd` (全行) を検査して multi-line bypass を防止

## Test plan
- [x] 既存動作の回帰テスト (11テスト: merge/rebase/cherry-pick の allow/block)
- [x] `--continue` state tracking (state作成 → allow → state persistence → multi-continue → abort清掃)
- [x] `--skip` whitelist (state有で許可、state無でブロック)
- [x] force push blocking (develop/main/master + `-f` + `--force-with-lease` + `+refspec` + `HEAD:refspec`)
- [x] feature ブランチへの force push は許可
- [x] 改ざん防止 (Write/Edit blocked, Bash blocked)
- [x] 全31テスト合格

Closes #16, Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 修正と改善

* **チョア**
  * Gitリベース操作の追跡機能を実装し、許可された操作の制御を強化しました
  * システムの状態ファイル保護対象を拡張し、より厳密な検証を行うようにしました
  * メインおよび開発ブランチへのフォースプッシュ操作をブロックするガード機能を追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->