### PR TITLE
chore: block foreground impl agents and release Codex counter (#31)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -152,8 +152,9 @@ hook スクリプトが委任ルールを自動的に強制します:
 | `context-budget-read-gate.sh` | Read ツール | 3+ ファイルで警告、6+ で強い警告 |
 | `context-budget-write-gate.sh` | Write ツール | テスト/ドキュメント作成検出 → Codex 提案 |
 | `context-budget-edit-write-gate.sh` | Edit/Write | 多数ソースファイル読み込み後の編集をブロック |
-| `context-budget-agent-gate.sh` | Agent ツール | サブエージェント数を監視 |
-| `codex-task-gate.sh` | テストファイル Edit/Write | テスト作成を Codex に委任提案 |
+| `context-budget-agent-gate.sh` | Agent ツール | foreground実装Agent 2つ目をブロック、1つ目に警告、background/TeamCreate強制 |
+| `codex-task-gate.sh` | Bash (Codex実行) | 2回目以降の Codex CLI 呼び出しをブロック（同時1タスク制限） |
+| `codex-task-release.sh` | PostToolUse Bash | Codex タスク完了後にカウンターを解放（順次再利用を可能に） |
 
 ### ユーティリティスクリプト
 
@@ -256,8 +257,9 @@ PR に GitHub レビューがない場合（ソロ開発など）、**ローカ�
 - `context-budget-read-gate.sh` — 3+ ソースファイル読み込みで警告/ブロック
 - `context-budget-write-gate.sh` — テスト/ドキュメント作成を検出し Codex 委任提案
 - `context-budget-edit-write-gate.sh` — 多数ファイル読み込み後の編集をブロック
-- `context-budget-agent-gate.sh` — エージェント生成数を監視
-- `context-budget-reset.sh` — セッション開始時にカウンターリセット
+- `context-budget-agent-gate.sh` — foreground実装Agentの制限（2つ目ブロック）、background/TeamCreate強制
+- `context-budget-reset.sh` — セッション開始時にカウンターリセット（`fg_impl_agent_count` 含む）
+- `codex-task-release.sh` — Codex タスク完了後にカウンター解放（PostToolUse）
 
 ### ワークフロー強制
 - `enforce-git-freshness.sh` — リモートより遅れている場合に編集をブロック

--- a/README.md
+++ b/README.md
@@ -151,8 +151,9 @@ Task received
 | `context-budget-read-gate.sh` | Read tool | Warn at 3+ files, strong warn at 6+ |
 | `context-budget-write-gate.sh` | Write tool | Detect test/doc creation → suggest Codex |
 | `context-budget-edit-write-gate.sh` | Edit/Write | Block when too many source files read |
-| `context-budget-agent-gate.sh` | Agent tool | Monitor subagent count |
-| `codex-task-gate.sh` | Edit/Write test files | Suggest Codex for test creation |
+| `context-budget-agent-gate.sh` | Agent tool | Block 2+ foreground impl agents, warn on 1st, enforce background/TeamCreate |
+| `codex-task-gate.sh` | Bash (Codex exec) | Block 2nd+ Codex CLI call (1 concurrent limit) |
+| `codex-task-release.sh` | PostToolUse Bash | Release Codex counter after task completes (enables sequential reuse) |
 
 ### Utility Scripts
 
@@ -255,8 +256,9 @@ Merged or closed PRs are automatically cleaned from the lock state:
 - `context-budget-read-gate.sh` — Warn/block after 3+ source file reads
 - `context-budget-write-gate.sh` — Detect test/doc creation for Codex delegation
 - `context-budget-edit-write-gate.sh` — Block edits when too many files read
-- `context-budget-agent-gate.sh` — Monitor agent spawning count
-- `context-budget-reset.sh` — Reset counters on session start
+- `context-budget-agent-gate.sh` — Enforce foreground impl agent limits (Rule 2+4), background/TeamCreate governance
+- `context-budget-reset.sh` — Reset all counters on session start (incl. `fg_impl_agent_count`)
+- `codex-task-release.sh` — Release Codex call counter after task completion (PostToolUse)
 
 ### Workflow Enforcement
 - `enforce-git-freshness.sh` — Block edits if behind remote

--- a/hooks/codex-task-release.sh
+++ b/hooks/codex-task-release.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# codex-task-release.sh — PostToolUse hook for Bash
+# ========================================================================
+# Releases codex_call_count after a Codex CLI command completes.
+#
+# Problem (Issue #31 / user feedback):
+#   codex-task-gate.sh (PreToolUse) increments codex_call_count on Codex
+#   execution, but never decrements it. This means after 1 Codex call
+#   completes, no further Codex calls are allowed for the entire session.
+#   The rule intent is "max 1 CONCURRENT Codex task", not "max 1 ever".
+#
+# Solution:
+#   This PostToolUse hook detects completed Codex commands and decrements
+#   codex_call_count, re-enabling future Codex calls.
+#
+# Trigger: PostToolUse for Bash tool
+# State file: ~/.claude/state/context-budget.json
+# ========================================================================
+
+set -euo pipefail
+
+input=$(cat)
+
+tool_name=$(echo "$input" | jq -r '.tool_name // ""' 2>/dev/null || echo "")
+bash_cmd=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+
+# Only process Bash tool completions
+[[ "$tool_name" != "Bash" ]] && exit 0
+
+# Only match actual Codex execution (same pattern as codex-task-gate.sh)
+first_line=$(echo "$bash_cmd" | head -1)
+is_codex_exec=false
+if echo "$first_line" | grep -qE '^\s*(\S+=\S+\s+)*bash\s+\S*codex-(parallel|orchestrate)'; then
+    is_codex_exec=true
+elif echo "$first_line" | grep -qE '^\s*(\S+=\S+\s+)*codex\s+exec\b'; then
+    is_codex_exec=true
+fi
+
+[[ "$is_codex_exec" != "true" ]] && exit 0
+
+# Decrement codex_call_count (release the lock)
+BUDGET_FILE="${HOME}/.claude/state/context-budget.json"
+if [[ -f "$BUDGET_FILE" ]]; then
+    _BUDGET_FILE="$BUDGET_FILE" python3 -c "
+import json, os
+f = os.environ['_BUDGET_FILE']
+with open(f) as fh:
+    s = json.load(fh)
+count = s.get('codex_call_count', 0)
+if count > 0:
+    s['codex_call_count'] = count - 1
+with open(f, 'w') as fh:
+    json.dump(s, fh, indent=2)
+" 2>/dev/null
+fi
+
+exit 0

--- a/hooks/context-budget-agent-gate.sh
+++ b/hooks/context-budget-agent-gate.sh
@@ -3,10 +3,11 @@
 # ========================================================================
 # PreToolUse hook: Agent launch governance (main session only).
 #
-# Enforces 3 rules:
+# Enforces 4 rules:
 #   1. BLOCK isolation: "worktree" (stale develop base, 3/3 failed 2026-03-18)
 #   2. BLOCK 2+ implementation agents → force TeamCreate with integrity checker
 #   3. WARN at 3+ agents → suggest Codex orchestration for mechanical tasks
+#   4. BLOCK 2+ foreground impl agents / WARN on 1st (Issue #31)
 #
 # Exemptions:
 #   - Subagent context (CLAUDE_AGENT_DEPTH >= 1): not counted/blocked
@@ -40,6 +41,7 @@ if [[ ! -f "$STATE_FILE" ]]; then
   "write_test_doc_count": 0,
   "agent_count": 0,
   "impl_agent_count": 0,
+  "fg_impl_agent_count": 0,
   "codex_call_count": 0,
   "warnings_issued": [],
   "started_at": ""
@@ -105,10 +107,10 @@ except Exception:
 # --- Rule 1: BLOCK worktree isolation ---
 isolation = tool_input.get("isolation", "")
 if isolation == "worktree":
-    print('🚫 [Worktree Block] isolation: "worktree" は使用禁止です。')
-    print("")
-    print("理由: stale develop base問題で3回連続失敗 (2026-03-18)。")
-    print("代替: TeamCreate / isolation なし Agent / 手動ブランチ作成")
+    print('🚫 [Worktree Block] isolation: "worktree" は使用禁止です。', file=sys.stderr)
+    print("", file=sys.stderr)
+    print("理由: stale develop base問題で3回連続失敗 (2026-03-18)。", file=sys.stderr)
+    print("代替: TeamCreate / isolation なし Agent / 手動ブランチ作成", file=sys.stderr)
     sys.exit(2)
 
 # --- Classify agent type ---
@@ -118,25 +120,38 @@ is_research = (
     subagent_type in RESEARCH_TYPES
     or any(kw in description for kw in RESEARCH_KEYWORDS)
 )
+is_background = bool(tool_input.get("run_in_background", False))
 
-# --- Rule 2: BLOCK 2+ standalone impl agents → TeamCreate ---
-# TeamCreate workers (team_name set) are EXEMPT — that's the correct pattern
+# --- Rule 2 + Rule 4 (combined): foreground impl agent governance ---
+# - Background agents: EXEMPT (parallel execution is the goal)
+# - TeamCreate workers (team_name set): EXEMPT
+# - Research/review agents: EXEMPT
+# - 1st foreground impl: WARN (suggest background/TeamCreate for next)
+# - 2nd+ foreground impl: BLOCK
 has_team = bool(tool_input.get("team_name", ""))
-if not is_research and not has_team:
+if not is_research and not has_team and not is_background:
     impl_count = state.get("impl_agent_count", 0)
     if impl_count >= 1:
-        print("🚫 [TeamCreate Required] 2つ目のスタンドアロン実装Agentをブロック。")
-        print("")
-        print("ルール: 並列実装 → TeamCreate (整合性チェックWorker含む)")
-        print("  → worktree問題なし（共有コンテキスト）")
-        print("  → ADR/プロダクト整合性を常時検証")
-        print("")
-        print("TeamCreate済みならteam_nameを指定してください。")
-        print("単一タスクなら isolation なし Agent を使用してください。")
+        print("🚫 [Foreground Impl Blocked] 2つ目のforeground実装Agentをブロック。", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("前回のforeground Agentでメインセッションがブロックされました。", file=sys.stderr)
+        print("独立タスクは並列実行が必須です。", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("修正方法:", file=sys.stderr)
+        print("  1. run_in_background: true を指定（推奨）", file=sys.stderr)
+        print("  2. TeamCreate で並列チームを構成", file=sys.stderr)
+        print("  3. Codex CLI 経路C で委任", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("Ref: Issue #31 — foreground実装Agentの逐次実行を防止", file=sys.stderr)
         with open(state_file, "w") as f:
             json.dump(state, f, indent=2)
         sys.exit(2)
     state["impl_agent_count"] = impl_count + 1
+    state["fg_impl_agent_count"] = state.get("fg_impl_agent_count", 0) + 1
+    # WARN on 1st foreground impl
+    print("⚠️ [Foreground Impl] 実装Agentがforegroundで起動されます。", file=sys.stderr)
+    print("  → 2つ目以降はrun_in_background: trueまたはTeamCreateを使用してください。", file=sys.stderr)
+    print("  → foreground実行はメインセッションをブロックします。", file=sys.stderr)
 
 # --- Count total agents ---
 state["agent_count"] = state.get("agent_count", 0) + 1
@@ -147,14 +162,14 @@ with open(state_file, "w") as f:
 
 # --- Rule 3: WARN at 3+ total agents ---
 if count == 3:
-    print("⚠️ [Context Budget] 3エージェント起動。")
-    print("  → 機械的タスクは codex-orchestrate.sh / TeamCreate を検討")
+    print("⚠️ [Context Budget] 3エージェント起動。", file=sys.stderr)
+    print("  → 機械的タスクは codex-orchestrate.sh / TeamCreate を検討", file=sys.stderr)
 elif count == 5:
-    print("🚫 [Context Budget] 5エージェント。コンテキスト消費が深刻。")
-    print("  → Codex CLI 経路C への切り替えを強く推奨")
+    print("🚫 [Context Budget] 5エージェント。コンテキスト消費が深刻。", file=sys.stderr)
+    print("  → Codex CLI 経路C への切り替えを強く推奨", file=sys.stderr)
 elif count >= 7:
-    print("🚫🚫 [Context Budget] {}エージェント（危険水域）。".format(count))
-    print("  → 残タスクはCodexに委任してください")
+    print("🚫🚫 [Context Budget] {}エージェント（危険水域）。".format(count), file=sys.stderr)
+    print("  → 残タスクはCodexに委任してください", file=sys.stderr)
 
 PYEOF
 

--- a/hooks/context-budget-reset.sh
+++ b/hooks/context-budget-reset.sh
@@ -24,6 +24,7 @@ cat > "$STATE_FILE" << EOF
   "write_test_doc_count": 0,
   "agent_count": 0,
   "impl_agent_count": 0,
+  "fg_impl_agent_count": 0,
   "codex_call_count": 0,
   "edit_count": 0,
   "edited_files": [],

--- a/settings.json
+++ b/settings.json
@@ -393,6 +393,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash ~/.claude/hooks/codex-task-release.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
             "command": "bash ~/.claude/hooks/post-merge-close-issues.sh"
           }
         ]


### PR DESCRIPTION
## Summary
- **Issue #31**: `context-budget-agent-gate.sh` に Rule 4 を統合。foreground実装Agentの2つ目をブロック、1つ目に警告
- **Codex改善**: `codex-task-release.sh` (PostToolUse) でCodexタスク完了後にカウンター解放。「セッション内1回限り」→「同時1タスク制限」に修正
- **品質**: 全blockingメッセージをstderrに統一、`context-budget-reset.sh` にスキーマ追加

## Changes
- `hooks/context-budget-agent-gate.sh`: Rule 2+4統合、background免除、stderr統一
- `hooks/context-budget-reset.sh`: `fg_impl_agent_count` 追加
- `hooks/codex-task-release.sh`: NEW — PostToolUse でCodexカウンター解放
- `settings.json`: PostToolUse hook追加
- `README.md` / `README.ja.md`: hook説明更新

## Test plan
- [ ] 1st foreground impl → WARN, exit 0
- [ ] 2nd foreground impl → BLOCK, exit 2
- [ ] Background impl (any count) → ALLOW
- [ ] Research/review agents → always ALLOW
- [ ] TeamCreate agents → always ALLOW
- [ ] Codex counter: 1 → release → 0 (re-enables next call)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * エージェント制約管理とタスク制限ポリシーに関するドキュメントを更新しました。

* **New Features**
  * Codex タスク完了後にリソースを自動解放する新機能を追加しました。

* **Improvements**
  * フォアグラウンド実装エージェントの監視制御を強化しました。
  * 状態管理システムをリセット時により詳細にカウンターを追跡するよう更新しました。
  * タスク実行制御の設定を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->