### PR TITLE
fix: align verify-pr-review.sh state path with merge hook (#19)

### DIFF
--- a/scripts/verify-pr-review.sh
+++ b/scripts/verify-pr-review.sh
@@ -18,7 +18,15 @@ if [ -z "$REPO" ]; then
     exit 1
 fi
 
-REVIEW_LOCK="$HOME/.claude/state/pr-review-lock.json"
+# Project-scoped state: match block-merge-without-review.sh resolution (Issue #19)
+if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+  _STATE_BASE="${CLAUDE_PROJECT_DIR}/.claude/state"
+elif git rev-parse --show-toplevel &>/dev/null; then
+  _STATE_BASE="$(git rev-parse --show-toplevel)/.claude/state"
+else
+  _STATE_BASE="$HOME/.claude/state"
+fi
+REVIEW_LOCK="$_STATE_BASE/pr-review-lock.json"
 mkdir -p "$(dirname "$REVIEW_LOCK")"
 [ ! -f "$REVIEW_LOCK" ] && echo '{}' > "$REVIEW_LOCK"
 


### PR DESCRIPTION
## Summary
- `verify-pr-review.sh` の state パス解決を `block-merge-without-review.sh` と同一ロジックに統一
- \$HOME ハードコード → \$CLAUDE_PROJECT_DIR → git root → \$HOME フォールバック

## Root cause
`verify-pr-review.sh` が \$HOME/.claude/state/pr-review-lock.json にロック解除を書き込む一方、`block-merge-without-review.sh` は project-scoped state を読むため、パス不一致でマージがブロックされ続けた。

## Test plan
- [ ] `verify-pr-review.sh` 実行後、merge hook が同じ lock file を参照することを確認
- [ ] `CLAUDE_PROJECT_DIR` 設定時: project-scoped パスに書き込み
- [ ] git repo 内: git root パスに書き込み
- [ ] フォールバック: \$HOME パスに書き込み

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * PR レビュー検証スクリプトを改善し、異なる環境設定に対応する柔軟な設定パス解決機構を実装しました。プロジェクトスコープの状態設定に対応し、フォールバック機構によりシステムの安定性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->