### PR TITLE
chore: warn when push invalidates completed review (#33)

### DIFF
--- a/hooks/pr-ci-review-gate.sh
+++ b/hooks/pr-ci-review-gate.sh
@@ -381,8 +381,18 @@ with open(f_path, 'r+') as f:
   # Dual-reset: clear from BOTH project-scoped AND global state
   # to prevent stale code_review=true from satisfying gates (Codex P2 finding)
   GLOBAL_REVIEW="$HOME/.claude/state/review-status.json"
+  review_was_set=false
   for _target in "$REVIEW_STATE" "$GLOBAL_REVIEW"; do
     [[ ! -f "$_target" ]] && continue
+    # Check if review was previously marked as complete before clearing
+    had_review=$(_STATE="$_target" _BR="$BRANCH" python3 -c "
+import json, os
+with open(os.environ['_STATE']) as f:
+    s = json.load(f)
+br = s.get(os.environ['_BR'], {})
+print('true' if br.get('code_review') or br.get('codex_review') else 'false')
+" 2>/dev/null || echo "false")
+    [[ "$had_review" == "true" ]] && review_was_set=true
     _STATE="$_target" _BR="$BRANCH" python3 -c "
 import json, os, fcntl
 f_path = os.environ['_STATE']
@@ -395,6 +405,15 @@ with open(f_path, 'r+') as f:
     fcntl.flock(f, fcntl.LOCK_UN)
 " 2>/dev/null
   done
+
+  # Issue #33: Warn when push invalidated a completed review
+  if [[ "$review_was_set" == "true" ]]; then
+    echo "" >&2
+    echo "⚠️ [Review Reset] Push でレビューステータスがリセットされました。" >&2
+    echo "  ブランチ: ${BRANCH} (PR #${PR_NUMBER})" >&2
+    echo "  push前のレビュー結果は無効化されました。" >&2
+    echo "  → PR作成/マージ前に code-reviewer + Codex CLI を再実行してください。" >&2
+  fi
 
   # Classify tier to show appropriate requirements
   TIER=$(classify_review_tier "$BRANCH")


### PR DESCRIPTION
## Summary
- `pr-ci-review-gate.sh` の POST_PUSH モードで、push前にレビューが完了していた場合に明示的な警告を表示
- push後に「レビュー完了」と誤報告するケースを防止

## Changes
- `hooks/pr-ci-review-gate.sh`: push前にcode_review/codex_reviewの有無をチェックし、リセット時に警告出力

## Test plan
- [ ] レビュー済みブランチにpush → 警告メッセージ表示
- [ ] レビュー未実施ブランチにpush → 警告なし（既存動作維持）

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * レビュー状態管理ロジックを改善し、既存の完了状態検出機能を追加しました。
  * 状態がリセットされた場合に警告メッセージを発行する仕組みを実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->