### PR TITLE
fix: tighten pr-guard.sh command detection regex

### DIFF
--- a/hooks/pr-guard.sh
+++ b/hooks/pr-guard.sh
@@ -7,7 +7,7 @@ input=$(cat)
 cmd=$(echo "$input" | jq -r '.tool_input.command // ""')
 
 cmd_first_line=$(echo "$cmd" | head -1)
-if ! echo "$cmd_first_line" | grep -q 'gh.*pr.*create'; then
+if ! echo "$cmd_first_line" | grep -qE 'gh\s+pr\s+create\b'; then
     exit 0
 fi
 


### PR DESCRIPTION
## Summary
- `pr-guard.sh` line 10: `gh.*pr.*create` → `gh\s+pr\s+create\b`
- ブランチ名やbodyに "pr"/"create" を含むコマンドへの誤マッチ防止

Closes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * PR作成コマンドの検出精度を向上させました。より厳密なコマンド形式の検証を実装し、信頼性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->