### PR TITLE
feat: ブランチワークフロー自動強制 — develop自動作成 + リリースPR許可

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 [Claude Code](https://claude.com/claude-code)（Anthropic 公式 CLI）のためのスキル・ルール・フック集です。
 
-27 のカスタムスキル、43 の hook スクリプト、5 つのルールセットを含む、本番環境レベルの Claude Code 設定を提供します。
+27 のカスタムスキル、44 の hook スクリプト、5 つのルールセットを含む、本番環境レベルの Claude Code 設定を提供します。
 
 [English](README.md) | **日本語**
 
@@ -23,7 +23,7 @@ chmod +x setup.sh
 claude-code-skills/
 ├── skills/           # 27 カスタムスキル定義 (SKILL.md + scripts + references)
 ├── rules/            # 5 グローバルルール (コーディング規約, Git, 品質, テスト, 委任)
-├── hooks/            # 43 hook スクリプト (品質ゲート, 安全ガード, ワークフロー強制)
+├── hooks/            # 44 hook スクリプト (品質ゲート, 安全ガード, ワークフロー強制)
 ├── scripts/          # 5 ユーティリティ (Codex 連携, PR レビュー, コンテキスト監視)
 ├── setup.sh          # ワンコマンドインストール
 ├── settings.json     # 設定テンプレート (パス等サニタイズ済み)
@@ -47,7 +47,7 @@ Think → Plan (gstack)
   /office-hours → /plan-ceo-review → /plan-eng-review → /plan-design-review
 
 Build → Review → Ship (カスタムスキル + hooks)
-  code-reviewer, review-loop, e2e, bugfix + 43 hook スクリプト
+  code-reviewer, review-loop, e2e, bugfix + 44 hook スクリプト
 
 Reflect (gstack)
   /retro
@@ -232,7 +232,7 @@ PR に GitHub レビューがない場合（ソロ開発など）、**ローカ�
 | **マージ後** | `post-merge-close-issues.sh` | リンクされた Issue を自動クローズ |
 | **セッション終了** | `pr-ci-review-gate.sh` (STOP) | 未検証 PR について警告 |
 
-## Hook システム（43 スクリプト）
+## Hook システム（44 スクリプト）
 
 ### 品質ゲート（マージ前）
 - `block-merge-without-ci.sh` — CI 全チェックグリーンなしでマージをブロック
@@ -252,6 +252,7 @@ PR に GitHub レビューがない場合（ソロ開発など）、**ローカ�
 - `audit-docker-build-args.sh` — Docker build args の http:// チェック
 - `block-local-hooks-write.sh` — settings.local.json によるグローバル hook 上書きを防止
 - `validate-no-local-hooks.sh` — セッション開始時に hook 上書きが存在しないことを検証
+- `enforce-branch-workflow.sh` — Auto-create develop branch, enforce feature branch workflow
 
 ### コンテキスト予算管理
 - `context-budget-read-gate.sh` — 3+ ソースファイル読み込みで警告/ブロック

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A curated collection of skills, rules, and hooks for [Claude Code](https://claude.com/claude-code) — Anthropic's official CLI for Claude.
 
-This repository provides a production-ready Claude Code configuration with 27 custom skills, 43 hook scripts, 5 rule sets, and integration with third-party skill frameworks.
+This repository provides a production-ready Claude Code configuration with 27 custom skills, 44 hook scripts, 5 rule sets, and integration with third-party skill frameworks.
 
 ## Quick Start
 
@@ -23,7 +23,7 @@ Restart Claude Code after installation.
 claude-code-skills/
 ├── skills/           # 27 custom skill definitions (SKILL.md + scripts + references)
 ├── rules/            # 5 global rule files (coding-style, git-workflow, quality, testing, delegation)
-├── hooks/            # 43 hook scripts (quality gates, safety guards, workflow enforcement)
+├── hooks/            # 44 hook scripts (quality gates, safety guards, workflow enforcement)
 ├── scripts/          # 5 utility scripts (Codex orchestration, PR review, context monitoring)
 ├── setup.sh          # One-command installation
 ├── settings.json     # Template settings (sanitized, no personal paths)
@@ -67,7 +67,7 @@ Think → Plan (gstack)
   /office-hours → /plan-ceo-review → /plan-eng-review → /plan-design-review
 
 Build → Review → Ship (custom skills + hooks)
-  code-reviewer, review-loop, e2e, bugfix + 43 hook scripts
+  code-reviewer, review-loop, e2e, bugfix + 44 hook scripts
 
 Reflect (gstack)
   /retro
@@ -252,7 +252,7 @@ Merged or closed PRs are automatically cleaned from the lock state:
 | **Post Merge** | `post-merge-close-issues.sh` | Auto-close linked issues |
 | **Session Stop** | `pr-ci-review-gate.sh` (STOP) | Warn about unverified PRs |
 
-## Hook System (43 Scripts)
+## Hook System (44 Scripts)
 
 ### Quality Gates (Pre-merge)
 - `block-merge-without-ci.sh` — Block merge unless all CI checks green
@@ -272,6 +272,7 @@ Merged or closed PRs are automatically cleaned from the lock state:
 - `audit-docker-build-args.sh` — Check for http:// in Docker build args
 - `block-local-hooks-write.sh` — Prevent settings.local.json from overriding global hooks
 - `validate-no-local-hooks.sh` — Validate no hook overrides exist on session start
+- `enforce-branch-workflow.sh` — Auto-create develop branch, enforce feature branch workflow
 
 ### Context Budget Management
 - `context-budget-read-gate.sh` — Warn/block after 3+ source file reads

--- a/hooks/enforce-branch-workflow.sh
+++ b/hooks/enforce-branch-workflow.sh
@@ -12,7 +12,7 @@
 # Ref: git-workflow.md — "保護ブランチ: develop, main, master"
 # =========================================================================
 
-set -uo pipefail
+set -euo pipefail
 
 # Only run in git repos
 git rev-parse --show-toplevel >/dev/null 2>&1 || exit 0
@@ -36,10 +36,10 @@ fi
 if [[ "$_has_develop" == "no" ]] && [[ "$_has_main" == "yes" ]]; then
   # Auto-create develop from main
   git branch develop main 2>/dev/null || true
-  git push -u origin develop 2>/dev/null || true
-  CONTEXT_LINES+=("[branch-workflow] develop ブランチを main から自動作成しました。")
+  CONTEXT_LINES+=("[branch-workflow] develop ブランチをローカルに作成しました。")
+  CONTEXT_LINES+=("  リモートへのpush: git push -u origin develop")
   CONTEXT_LINES+=("  今後は feat/* → develop → main のフローで開発してください。")
-  echo "[branch-workflow] develop ブランチを自動作成しました。" >&2
+  echo "[branch-workflow] develop ブランチをローカルに作成しました (push未実行)。" >&2
 fi
 
 # --- 2. Warn if on protected branch ---
@@ -58,15 +58,17 @@ esac
 
 # --- 3. Output additionalContext ---
 if [[ ${#CONTEXT_LINES[@]} -gt 0 ]]; then
-  JOINED=$(printf '%s\\n' "${CONTEXT_LINES[@]}")
-  cat <<HOOK_JSON
-{
-  "hookSpecificOutput": {
-    "hookEventName": "SessionStart",
-    "additionalContext": "${JOINED}"
-  }
-}
-HOOK_JSON
+  JOINED=$(printf '%s\n' "${CONTEXT_LINES[@]}")
+  if command -v jq &>/dev/null; then
+    jq -n --arg ctx "$JOINED" '{
+      hookSpecificOutput: {
+        hookEventName: "SessionStart",
+        additionalContext: $ctx
+      }
+    }'
+  else
+    echo "[branch-workflow] jq not found. Context output skipped." >&2
+  fi
 fi
 
 exit 0

--- a/hooks/enforce-branch-workflow.sh
+++ b/hooks/enforce-branch-workflow.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# enforce-branch-workflow.sh — SessionStart hook
+# =========================================================================
+# Enforces the develop branch workflow:
+#   main ← develop ← feat/* / fix/* / refactor/* / chore/*
+#
+# On SessionStart:
+#   1. Auto-create develop from main if only main exists
+#   2. Warn if currently on main/develop (should be on feature branch)
+#   3. Inject branch workflow guidance via additionalContext
+#
+# Ref: git-workflow.md — "保護ブランチ: develop, main, master"
+# =========================================================================
+
+set -uo pipefail
+
+# Only run in git repos
+git rev-parse --show-toplevel >/dev/null 2>&1 || exit 0
+
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+CONTEXT_LINES=()
+
+# --- 1. Auto-create develop if it doesn't exist ---
+_has_develop="no"
+git rev-parse --verify origin/develop >/dev/null 2>&1 && _has_develop="yes"
+if [[ "$_has_develop" == "no" ]]; then
+  git rev-parse --verify develop >/dev/null 2>&1 && _has_develop="yes"
+fi
+
+_has_main="no"
+git rev-parse --verify origin/main >/dev/null 2>&1 && _has_main="yes"
+if [[ "$_has_main" == "no" ]]; then
+  git rev-parse --verify main >/dev/null 2>&1 && _has_main="yes"
+fi
+
+if [[ "$_has_develop" == "no" ]] && [[ "$_has_main" == "yes" ]]; then
+  # Auto-create develop from main
+  git branch develop main 2>/dev/null || true
+  git push -u origin develop 2>/dev/null || true
+  CONTEXT_LINES+=("[branch-workflow] develop ブランチを main から自動作成しました。")
+  CONTEXT_LINES+=("  今後は feat/* → develop → main のフローで開発してください。")
+  echo "[branch-workflow] develop ブランチを自動作成しました。" >&2
+fi
+
+# --- 2. Warn if on protected branch ---
+case "$CURRENT_BRANCH" in
+  main|master)
+    CONTEXT_LINES+=("[branch-workflow] 現在 $CURRENT_BRANCH ブランチです。直接編集は禁止です。")
+    CONTEXT_LINES+=("  作業開始前に: git checkout -b feat/<description> develop")
+    echo "[branch-workflow] WARNING: $CURRENT_BRANCH ブランチ上です。feature ブランチに切り替えてください。" >&2
+    ;;
+  develop)
+    CONTEXT_LINES+=("[branch-workflow] 現在 develop ブランチです。")
+    CONTEXT_LINES+=("  実装作業は feature ブランチで行ってください: git checkout -b feat/<description>")
+    CONTEXT_LINES+=("  develop → main のリリースPRは develop 上から作成可能です。")
+    ;;
+esac
+
+# --- 3. Output additionalContext ---
+if [[ ${#CONTEXT_LINES[@]} -gt 0 ]]; then
+  JOINED=$(printf '%s\\n' "${CONTEXT_LINES[@]}")
+  cat <<HOOK_JSON
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "${JOINED}"
+  }
+}
+HOOK_JSON
+fi
+
+exit 0

--- a/hooks/pr-guard.sh
+++ b/hooks/pr-guard.sh
@@ -25,12 +25,12 @@ if [[ "$_develop_exists" == "yes" ]]; then
     [[ "$_dev_sha" == "$_main_sha" ]] && _develop_main_same="yes"
 fi
 
-if echo "$cmd" | grep -q '\-\-base main'; then
+if echo "$cmd" | grep -qE '\-\-base\s+main(\s|$)'; then
     _current=$(git branch --show-current 2>/dev/null || echo "")
     _is_release="no"
     # Allow release PR: develop → main
     [[ "$_current" == "develop" ]] && _is_release="yes"
-    echo "$cmd" | grep -q '\-\-head develop' && _is_release="yes"
+    echo "$cmd" | grep -qE '\-\-head\s+develop(\s|$)' && _is_release="yes"
 
     if [[ "$_is_release" == "yes" ]]; then
         : # Release PR from develop → main: allowed
@@ -38,7 +38,7 @@ if echo "$cmd" | grep -q '\-\-base main'; then
         BLOCKERS+=("[BLOCK] PRのターゲットがmainです。--base develop を使ってください。main ← develop ← feat/*")
         BLOCKERS+=("  develop → main リリースPRは develop ブランチから作成してください。")
     fi
-elif echo "$cmd" | grep -q '\-\-base develop'; then
+elif echo "$cmd" | grep -qE '\-\-base\s+develop(\s|$)'; then
     : # OK
 else
     if [[ "$_develop_exists" == "yes" ]]; then

--- a/hooks/pr-guard.sh
+++ b/hooks/pr-guard.sh
@@ -17,7 +17,7 @@ project_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 
 # --- 0. PR target branch check ---
 # Allow --base main when: develop doesn't exist, or develop == main (in sync)
-_develop_exists=$(git rev-parse --verify origin/develop 2>/dev/null && echo "yes" || echo "no")
+_develop_exists=$(git rev-parse --verify origin/develop >/dev/null 2>&1 && echo "yes" || echo "no")
 _develop_main_same="no"
 if [[ "$_develop_exists" == "yes" ]]; then
     _dev_sha=$(git rev-parse origin/develop 2>/dev/null || echo "")
@@ -26,17 +26,24 @@ if [[ "$_develop_exists" == "yes" ]]; then
 fi
 
 if echo "$cmd" | grep -q '\-\-base main'; then
-    if [[ "$_develop_exists" == "yes" ]] && [[ "$_develop_main_same" == "no" ]]; then
+    _current=$(git branch --show-current 2>/dev/null || echo "")
+    _is_release="no"
+    # Allow release PR: develop → main
+    [[ "$_current" == "develop" ]] && _is_release="yes"
+    echo "$cmd" | grep -q '\-\-head develop' && _is_release="yes"
+
+    if [[ "$_is_release" == "yes" ]]; then
+        : # Release PR from develop → main: allowed
+    elif [[ "$_develop_exists" == "yes" ]] && [[ "$_develop_main_same" == "no" ]]; then
         BLOCKERS+=("[BLOCK] PRのターゲットがmainです。--base develop を使ってください。main ← develop ← feat/*")
+        BLOCKERS+=("  develop → main リリースPRは develop ブランチから作成してください。")
     fi
-    # If develop doesn't exist or develop==main, --base main is OK
 elif echo "$cmd" | grep -q '\-\-base develop'; then
     : # OK
 else
     if [[ "$_develop_exists" == "yes" ]]; then
         BLOCKERS+=("[BLOCK] --base が未指定です。明示的に --base develop を指定してください")
     fi
-    # If develop doesn't exist, --base omission is OK (defaults to main)
 fi
 
 # --- 1. BLOCK: Issue reference with close keyword required ---

--- a/settings.json
+++ b/settings.json
@@ -75,6 +75,12 @@
             "command": "bash ~/.claude/hooks/validate-no-local-hooks.sh",
             "timeout": 5,
             "statusMessage": "Validating settings.local.json has no hook overrides..."
+          },
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/enforce-branch-workflow.sh",
+            "timeout": 15,
+            "statusMessage": "Checking branch workflow..."
           }
         ]
       }


