### PR TITLE
chore: dual-write codex review status for path consistency (#35)

### DIFF
--- a/hooks/record-codex-review.sh
+++ b/hooks/record-codex-review.sh
@@ -4,8 +4,13 @@
 # Records Codex CLI review completion in review-status.json.
 # Called by codex-parallel.sh after --review mode completes.
 #
+# Dual-write: writes to BOTH global and project-scoped state files
+# to prevent path-dependent mismatch (Issue #35).
+# Pattern matches record-code-review.sh (PostToolUse hook).
+#
 # Usage: record-codex-review.sh <branch> [repo-path]
-# State file: <project>/.claude/state/review-status.json
+# State file: ~/.claude/state/review-status.json (global)
+#             <project>/.claude/state/review-status.json (project-scoped)
 # ========================================================================
 
 set -euo pipefail
@@ -13,27 +18,32 @@ set -euo pipefail
 BRANCH="${1:?branch required}"
 REPO_PATH="${2:-$(pwd)}"
 
-# Determine state directory
-if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
-  STATE_DIR="${CLAUDE_PROJECT_DIR}/.claude/state"
-elif [[ -d "$REPO_PATH/.git" ]] || [[ -f "$REPO_PATH/.git" ]]; then
-  STATE_DIR="$REPO_PATH/.claude/state"
-else
-  STATE_DIR="$HOME/.claude/state"
-fi
-REVIEW_STATE="$STATE_DIR/review-status.json"
-mkdir -p "$STATE_DIR"
-[ ! -f "$REVIEW_STATE" ] && echo '{}' > "$REVIEW_STATE"
-
-# Update review-status.json: mark codex_review as true for this branch
 NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-if command -v jq &>/dev/null; then
-  tmp=$(mktemp)
-  jq --arg b "$BRANCH" --arg t "$NOW" \
-    '.[$b] = ((.[$b] // {}) + {"codex_review": true, "codex_review_at": $t})' \
-    "$REVIEW_STATE" > "$tmp" 2>/dev/null && mv "$tmp" "$REVIEW_STATE"
-else
-  _STATE="$REVIEW_STATE" _BR="$BRANCH" _NOW="$NOW" python3 -c "
+
+# --- Helper: write codex_review to a single state file ---
+write_codex_review() {
+  local target="$1"
+  mkdir -p "$(dirname "$target")"
+  [ ! -f "$target" ] && echo '{}' > "$target"
+
+  if command -v jq &>/dev/null; then
+    local tmp
+    tmp=$(mktemp)
+    if jq --arg b "$BRANCH" --arg t "$NOW" \
+      '.[$b] = ((.[$b] // {}) + {"codex_review": true, "codex_review_at": $t})' \
+      "$target" > "$tmp" 2>/dev/null; then
+      mv "$tmp" "$target"
+    else
+      rm -f "$tmp"
+      # Reset corrupted file and retry once
+      echo '{}' > "$target"
+      tmp=$(mktemp)
+      jq --arg b "$BRANCH" --arg t "$NOW" \
+        '.[$b] = {"codex_review": true, "codex_review_at": $t}' \
+        "$target" > "$tmp" 2>/dev/null && mv "$tmp" "$target" || rm -f "$tmp"
+    fi
+  else
+    _STATE="$target" _BR="$BRANCH" _NOW="$NOW" python3 -c "
 import json, os
 f_path = os.environ['_STATE']
 with open(f_path) as f: s = json.load(f)
@@ -41,6 +51,24 @@ s.setdefault(os.environ['_BR'], {})['codex_review'] = True
 s[os.environ['_BR']]['codex_review_at'] = os.environ['_NOW']
 with open(f_path, 'w') as f: json.dump(s, f, indent=2)
 " 2>/dev/null || true
+  fi
+}
+
+# --- Determine project-scoped state directory ---
+PROJECT_STATE_DIR=""
+if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+  PROJECT_STATE_DIR="${CLAUDE_PROJECT_DIR}/.claude/state"
+elif [[ -d "$REPO_PATH/.git" ]] || [[ -f "$REPO_PATH/.git" ]]; then
+  PROJECT_STATE_DIR="$REPO_PATH/.claude/state"
+fi
+
+# --- Global state (always write) ---
+GLOBAL_STATE="$HOME/.claude/state/review-status.json"
+write_codex_review "$GLOBAL_STATE"
+
+# --- Project-scoped state (write if different from global) ---
+if [[ -n "$PROJECT_STATE_DIR" ]] && [[ "$PROJECT_STATE_DIR" != "$HOME/.claude/state" ]]; then
+  write_codex_review "$PROJECT_STATE_DIR/review-status.json"
 fi
 
 echo "✅ [review-gate] Codex CLI レビュー完了を記録: branch=$BRANCH" >&2


### PR DESCRIPTION
## Summary
- `record-codex-review.sh` にデュアルライト追加（global + project-scoped）
- `record-code-review.sh` と同じパターンに統一
- グローバル側で `codex_review` が欠落する不整合を解消

## Changes
- `hooks/record-codex-review.sh`: ヘルパー関数 `write_codex_review()` でデュアルライト、corrupted file recovery追加

## Test plan
- [ ] Codex CLI review完了後、global と project 両方に codex_review=true が記録される
- [ ] 既存の code_review=true がある場合、上書きせずマージされる

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * コーデックスレビューの完了ステータス記録の信頼性が向上しました。システムは複数の場所にステータスを同期し、エラーが発生した場合の復旧機能を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->