### PR TITLE
fix: POSIX character class in force push regex

### DIFF
--- a/hooks/git-push-guard.sh
+++ b/hooks/git-push-guard.sh
@@ -12,7 +12,7 @@ cmd=$(echo "$input" | jq -r '.tool_input.command // ""')
 if echo "$cmd" | grep -qE 'git\s+push\b.*(--(force|force-with-lease)\b|-f\b)' || \
    echo "$cmd" | grep -qE 'git\s+push\s+-[a-zA-Z]*f'; then
     for branch in develop main master; do
-        if echo "$cmd" | grep -qE "(^|[\s:+/])${branch}(\b|$)"; then
+        if echo "$cmd" | grep -qE "(^|[[:space:]:+/])${branch}(\b|$)"; then
             cat >&2 <<ERRMSG
 [BLOCK] 共有ブランチ '${branch}' への force push を検出
 


### PR DESCRIPTION
## Summary
- `git-push-guard.sh` line 15: `[\s:+/]` → `[[:space:]:+/]`
- macOS の `grep -E` (POSIX ERE) は character class 内の `\s` を認識しない
- これにより force push 検出が完全に無効化されていた

## Test results
- git push --force origin develop → BLOCK (修正後)
- git push --force-with-lease origin main → BLOCK
- git push -f origin develop → BLOCK
- git push --force origin +develop → BLOCK
- git push --force origin feat/x → ALLOW (feature branch OK)

Closes #17