### PR TITLE
feat: PostToolUse Quality Loop + リンター設定保護 hook

### DIFF
--- a/hooks/post-lint-format.sh
+++ b/hooks/post-lint-format.sh
@@ -8,7 +8,9 @@
 #   3. Return remaining violations via JSON additionalContext
 #
 # Performance: 2s timeout per tool. Silent skip if tool not installed.
-set -euo pipefail
+# Security: No npx --yes (supply-chain risk). Only pre-installed tools.
+set -uo pipefail
+# Note: -e intentionally omitted — timeout exits non-zero and we handle it
 
 TIMEOUT=2
 MAX_OUTPUT_LINES=20
@@ -28,74 +30,71 @@ esac
 
 diagnostics=""
 
-run_with_timeout() {
-  timeout "$TIMEOUT" bash -c "$1" 2>&1 || true
+# Safe timeout wrapper: passes file as argument, not interpolated in bash -c
+run_lint() {
+  local tool="$1"
+  shift
+  timeout "$TIMEOUT" "$tool" "$@" 2>&1 || true
 }
 
 case "$file" in
   *.ts|*.tsx|*.js|*.jsx)
-    # Phase 1: Auto-fix (silent)
+    # Phase 1: Auto-fix (silent) — only if tool is installed
     if command -v biome >/dev/null 2>&1; then
-      run_with_timeout "biome format --write '$file'" >/dev/null 2>&1
-    elif command -v npx >/dev/null 2>&1; then
-      run_with_timeout "npx --yes @biomejs/biome format --write '$file'" >/dev/null 2>&1
+      run_lint biome format --write "$file" >/dev/null 2>&1
     fi
 
     if command -v oxlint >/dev/null 2>&1; then
-      run_with_timeout "oxlint --fix '$file'" >/dev/null 2>&1
-    elif command -v npx >/dev/null 2>&1; then
-      run_with_timeout "npx --yes oxlint --fix '$file'" >/dev/null 2>&1
+      run_lint oxlint --fix "$file" >/dev/null 2>&1
     fi
 
     # Phase 2: Check remaining violations
     if command -v oxlint >/dev/null 2>&1; then
-      diagnostics="$(run_with_timeout "oxlint '$file'" | head -"$MAX_OUTPUT_LINES")"
-    elif command -v npx >/dev/null 2>&1; then
-      diagnostics="$(run_with_timeout "npx --yes oxlint '$file'" | head -"$MAX_OUTPUT_LINES")"
+      diagnostics="$(run_lint oxlint "$file" | head -"$MAX_OUTPUT_LINES")"
     fi
     ;;
 
   *.py)
     # Phase 1: Auto-fix (silent)
     if command -v ruff >/dev/null 2>&1; then
-      run_with_timeout "ruff check --fix '$file'" >/dev/null 2>&1
-      run_with_timeout "ruff format '$file'" >/dev/null 2>&1
+      run_lint ruff check --fix "$file" >/dev/null 2>&1
+      run_lint ruff format "$file" >/dev/null 2>&1
     fi
 
     # Phase 2: Check remaining violations
     if command -v ruff >/dev/null 2>&1; then
-      diagnostics="$(run_with_timeout "ruff check '$file'" | head -"$MAX_OUTPUT_LINES")"
+      diagnostics="$(run_lint ruff check "$file" | head -"$MAX_OUTPUT_LINES")"
     fi
     ;;
 
   *.go)
     # Phase 1: Auto-fix (silent)
     if command -v gofumpt >/dev/null 2>&1; then
-      run_with_timeout "gofumpt -w '$file'" >/dev/null 2>&1
+      run_lint gofumpt -w "$file" >/dev/null 2>&1
     fi
     if command -v golangci-lint >/dev/null 2>&1; then
-      run_with_timeout "golangci-lint run --fix '$file'" >/dev/null 2>&1
+      dir=""
+      dir="$(dirname "$file")"
+      run_lint golangci-lint run --fix "${dir}/..." >/dev/null 2>&1
     fi
 
