### PR TITLE
fix: severity-prefix patterns in review guard (Closes #21)

### DIFF
--- a/hooks/block-merge-without-review.sh
+++ b/hooks/block-merge-without-review.sh
@@ -114,8 +114,10 @@ PR_COMMENTS=$(gh api "repos/${REPO}/pulls/${PR_NUM}/comments" 2>/dev/null || ech
 ISSUE_COMMENTS=$(gh api "repos/${REPO}/issues/${PR_NUM}/comments" 2>/dev/null || echo "[]")
 
 # Check for unresolved CRITICAL/HIGH in any source
-HAS_CRITICAL=$(echo "$PR_COMMENTS $ISSUE_COMMENTS" | grep -ci "CRITICAL\|critical" || true)
-HAS_HIGH=$(echo "$PR_COMMENTS $ISSUE_COMMENTS" | grep -ci "\bHIGH\b" || true)
+# Use severity-prefix patterns to avoid false positives from words like "high-level"
+# Matches: [CRITICAL], CRITICAL:, severity: CRITICAL, **CRITICAL**, > CRITICAL
+HAS_CRITICAL=$(echo "$PR_COMMENTS $ISSUE_COMMENTS" | grep -ciE '\[CRITICAL\]|severity:\s*CRITICAL|^\s*CRITICAL:|>\s*CRITICAL|\*\*CRITICAL\*\*' || true)
+HAS_HIGH=$(echo "$PR_COMMENTS $ISSUE_COMMENTS" | grep -ciE '\[HIGH\]|severity:\s*HIGH|^\s*HIGH:|>\s*HIGH|\*\*HIGH\*\*' || true)
 
 if [ "$HAS_CRITICAL" -gt 0 ] || [ "$HAS_HIGH" -gt 0 ]; then
     echo "[BLOCK] PR #${PR_NUM} にCRITICAL/HIGH指摘が残っている可能性があります。" >&2


### PR DESCRIPTION
## Summary
- `block-merge-without-review.sh` の CRITICAL/HIGH 検出を severity-prefix パターンに変更
- `[HIGH]`, `severity: HIGH`, `**HIGH**`, `> HIGH` 等の構造化パターンのみマッチ
- CodeRabbit の "high-level summary" 等の false positive を解消

## Test results
- "high-level summary" → NO MATCH (false positive 解消)
- "CRITICAL=0 HIGH=0" → NO MATCH (カウントテキスト除外)
- "[HIGH] SQL injection" → MATCH (実際の指摘を検出)
- "severity: HIGH" → MATCH
- "**HIGH** Missing auth" → MATCH
- "> CRITICAL finding" → MATCH

Closes #21


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* コードレビューコメント内の重大度レベル検出ロジックを改善しました。より正確なパターンマッチングにより、マージのブロック判定がより厳密で信頼性の高いものになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->