### PR TITLE
fix: codex-task-gate false positive and force push guard implicit branch (#28, #29)

### DIFF
--- a/hooks/codex-task-gate.sh
+++ b/hooks/codex-task-gate.sh
@@ -12,7 +12,18 @@ input=$(cat)
 tool_name=$(echo "$input" | jq -r '.tool_name // ""' 2>/dev/null || echo "")
 bash_cmd=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 
-if [[ "$tool_name" == "Bash" ]] && echo "$(echo "$bash_cmd" | head -1)" | grep -qE '(codex-parallel|codex exec)'; then
+# Only match actual EXECUTION of Codex commands, not mentions in cat/grep/echo/ls
+# - bash <path>codex-parallel.sh or codex-orchestrate.sh
+# - codex exec at command start position (with optional env var prefixes)
+first_line=$(echo "$bash_cmd" | head -1)
+is_codex_exec=false
+if echo "$first_line" | grep -qE '^\s*(\S+=\S+\s+)*bash\s+\S*codex-(parallel|orchestrate)'; then
+    is_codex_exec=true
+elif echo "$first_line" | grep -qE '^\s*(\S+=\S+\s+)*codex\s+exec\b'; then
+    is_codex_exec=true
+fi
+
+if [[ "$tool_name" == "Bash" ]] && [[ "$is_codex_exec" == "true" ]]; then
     BUDGET_FILE="${HOME}/.claude/state/context-budget.json"
     if [[ -f "$BUDGET_FILE" ]]; then
         codex_count=$(_BUDGET_FILE="$BUDGET_FILE" python3 -c "

--- a/hooks/git-push-guard.sh
+++ b/hooks/git-push-guard.sh
@@ -11,8 +11,9 @@ cmd=$(echo "$input" | jq -r '.tool_input.command // ""')
 # Feature branches are allowed (user's own branch history cleanup is legitimate)
 if echo "$cmd" | grep -qE 'git\s+push\b.*(--(force|force-with-lease)\b|-f\b)' || \
    echo "$cmd" | grep -qE 'git\s+push\s+-[a-zA-Z]*f'; then
+    # Check explicit branch names in the command
     for branch in develop main master; do
-        if echo "$cmd" | grep -qE "(^|[[:space:]:+/])${branch}(\b|$)"; then
+        if echo "$cmd" | grep -qE "(^|[[:space:]])${branch}([[:space:]]|$|:)"; then
             cat >&2 <<ERRMSG
 [BLOCK] 共有ブランチ '${branch}' への force push を検出
 
@@ -25,6 +26,26 @@ if echo "$cmd" | grep -qE 'git\s+push\b.*(--(force|force-with-lease)\b|-f\b)' ||
   (Claude Code プロンプトで) ! git push --force-with-lease origin ${branch}
 
 Ref: Issue #17 — AI からの force push はブロック、ユーザー手動実行に限定
+ERRMSG
+            exit 2
+        fi
+    done
+
+    # Fallback: if no explicit branch in command, check current branch
+    # Catches: git push --force, git push --force origin (implicit branch)
+    current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    for branch in develop main master; do
+        if [[ "$current_branch" == "$branch" ]]; then
+            cat >&2 <<ERRMSG
+[BLOCK] 共有ブランチ '${branch}' への force push を検出（暗黙的ブランチ）
+
+現在のブランチ '${branch}' は共有ブランチです。
+コマンドにブランチ名が明示されていなくても、force push はブロックされます。
+
+対処法: ユーザーが手動で実行してください。
+  (Claude Code プロンプトで) ! git push --force-with-lease origin ${branch}
+
+Ref: Issue #28 — 差分有無にかかわらず共有ブランチへの force push をブロック
 ERRMSG
             exit 2
         fi


### PR DESCRIPTION
## Summary
- **Issue #29**: codex-task-gate.sh の Codex コマンド検出パターンを厳密化。cat codex-parallel.sh 等の非実行コマンドでも codex_call_count がインクリメントされるバグを修正
- **Issue #28**: git-push-guard.sh に暗黙的ブランチ検出を追加。ブランチ名省略時でも共有ブランチへの force push をブロック。明示的ブランチのパターンマッチングも改善

## Changes
### codex-task-gate.sh
- 旧: grep -qE (codex-parallel|codex exec) — 部分文字列マッチ（false positive）
- 新: ^\s*(\S+=\S+\s+)*bash\s+\S*codex-(parallel|orchestrate) + ^\s*(\S+=\S+\s+)*codex\s+exec\b — コマンド実行のみマッチ

### git-push-guard.sh
- 明示的ブランチ: \b → ([[:space:]]|$|:) で false positive 回避（e.g., feat/develop-cleanup）
- 暗黙的ブランチ: git rev-parse --abbrev-ref HEAD でカレントブランチをフォールバック検出

## Test plan
- [ ] codex-task-gate: bash codex-parallel.sh → MATCH, cat codex-parallel.sh → NO MATCH
- [ ] codex-task-gate: codex exec → MATCH, echo codex exec → NO MATCH
- [ ] push-guard: force push to shared branch with explicit name → BLOCK
- [ ] push-guard: force push to feat/develop-cleanup → ALLOW
- [ ] push-guard: force push without branch name (on shared branch) → BLOCK

Closes #28
Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * Codexコマンド検出ロジックの精度を向上：テキスト内の単なる「codex」記述による誤検出を排除しました。
  * ブランチ保護の強化：強制プッシュ時の共有ブランチ検出を改善し、より確実にブロックされるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->