### PR TITLE
fix: tighten grep patterns in CI guard and verify script (Closes #23, Closes #24)

### DIFF
--- a/hooks/block-merge-without-ci.sh
+++ b/hooks/block-merge-without-ci.sh
@@ -8,7 +8,7 @@ cmd=$(echo "$input" | jq -r '.tool_input.command // ""')
 cmd_first_line=$(echo "$cmd" | head -1)
 
 # Only trigger for merge commands
-if ! echo "$cmd_first_line" | grep -q 'gh.*pr.*merge'; then
+if ! echo "$cmd_first_line" | grep -qE 'gh\s+pr\s+merge\b'; then
     exit 0
 fi
 

--- a/scripts/verify-pr-review.sh
+++ b/scripts/verify-pr-review.sh
@@ -51,9 +51,10 @@ ISSUE_COMMENTS=$(gh api "repos/${REPO}/issues/${PR_NUM}/comments" 2>/dev/null ||
 
 # Count blocking indicators across ALL sources
 COMBINED="$REVIEWS $PR_COMMENTS $ISSUE_COMMENTS"
-BLOCKING=$(echo "$COMBINED" | grep -ci "blocking\|🔴" || true)
-MUST_FIX=$(echo "$COMBINED" | grep -ci "must.fix\|MUST FIX" || true)
-CRITICAL=$(echo "$COMBINED" | grep -ci "critical" || true)
+# Use severity-prefix patterns to avoid false positives (aligned with block-merge-without-review.sh)
+BLOCKING=$(echo "$COMBINED" | grep -ciE '\[BLOCKING\]|severity:\s*BLOCKING|^\s*BLOCKING[:\s-]|>\s*BLOCKING|\*\*BLOCKING\*\*|🔴' || true)
+MUST_FIX=$(echo "$COMBINED" | grep -ciE '\[MUST.FIX\]|severity:\s*MUST.FIX|^\s*MUST.FIX[:\s-]|>\s*MUST.FIX|\*\*MUST.FIX\*\*' || true)
+CRITICAL=$(echo "$COMBINED" | grep -ciE '\[CRITICAL\]|severity:\s*CRITICAL|^\s*CRITICAL[:\s-]|>\s*CRITICAL|\*\*CRITICAL\*\*' || true)
 
 # Get latest claude-review summary
 LATEST_SUMMARY=$(echo "$ISSUE_COMMENTS" | python3 -c "


### PR DESCRIPTION
## Summary
- `block-merge-without-ci.sh`: `gh.*pr.*merge` → `gh\s+pr\s+merge\b` で "merge" を含むブランチ名への誤マッチを解消
- `verify-pr-review.sh`: bare grep → severity-prefix パターンに統一（`block-merge-without-review.sh` と整合）

Closes #23, Closes #24
