### PR TITLE
fix: grep -P macOS compatibility in enforce-issue-close-verification (#37)

### DIFF
--- a/hooks/enforce-issue-close-verification.sh
+++ b/hooks/enforce-issue-close-verification.sh
@@ -18,7 +18,16 @@ if [ -z "$ISSUE_NUM" ]; then
 fi
 
 # Check if the close comment contains verification evidence
-COMMENT=$(echo "$COMMAND" | grep -oP '(?<=--comment ")[^"]*' || echo "$COMMAND")
+# Extract comment from -c "..." or --comment "..." (BSD compatible, no grep -P)
+COMMENT=$(echo "$COMMAND" | sed -En 's/.*(--comment|-c) "([^"]*)".*/\2/p')
+if [ -z "$COMMENT" ]; then
+  # Try single-quoted variant: -c '...'
+  COMMENT=$(echo "$COMMAND" | sed -En "s/.*(--comment|-c) '([^']*)'.*/\2/p")
+fi
+if [ -z "$COMMENT" ]; then
+  # No explicit comment flag found — use entire command for pattern matching
+  COMMENT="$COMMAND"
+fi
 
 # Required patterns in the close comment
 HAS_FILE_EVIDENCE=false


### PR DESCRIPTION
## Summary
- `enforce-issue-close-verification.sh` の `grep -oP` を `sed -En` に置換
- macOS BSD grep で `-P` (Perl regex) 未対応によるIssueクローズ完全ブロックを修正

## Changes
- `grep -oP '(?<=--comment ")[^"]*'` → `sed -En 's/.*(--comment|-c) "([^"]*)".*/\2/p'`
- single-quote variant (`-c '...'`) の抽出も追加

## Test plan
- [ ] `--comment "msg"` → 正常抽出
- [ ] `-c "msg"` → 正常抽出
- [ ] `-c 'msg'` → 正常抽出
- [ ] コメントなし → フォールバック (全コマンド文字列)
- [ ] `grep: invalid option -- P` エラーが出ないこと

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 内部検証スクリプトの互換性を改善しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->