### PR TITLE
docs: 参考ドキュメント(ベストプラクティス記事)を配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ claude-code-skills/
 
 新しいADRを追加する場合は [テンプレート](docs/adr/template.md) を使用してください。
 
+## References
+
+| ドキュメント | 説明 |
+|-------------|------|
+| [Harness Engineering ベストプラクティス 2026](docs/references/harness-engineering-best-practices-2026.md) | 本リポジトリの設計方針の根拠となる記事のサマリ |
+
+詳細は [docs/references/](docs/references/) を参照してください。
+
 ## Third-Party Dependencies
 
 This configuration integrates with the following third-party skill frameworks. They are **not bundled** in this repository — `setup.sh` installs them automatically.

--- a/docs/references/README.md
+++ b/docs/references/README.md
@@ -1,0 +1,7 @@
+# 参考ドキュメント
+
+設計判断の根拠となる外部ドキュメントのサマリを管理します。
+
+| ドキュメント | 原文URL | 関連ADR |
+|-------------|---------|---------|
+| [Harness Engineering ベストプラクティス 2026](harness-engineering-best-practices-2026.md) | [nyosegawa.com](https://nyosegawa.com/posts/harness-engineering-best-practices-2026/) | ADR-001〜004 |

--- a/docs/references/harness-engineering-best-practices-2026.md
+++ b/docs/references/harness-engineering-best-practices-2026.md
@@ -1,0 +1,32 @@
+# Harness Engineering ベストプラクティス (2026年3月)
+
+## 原文
+https://nyosegawa.com/posts/harness-engineering-best-practices-2026/
+
+## サマリ
+
+### 核心原則
+"プロンプトではなく仕組みで品質強制"
+
+### 8つの柱
+1. **リポジトリ衛生** — ADR, テスト優先, CI/CD完備
+2. **決定論的品質強制** — PostToolUse/PreToolUse hookで自動lint/format
+3. **フィードバック速度階層** — ms (PostToolUse) → s (pre-commit) → min (CI) → h (review)
+4. **CLAUDE.md/rules ポインタ型設計** — 50行以下, hookで強制済み内容は削除
+5. **Codex大規模委任モデル** — 1リクエスト, 内部分割はCodex自律
+6. **テスト反証可能性** — テストがバグを検出することを証明
+7. **セキュリティ・ガードレール** — shell injection防止, npx禁止
+8. **計測とスコアリング** — delivery_score.py による定量評価
+
+## ADRとの対応
+
+| 柱 | 対応ADR |
+|----|---------|
+| 決定論的品質強制 | ADR-001: PostToolUse Quality Loop |
+| CLAUDE.md設計 | ADR-002: ポインタ型設計原則 |
+| フィードバック速度階層 | ADR-003: フィードバック速度階層 |
+| Codex委任 | ADR-004: Codex大規模委任モデル |
+
+## 引用
+> "短ければ短いほど良い。理想は50行以下"
+> "150-200指示でprimacy bias顕著、性能劣化開始"


### PR DESCRIPTION
## Summary
- `docs/references/README.md`: 参考ドキュメントの索引ページを新規作成
- `docs/references/harness-engineering-best-practices-2026.md`: ベストプラクティス記事の構造化サマリを新規作成（8つの柱 + ADR対応表 + 引用）
- `README.md`: ADRセクション直後にReferencesセクションを追加

Closes #48

## Test plan
- [ ] `docs/references/README.md` のリンクが `harness-engineering-best-practices-2026.md` に正しく遷移すること
- [ ] `README.md` のReferencesセクションから `docs/references/harness-engineering-best-practices-2026.md` に正しく遷移すること
- [ ] ADR対応表のADR番号がdocs/adr/配下の既存ADRと一致すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* リファレンスドキュメントセクションをREADMEに追加し、設計方針の参照資料への訪問性を向上
* Harness Engineering ベストプラクティス（2026年版）に関するドキュメントを新規追加
* 外部参考資料を体系的に管理するためのドキュメント構造を整備

<!-- end of auto-generated comment: release notes by coderabbit.ai -->