-    # Phase 2: Check remaining violations
+    # Phase 2: Check remaining violations (directory scope)
     if command -v golangci-lint >/dev/null 2>&1; then
-      diagnostics="$(run_with_timeout "golangci-lint run '$file'" | head -"$MAX_OUTPUT_LINES")"
+      dir=""
+      dir="$(dirname "$file")"
+      diagnostics="$(run_lint golangci-lint run "${dir}/..." | head -"$MAX_OUTPUT_LINES")"
     fi
     ;;
 
   *.json|*.css)
     # Phase 1: Auto-fix (silent)
     if command -v biome >/dev/null 2>&1; then
-      run_with_timeout "biome check --write '$file'" >/dev/null 2>&1
-    elif command -v npx >/dev/null 2>&1; then
-      run_with_timeout "npx --yes @biomejs/biome check --write '$file'" >/dev/null 2>&1
+      run_lint biome check --write "$file" >/dev/null 2>&1
     fi
 
     # Phase 2: Check remaining violations
     if command -v biome >/dev/null 2>&1; then
-      diagnostics="$(run_with_timeout "biome check '$file'" | head -"$MAX_OUTPUT_LINES")"
-    elif command -v npx >/dev/null 2>&1; then
-      diagnostics="$(run_with_timeout "npx --yes @biomejs/biome check '$file'" | head -"$MAX_OUTPUT_LINES")"
+      diagnostics="$(run_lint biome check "$file" | head -"$MAX_OUTPUT_LINES")"
     fi
     ;;
 
@@ -111,7 +110,6 @@ if [[ -n "$diagnostics" ]] \
   && [[ "$diagnostics" != *"No lint violations"* ]] \
   && [[ "$diagnostics" != *"Found 0 error"* ]] \
   && [[ "$diagnostics" != *"All checks passed"* ]] \