### PR DESCRIPTION
## Summary

mainブランチへの直接push防止 + develop → main リリースPRフローの確立。

- **enforce-branch-workflow.sh** (新規): SessionStartでdevelop自動作成 + 保護ブランチ警告
- **pr-guard.sh修正**: >/dev/null バグ修正 + develop→mainリリースPR許可
- **settings.json**: 新hookをSessionStartに登録

## 背景

mainに直接pushされた8コミットが発見され、develop↔mainが乖離。
今後の再発防止として、ブランチワークフローを自動強制するhookを追加。

Closes #66 (部分: pr-guard.sh >/dev/null修正)

## Test plan

- [x] `bash -n` シンタックスチェック全パス
- [x] settings.json valid JSON
- [ ] developが存在しないリポジトリでSessionStart → develop自動作成
- [ ] feature branchから `--base main` → ブロック
- [ ] develop branchから `--base main` → リリースPR許可

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * セッション開始時にブランチワークフローを確認・管理する新しいフックを追加しました（develop の自動作成とフィーチャーブランチ運用を支援）。

* **改善**
  * プルリクエスト保護ロジックを改善し、特定の --base/--head シナリオや origin/develop の存在判定をより寛容かつ正確に扱うよう最適化しました。
  * セッション開始フック列に新フックを追加（タイムアウトとステータスメッセージ付き）。

* **ドキュメント**
  * README 等の記載を更新し、利用可能なフックスクリプト数を「41」に修正しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->