-  && [[ "$diagnostics" != *"Checked 1 file"*"Found 0"* ]] \
   && [[ "$diagnostics" != *"0 diagnostics"* ]]; then
   jq -Rn --arg msg "$diagnostics" '{
     hookSpecificOutput: {

--- a/hooks/post-lint-format.sh
+++ b/hooks/post-lint-format.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# PostToolUse Quality Loop — ADR-001, ADR-003
+# Runs linting/formatting after Write/Edit, returns violations via additionalContext
+#
+# Architecture:
+#   1. Auto-fix phase (silent): formatter → linter --fix
+#   2. Residual check: re-run linter (no --fix)
+#   3. Return remaining violations via JSON additionalContext
+#
+# Performance: 2s timeout per tool. Silent skip if tool not installed.
+set -euo pipefail
+
+TIMEOUT=2
+MAX_OUTPUT_LINES=20
+
+input="$(cat)"
+file="$(jq -r '.tool_input.file_path // .tool_input.path // empty' <<< "$input")"
+
+# Skip if no file or excluded path
+[[ -z "$file" ]] && exit 0
+case "$file" in
+  */node_modules/*|*/dist/*|*/build/*|*/.next/*|*/vendor/*|*/.claude/*|*/__pycache__/*|*/.git/*)
+    exit 0 ;;
+esac
+
+# Skip if file doesn't exist (was deleted)
+[[ ! -f "$file" ]] && exit 0
+
+diagnostics=""
+
+run_with_timeout() {
+  timeout "$TIMEOUT" bash -c "$1" 2>&1 || true
+}
+
+case "$file" in
+  *.ts|*.tsx|*.js|*.jsx)
+    # Phase 1: Auto-fix (silent)
+    if command -v biome >/dev/null 2>&1; then
+      run_with_timeout "biome format --write '$file'" >/dev/null 2>&1
+    elif command -v npx >/dev/null 2>&1; then
+      run_with_timeout "npx --yes @biomejs/biome format --write '$file'" >/dev/null 2>&1
+    fi
+
+    if command -v oxlint >/dev/null 2>&1; then
+      run_with_timeout "oxlint --fix '$file'" >/dev/null 2>&1
+    elif command -v npx >/dev/null 2>&1; then
+      run_with_timeout "npx --yes oxlint --fix '$file'" >/dev/null 2>&1
+    fi
+
+    # Phase 2: Check remaining violations
+    if command -v oxlint >/dev/null 2>&1; then
+      diagnostics="$(run_with_timeout "oxlint '$file'" | head -"$MAX_OUTPUT_LINES")"
+    elif command -v npx >/dev/null 2>&1; then
+      diagnostics="$(run_with_timeout "npx --yes oxlint '$file'" | head -"$MAX_OUTPUT_LINES")"
+    fi
+    ;;
+
+  *.py)
+    # Phase 1: Auto-fix (silent)
+    if command -v ruff >/dev/null 2>&1; then
+      run_with_timeout "ruff check --fix '$file'" >/dev/null 2>&1
+      run_with_timeout "ruff format '$file'" >/dev/null 2>&1
+    fi
+
+    # Phase 2: Check remaining violations
+    if command -v ruff >/dev/null 2>&1; then
+      diagnostics="$(run_with_timeout "ruff check '$file'" | head -"$MAX_OUTPUT_LINES")"
+    fi
+    ;;
+
+  *.go)
+    # Phase 1: Auto-fix (silent)
+    if command -v gofumpt >/dev/null 2>&1; then
+      run_with_timeout "gofumpt -w '$file'" >/dev/null 2>&1
+    fi
+    if command -v golangci-lint >/dev/null 2>&1; then
+      run_with_timeout "golangci-lint run --fix '$file'" >/dev/null 2>&1
+    fi
+
+    # Phase 2: Check remaining violations
+    if command -v golangci-lint >/dev/null 2>&1; then
+      diagnostics="$(run_with_timeout "golangci-lint run '$file'" | head -"$MAX_OUTPUT_LINES")"
+    fi
+    ;;
+
+  *.json|*.css)
+    # Phase 1: Auto-fix (silent)
+    if command -v biome >/dev/null 2>&1; then
+      run_with_timeout "biome check --write '$file'" >/dev/null 2>&1
+    elif command -v npx >/dev/null 2>&1; then
+      run_with_timeout "npx --yes @biomejs/biome check --write '$file'" >/dev/null 2>&1
+    fi
+
+    # Phase 2: Check remaining violations
+    if command -v biome >/dev/null 2>&1; then
+      diagnostics="$(run_with_timeout "biome check '$file'" | head -"$MAX_OUTPUT_LINES")"
+    elif command -v npx >/dev/null 2>&1; then
+      diagnostics="$(run_with_timeout "npx --yes @biomejs/biome check '$file'" | head -"$MAX_OUTPUT_LINES")"
+    fi
+    ;;
+
+  *)
+    # Unsupported file type — silent skip
+    exit 0
+    ;;
+esac
+
+# Phase 3: Return remaining violations via additionalContext
+# Filter out "all clean" messages from various tools
+if [[ -n "$diagnostics" ]] \
+  && [[ "$diagnostics" != *"No lint violations"* ]] \
+  && [[ "$diagnostics" != *"Found 0 error"* ]] \
+  && [[ "$diagnostics" != *"All checks passed"* ]] \
+  && [[ "$diagnostics" != *"Checked 1 file"*"Found 0"* ]] \
+  && [[ "$diagnostics" != *"0 diagnostics"* ]]; then
+  jq -Rn --arg msg "$diagnostics" '{
+    hookSpecificOutput: {
+      hookEventName: "PostToolUse",
+      additionalContext: ("Lint violations found. Fix the code (not the linter config):\n\n" + $msg)
+    }
+  }'
+fi

--- a/hooks/protect-linter-config.sh
+++ b/hooks/protect-linter-config.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# PreToolUse Safety Gate — ADR-001, ADR-003
+# Blocks modification of linter/formatter/type-checker configuration files.
+#
+# WHY: Agents tend to weaken linter rules instead of fixing code when they
+#      encounter lint errors. This hook deterministically prevents that.
+#
+# Exit 2 = block the tool call (Claude Code PreToolUse convention)
+set -euo pipefail
+
+input="$(cat)"
+file="$(jq -r '.tool_input.file_path // .tool_input.path // empty' <<< "$input")"
+
+[[ -z "$file" ]] && exit 0
+
+PROTECTED_PATTERNS=(
+  ".eslintrc"
+  "eslint.config"
+  "biome.json"
+  "biome.jsonc"
+  ".oxlintrc"
+  "pyproject.toml"
+  ".golangci."
+  "Cargo.toml"
+  ".prettierrc"
+  "prettier.config"
+  ".editorconfig"
+  "tsconfig.json"
+  "tsconfig."
+  "lefthook.yml"
+  ".pre-commit-config"
+  ".ruff.toml"
+  "ruff.toml"
+)
+
+basename_file="$(basename "$file")"
+
+for pattern in "${PROTECTED_PATTERNS[@]}"; do
+  case "$basename_file" in
+    *"$pattern"*)
+      cat >&2 <<MSG
+BLOCKED: $file is a protected linter/formatter config.
+
+WHY: Agents tend to weaken linter rules instead of fixing code.
+     When a linter reports errors, fix the SOURCE CODE, not the config.
+     See ADR-001 (docs/adr/001-posttooluse-quality-loop.md)
+     See ADR-003 (docs/adr/003-feedback-speed-hierarchy.md)
+
+FIX: Fix the code that violates the rule.
+     If the rule is genuinely wrong, propose an ADR to change it.
+MSG
+      exit 2
+      ;;
+  esac
+done

--- a/hooks/protect-linter-config.sh
+++ b/hooks/protect-linter-config.sh
@@ -5,6 +5,13 @@
 # WHY: Agents tend to weaken linter rules instead of fixing code when they
 #      encounter lint errors. This hook deterministically prevents that.
 #
+# Protected file categories:
+#   - Linter configs: .eslintrc*, biome.json*, .oxlintrc*, .ruff.toml, .golangci.*
+#   - Formatter configs: .prettierrc*, .editorconfig
+#   - Type checker configs: tsconfig.json* (type safety is a quality gate)
+#   - Build tool configs: pyproject.toml, Cargo.toml (contain linter sections)
+#   - Pre-commit configs: lefthook.yml, .pre-commit-config*
+#
 # Exit 2 = block the tool call (Claude Code PreToolUse convention)
 set -euo pipefail
 
@@ -13,33 +20,19 @@ file="$(jq -r '.tool_input.file_path // .tool_input.path // empty' <<< "$input")
 
 [[ -z "$file" ]] && exit 0
 
-PROTECTED_PATTERNS=(
-  ".eslintrc"
-  "eslint.config"
-  "biome.json"
-  "biome.jsonc"
-  ".oxlintrc"
-  "pyproject.toml"
-  ".golangci."
-  "Cargo.toml"
-  ".prettierrc"
-  "prettier.config"
-  ".editorconfig"
-  "tsconfig.json"
-  "tsconfig."
-  "lefthook.yml"
-  ".pre-commit-config"
-  ".ruff.toml"
-  "ruff.toml"
-)
-
 basename_file="$(basename "$file")"
 
-for pattern in "${PROTECTED_PATTERNS[@]}"; do
-  case "$basename_file" in
-    *"$pattern"*)
-      cat >&2 <<MSG
-BLOCKED: $file is a protected linter/formatter config.
+# O(1) pattern matching using case statement (SUGGESTION-3 from review)
+case "$basename_file" in
+  .eslintrc*|eslint.config*|biome.json*|biome.jsonc|\
+  .oxlintrc*|.ruff.toml|ruff.toml|\
+  .golangci.yml|.golangci.yaml|\
+  .prettierrc*|prettier.config*|.editorconfig|\
+  tsconfig.json|tsconfig.*.json|\
+  pyproject.toml|Cargo.toml|\
+  lefthook.yml|.pre-commit-config*)
+    cat >&2 <<MSG
+BLOCKED: $basename_file is a protected linter/formatter/type-checker config.
 
 WHY: Agents tend to weaken linter rules instead of fixing code.
      When a linter reports errors, fix the SOURCE CODE, not the config.
@@ -48,8 +41,11 @@ WHY: Agents tend to weaken linter rules instead of fixing code.
 
 FIX: Fix the code that violates the rule.
      If the rule is genuinely wrong, propose an ADR to change it.
+
+NOTE: pyproject.toml and Cargo.toml are fully protected because they
+      contain linter/formatter configuration sections ([tool.ruff], [lints.clippy]).
+      tsconfig.json is protected because type safety is a quality gate.
 MSG
-      exit 2
-      ;;
-  esac
-done
+    exit 2
+    ;;
+esac

--- a/settings.json
+++ b/settings.json
@@ -110,6 +110,12 @@
           {
             "type": "command",
             "command": "bash ~/.claude/hooks/enforce-factcheck-before-edit.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/protect-linter-config.sh",
+            "timeout": 5,
+            "statusMessage": "Checking linter config protection..."
           }
         ]
       },
@@ -142,6 +148,12 @@
           {
             "type": "command",
             "command": "bash ~/.claude/hooks/block-version-downgrade.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/protect-linter-config.sh",
+            "timeout": 5,
+            "statusMessage": "Checking linter config protection..."
           }
         ]
       },
@@ -465,6 +477,17 @@
             "command": "bash ~/.claude/hooks/workflow-sync-guard.sh",
             "timeout": 10,
             "statusMessage": "Checking workflow file sync..."
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/post-lint-format.sh",
+            "timeout": 5,
+            "statusMessage": "Running PostToolUse Quality Loop (lint + format)..."
           }
         ]
       }


### PR DESCRIPTION
## Summary

- `post-lint-format.sh`: Write/Edit 後に自動リンティング・フォーマッティング (ADR-001)
- `protect-linter-config.sh`: リンター設定ファイルの編集をブロック (ADR-003)
- `settings.json`: hook matcher 追加 (PreToolUse + PostToolUse)

## Architecture (ADR-001: Quality Loop)

Write/Edit trigger → PostToolUse Hook → [1] Auto-fix → [2] Residual check → [3] additionalContext JSON

## Supported Languages

| Language | Formatter | Linter | Timeout |
|----------|-----------|--------|---------|
| TS/JS | biome format | oxlint | 2s |
| Python | ruff format | ruff check | 2s |
| Go | gofumpt | golangci-lint | 2s |
| JSON/CSS | biome check | biome check | 2s |

## Code Review Fixes (2nd commit)

- CRITICAL: Shell injection fix (direct tool invocation instead of bash -c)
- CRITICAL: Removed npx --yes (supply-chain risk)
- HIGH: Added rationale for pyproject.toml/Cargo.toml/tsconfig in error message
- SUGGESTION: O(1) case statement, golangci-lint directory scope

## Test plan

- [ ] TS/Python/Go file edit triggers linting
- [ ] Missing tool → silent skip
- [ ] node_modules/ excluded
- [ ] biome.json/tsconfig/pyproject.toml edit → BLOCKED
- [ ] Normal code file edit → not blocked

Closes #43, Closes #44
Epic: #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ファイル保存時に自動的にコードをリントおよびフォーマット処理する機能を追加しました。
  * リント・フォーマッター設定ファイルを保護し、意図しない編集を防止するセーフガード機能を実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->