### PR TITLE
feat: PR作成後レビュー自動強制 + Codex MCP使用禁止hook (Closes #72)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 [Claude Code](https://claude.com/claude-code)（Anthropic 公式 CLI）のためのスキル・ルール・フック集です。
 
-27 のカスタムスキル、44 の hook スクリプト、5 つのルールセットを含む、本番環境レベルの Claude Code 設定を提供します。
+27 のカスタムスキル、52 の hook スクリプト、5 つのルールセットを含む、本番環境レベルの Claude Code 設定を提供します。
 
 [English](README.md) | **日本語**
 
@@ -23,7 +23,7 @@ chmod +x setup.sh
 claude-code-skills/
 ├── skills/           # 27 カスタムスキル定義 (SKILL.md + scripts + references)
 ├── rules/            # 5 グローバルルール (コーディング規約, Git, 品質, テスト, 委任)
-├── hooks/            # 44 hook スクリプト (品質ゲート, 安全ガード, ワークフロー強制)
+├── hooks/            # 52 hook スクリプト (品質ゲート, 安全ガード, ワークフロー強制)
 ├── scripts/          # 5 ユーティリティ (Codex 連携, PR レビュー, コンテキスト監視)
 ├── setup.sh          # ワンコマンドインストール
 ├── settings.json     # 設定テンプレート (パス等サニタイズ済み)
@@ -47,7 +47,7 @@ Think → Plan (gstack)
   /office-hours → /plan-ceo-review → /plan-eng-review → /plan-design-review
 
 Build → Review → Ship (カスタムスキル + hooks)
-  code-reviewer, review-loop, e2e, bugfix + 44 hook スクリプト
+  code-reviewer, review-loop, e2e, bugfix + 52 hook スクリプト
 
 Reflect (gstack)
   /retro
@@ -232,13 +232,21 @@ PR に GitHub レビューがない場合（ソロ開発など）、**ローカ�
 | **マージ後** | `post-merge-close-issues.sh` | リンクされた Issue を自動クローズ |
 | **セッション終了** | `pr-ci-review-gate.sh` (STOP) | 未検証 PR について警告 |
 
-## Hook システム（44 スクリプト）
+## Hook システム（52 スクリプト）
+
+### セッション初期化
+- `auto-init-permissions.sh` — セッション開始時にパーミッションを自動初期化
+- `context-budget-reset.sh` — セッション開始時にカウンターリセット（`fg_impl_agent_count` 含む）
+- `reset-factcheck.sh` — セッション開始時にファクトチェック状態をリセット
+- `enforce-branch-workflow.sh` — develop ブランチ自動作成、フィーチャーブランチワークフロー強制
+- `validate-no-local-hooks.sh` — セッション開始時に hook 上書きが存在しないことを検証
 
 ### 品質ゲート（マージ前）
 - `block-merge-without-ci.sh` — CI 全チェックグリーンなしでマージをブロック
 - `block-merge-without-review.sh` — 最新 push 後のレビューなしでマージをブロック
 - `pr-ci-review-gate.sh` — 6 モードゲート (PRE_CREATE / PRE_MERGE / POST_PUSH / STOP / VERIFY / CLEANUP) Tier 制レビュー対応
 - `pr-merge-claude-review-gate.sh` — 5 サブゲート Claude レビュー強制
+- `inject-claude-review-on-checks.sh` — `gh pr checks` / `gh pr merge` 時にレビューコメントを自動取得
 - `pr-guard.sh` — ベースブランチ、Issue 参照、コンフリクトチェック
 - `task-completion-gate.sh` — 早期タスク完了をブロック（CI pending または CRITICAL/HIGH 指摘あり）
 - `stop-test-gate.sh` — セッション終了前にプロジェクトテスト実行（Stop hook、stop_hook_active ガード付き）
@@ -251,15 +259,17 @@ PR に GitHub レビューがない場合（ソロ開発など）、**ローカ�
 - `block-version-downgrade.sh` — 依存パッケージのダウングレード防止
 - `audit-docker-build-args.sh` — Docker build args の http:// チェック
 - `block-local-hooks-write.sh` — settings.local.json によるグローバル hook 上書きを防止
-- `validate-no-local-hooks.sh` — セッション開始時に hook 上書きが存在しないことを検証
-- `enforce-branch-workflow.sh` — Auto-create develop branch, enforce feature branch workflow
+- `block-codex-mcp.sh` — Codex MCP 使用をブロック、CLI 経由のみ強制 (PreToolUse)
+- `block-state-file-tampering.sh` — AI による状態ファイル自己改ざん防止 (Write/Edit)
+- `block-state-file-tampering-bash.sh` — AI による状態ファイル自己改ざん防止 (Bash)
+- `protect-linter-config.sh` — リンター設定の不正変更を防止
 
 ### コンテキスト予算管理
 - `context-budget-read-gate.sh` — 3+ ソースファイル読み込みで警告/ブロック
 - `context-budget-write-gate.sh` — テスト/ドキュメント作成を検出し Codex 委任提案
 - `context-budget-edit-write-gate.sh` — 多数ファイル読み込み後の編集をブロック
-- `context-budget-agent-gate.sh` — foreground実装Agentの制限（2つ目ブロック）、background/TeamCreate強制
-- `context-budget-reset.sh` — セッション開始時にカウンターリセット（`fg_impl_agent_count` 含む）
+- `context-budget-agent-gate.sh` — foreground 実装 Agent の制限（2つ目ブロック）、background/TeamCreate 強制
+- `codex-task-gate.sh` — 2回目以降の Codex CLI 呼び出しをブロック（同時1タスク制限）
 - `codex-task-release.sh` — Codex タスク完了後にカウンター解放（PostToolUse）
 
 ### ワークフロー強制
@@ -282,7 +292,10 @@ PR に GitHub レビューがない場合（ソロ開発など）、**ローカ�
 - `track-agent-team.sh` — エージェントチームの生成と完了を追跡
 - `post-merge-close-issues.sh` — マージ後にリンクされた Issue を自動クローズ
 - `post-deploy-verify.sh` — デプロイ後の検証チェック
+- `post-lint-format.sh` — ファイル編集後に lint/format チェック実行（PostToolUse Quality Loop）
+- `post-pr-create-review-trigger.sh` — PR 作成後にコードレビューを自動トリガー (PostToolUse)
 - `workflow-sync-guard.sh` — push 後のワークフロー状態同期
+- `verify-test-falsifiability.sh` — テストが宣言されたバグを実際に検出するか検証 (PostToolUse)
 - `tool-failure-recovery.sh` — ツール失敗時のエラー回復ガイダンス（PostToolUseFailure）
 
 ## Hook Matcher 構文

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A curated collection of skills, rules, and hooks for [Claude Code](https://claude.com/claude-code) — Anthropic's official CLI for Claude.
 
-This repository provides a production-ready Claude Code configuration with 27 custom skills, 44 hook scripts, 5 rule sets, and integration with third-party skill frameworks.
+This repository provides a production-ready Claude Code configuration with 27 custom skills, 52 hook scripts, 5 rule sets, and integration with third-party skill frameworks.
 
 ## Quick Start
 
@@ -23,7 +23,7 @@ Restart Claude Code after installation.
 claude-code-skills/
 ├── skills/           # 27 custom skill definitions (SKILL.md + scripts + references)
 ├── rules/            # 5 global rule files (coding-style, git-workflow, quality, testing, delegation)
-├── hooks/            # 44 hook scripts (quality gates, safety guards, workflow enforcement)
+├── hooks/            # 52 hook scripts (quality gates, safety guards, workflow enforcement)
 ├── scripts/          # 5 utility scripts (Codex orchestration, PR review, context monitoring)
 ├── setup.sh          # One-command installation
 ├── settings.json     # Template settings (sanitized, no personal paths)
@@ -32,24 +32,24 @@ claude-code-skills/
 
 ## Architecture Decision Records (ADR)
 
-設計判断はADRとして `docs/adr/` に記録されています。
+Design decisions are recorded as ADRs in `docs/adr/`.
 
-| ADR | タイトル | ステータス |
-|-----|---------|-----------|
+| ADR | Title | Status |
+|-----|-------|--------|
 | [001](docs/adr/001-posttooluse-quality-loop.md) | PostToolUse Quality Loop | Accepted |
-| [002](docs/adr/002-pointer-design-principle.md) | CLAUDE.md ポインタ型設計原則 | Accepted |
-| [003](docs/adr/003-feedback-speed-hierarchy.md) | フィードバック速度階層 | Accepted |
-| [004](docs/adr/004-codex-delegation-model.md) | Codex 大規模委任モデル | Accepted |
+| [002](docs/adr/002-pointer-design-principle.md) | CLAUDE.md Pointer Design Principle | Accepted |
+| [003](docs/adr/003-feedback-speed-hierarchy.md) | Feedback Speed Hierarchy | Accepted |
+| [004](docs/adr/004-codex-delegation-model.md) | Codex Large-Scale Delegation Model | Accepted |
 
-新しいADRを追加する場合は [テンプレート](docs/adr/template.md) を使用してください。
+To add a new ADR, use the [template](docs/adr/template.md).
 
 ## References
 
-| ドキュメント | 説明 |
-|-------------|------|
-| [Harness Engineering ベストプラクティス 2026](docs/references/harness-engineering-best-practices-2026.md) | 本リポジトリの設計方針の根拠となる記事のサマリ |
+| Document | Description |
+|----------|-------------|
+| [Harness Engineering Best Practices 2026](docs/references/harness-engineering-best-practices-2026.md) | Summary of the article that underpins this repository's design philosophy |
 
-詳細は [docs/references/](docs/references/) を参照してください。
+See [docs/references/](docs/references/) for details.
 
 ## Third-Party Dependencies
 
@@ -67,7 +67,7 @@ Think → Plan (gstack)
   /office-hours → /plan-ceo-review → /plan-eng-review → /plan-design-review
 
 Build → Review → Ship (custom skills + hooks)
-  code-reviewer, review-loop, e2e, bugfix + 44 hook scripts
+  code-reviewer, review-loop, e2e, bugfix + 52 hook scripts
 
 Reflect (gstack)
   /retro
@@ -252,13 +252,21 @@ Merged or closed PRs are automatically cleaned from the lock state:
 | **Post Merge** | `post-merge-close-issues.sh` | Auto-close linked issues |
 | **Session Stop** | `pr-ci-review-gate.sh` (STOP) | Warn about unverified PRs |
 
-## Hook System (44 Scripts)
+## Hook System (52 Scripts)
+
+### Session Initialization
+- `auto-init-permissions.sh` — Auto-initialize permissions on session start
+- `context-budget-reset.sh` — Reset all counters on session start (incl. `fg_impl_agent_count`)
+- `reset-factcheck.sh` — Reset fact-check state on session start
+- `enforce-branch-workflow.sh` — Auto-create develop branch, enforce feature branch workflow
+- `validate-no-local-hooks.sh` — Validate no hook overrides exist on session start
 
 ### Quality Gates (Pre-merge)
 - `block-merge-without-ci.sh` — Block merge unless all CI checks green
 - `block-merge-without-review.sh` — Block merge unless review is newer than latest push
 - `pr-ci-review-gate.sh` — 6-mode gate (PRE_CREATE / PRE_MERGE / POST_PUSH / STOP / VERIFY / CLEANUP) with tiered review
 - `pr-merge-claude-review-gate.sh` — 5-sub-gate Claude review enforcement
+- `inject-claude-review-on-checks.sh` — Auto-fetch review comments on `gh pr checks` / `gh pr merge`
 - `pr-guard.sh` — Base branch, issue ref, conflict checks
 - `task-completion-gate.sh` — Block premature task completion (CI pending or CRITICAL/HIGH findings)
 - `stop-test-gate.sh` — Run project tests before session end (Stop hook with stop_hook_active guard)
@@ -271,15 +279,17 @@ Merged or closed PRs are automatically cleaned from the lock state:
 - `block-version-downgrade.sh` — Prevent dependency downgrades
 - `audit-docker-build-args.sh` — Check for http:// in Docker build args
 - `block-local-hooks-write.sh` — Prevent settings.local.json from overriding global hooks
-- `validate-no-local-hooks.sh` — Validate no hook overrides exist on session start
-- `enforce-branch-workflow.sh` — Auto-create develop branch, enforce feature branch workflow
+- `block-codex-mcp.sh` — Block Codex MCP usage, enforce CLI-only (PreToolUse)
+- `block-state-file-tampering.sh` — Prevent AI self-bypass of state files (Write/Edit)
+- `block-state-file-tampering-bash.sh` — Prevent AI self-bypass of state files (Bash)
+- `protect-linter-config.sh` — Prevent unauthorized linter config modifications
 
 ### Context Budget Management
 - `context-budget-read-gate.sh` — Warn/block after 3+ source file reads
 - `context-budget-write-gate.sh` — Detect test/doc creation for Codex delegation
 - `context-budget-edit-write-gate.sh` — Block edits when too many files read
 - `context-budget-agent-gate.sh` — Enforce foreground impl agent limits (Rule 2+4), background/TeamCreate governance
-- `context-budget-reset.sh` — Reset all counters on session start (incl. `fg_impl_agent_count`)
+- `codex-task-gate.sh` — Block 2nd+ Codex CLI call (1 concurrent limit)
 - `codex-task-release.sh` — Release Codex call counter after task completion (PostToolUse)
 
 ### Workflow Enforcement
@@ -302,7 +312,10 @@ Merged or closed PRs are automatically cleaned from the lock state:
 - `track-agent-team.sh` — Track agent team spawning and completion
 - `post-merge-close-issues.sh` — Auto-close linked issues after merge
 - `post-deploy-verify.sh` — Post-deployment verification checks
+- `post-lint-format.sh` — Run lint and format checks after file edits (PostToolUse Quality Loop)
+- `post-pr-create-review-trigger.sh` — Auto-trigger code review after PR creation (PostToolUse)
 - `workflow-sync-guard.sh` — Sync workflow state after push
+- `verify-test-falsifiability.sh` — Verify tests actually detect declared bugs (PostToolUse)
 - `tool-failure-recovery.sh` — Error recovery guidance on tool failure (PostToolUseFailure)
 
 ## Hook Matcher Syntax

--- a/hooks/block-codex-mcp.sh
+++ b/hooks/block-codex-mcp.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# block-codex-mcp.sh — PreToolUse hook (matcher: mcp__codex__.*)
+# =========================================================================
+# Issue #72: Enforce Codex CLI-only usage (block MCP)
+#
+# Ref: delegation.md — "Codex MCP使用禁止 — CLI経由のみ（Ref: Issue #11）"
+# Ref: https://code.claude.com/docs/en/hooks
+#   Event: PreToolUse (matcher supports regex on tool name)
+#   Exit 2 = block the tool call
+#
+# Why: Codex MCP has limitations vs CLI:
+#   - No sandbox isolation
+#   - No worktree support
+#   - No task file input
+#   - Inconsistent behavior reported (Issue #11)
+# =========================================================================
+
+set -euo pipefail
+
+echo "" >&2
+echo "[BLOCKED] Codex MCP (mcp__codex__*) の使用は禁止されています。" >&2
+echo "" >&2
+echo "理由: delegation.md — 'Codex MCP使用禁止 — CLI経由のみ (Ref: Issue #11)'" >&2
+echo "" >&2
+echo "代替方法 (Codex CLI):" >&2
+echo "  レビュー:  bash codex exec review --base develop" >&2
+echo "  実装委任:  bash ~/.claude/scripts/codex-parallel.sh <repo> <branch> '<prompt>'" >&2
+echo "  対話:      bash codex chat '<question>'" >&2
+echo "" >&2
+exit 2

--- a/hooks/block-codex-mcp.sh
+++ b/hooks/block-codex-mcp.sh
@@ -23,8 +23,8 @@ echo "" >&2
 echo "理由: delegation.md — 'Codex MCP使用禁止 — CLI経由のみ (Ref: Issue #11)'" >&2
 echo "" >&2
 echo "代替方法 (Codex CLI):" >&2
-echo "  レビュー:  bash codex exec review --base develop" >&2
+echo "  レビュー:  codex exec review --base develop" >&2
 echo "  実装委任:  bash ~/.claude/scripts/codex-parallel.sh <repo> <branch> '<prompt>'" >&2
-echo "  対話:      bash codex chat '<question>'" >&2
+echo "  対話:      codex exec '<question>'" >&2
 echo "" >&2
 exit 2

--- a/hooks/post-pr-create-review-trigger.sh
+++ b/hooks/post-pr-create-review-trigger.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# post-pr-create-review-trigger.sh — PostToolUse hook (Bash)
+# =========================================================================
+# Issue #72: Auto-trigger review after PR creation
+#
+# Ref: https://code.claude.com/docs/en/hooks
+#   Event: PostToolUse (matcher: Bash)
+#   stdin: { tool_name, tool_input, tool_response, tool_use_id }
+#   Exit 0 + JSON = additionalContext injected
+#   Cannot block (tool already executed)
+#
+# Logic:
+#   1. Detect gh pr create in tool_input.command
+#   2. Extract PR URL/number from tool_response
+#   3. Set review_pending in state file
+#   4. Inject review instructions via additionalContext
+# =========================================================================
+
+set -euo pipefail
+export GH_FORCE_TTY=0
+export GH_NO_UPDATE_NOTIFIER=1
+
+# Subagent exemption — subagents creating PRs is blocked by other hooks
+[[ "${CLAUDE_AGENT_DEPTH:-0}" -ge 1 ]] && exit 0
+
+input=""
+[[ ! -t 0 ]] && input=$(cat 2>/dev/null || echo "")
+[[ -z "$input" ]] && exit 0
+command -v jq &>/dev/null || exit 0
+
+# Check if this was a gh pr create command
+cmd=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+if ! echo "$(echo "$cmd" | head -1)" | grep -qE 'gh\s+pr\s+create'; then
+  exit 0
+fi
+
+# Extract PR number from tool_response (gh pr create outputs the PR URL)
+tool_response=$(echo "$input" | jq -r '.tool_response // ""' 2>/dev/null || echo "")
+PR_NUMBER=""
+if [[ -n "$tool_response" ]]; then
+  # gh pr create outputs URL like https://github.com/owner/repo/pull/123
+  PR_NUMBER=$(echo "$tool_response" | grep -oE '/pull/[0-9]+' | grep -oE '[0-9]+' | head -1)
+fi
+
+# If we can't find PR number from response, try from current branch
+if [[ -z "$PR_NUMBER" ]]; then
+  BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+  if [[ -n "$BRANCH" ]]; then
+    PR_NUMBER=$(gh pr list --head "$BRANCH" --state open --json number -q '.[0].number' 2>/dev/null || echo "")
+  fi
+fi
+
+[[ -z "$PR_NUMBER" ]] && exit 0
+
+# Set review_pending in state file
+if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+  STATE_DIR="${CLAUDE_PROJECT_DIR}/.claude/state"
+elif git rev-parse --show-toplevel &>/dev/null; then
+  STATE_DIR="$(git rev-parse --show-toplevel)/.claude/state"
+else
+  STATE_DIR="$HOME/.claude/state"
+fi
+mkdir -p "$STATE_DIR"
+
+BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+
+# Write review-pending state
+LOCK_STATE="$STATE_DIR/pr-review-lock.json"
+[[ ! -f "$LOCK_STATE" ]] && echo '{}' > "$LOCK_STATE"
+
+if command -v python3 &>/dev/null; then
+  _PR="$PR_NUMBER" _BRANCH="$BRANCH" _LOCK="$LOCK_STATE" python3 -c "
+import json, os
+lock_file = os.environ['_LOCK']
+with open(lock_file) as f: s = json.load(f)
+s[os.environ['_PR']] = {
+  'status': 'review_pending',
+  'branch': os.environ['_BRANCH'],
+  'ci_green': False,
+  'review_lgtm': False,
+  'verified': False
+}
+with open(lock_file, 'w') as f: json.dump(s, f, indent=2)
+" 2>/dev/null
+fi
+
+# Inject review instructions via additionalContext
+REVIEW_MSG="[AUTO-REVIEW REQUIRED] PR #${PR_NUMBER} を作成しました。マージ前に以下を実行してください:
+
+1. code-reviewer エージェントでレビュー:
+   Agent(subagent_type='code-reviewer', prompt='Review PR #${PR_NUMBER} on branch ${BRANCH}')
+
+2. Codex CLI セカンドオピニオン:
+   bash codex exec review --base develop
+
+3. 全CRITICAL/HIGH指摘を修正
+
+4. レビュー完了後にマージ:
+   gh pr merge ${PR_NUMBER} --merge
+
+レビューなしでのタスク完了・セッション終了はブロックされます。"
+
+if command -v jq &>/dev/null; then
+  jq -n --arg ctx "$REVIEW_MSG" '{
+    hookSpecificOutput: {
+      hookEventName: "PostToolUse",
+      additionalContext: $ctx
+    }
+  }'
+fi
+
+echo "[post-pr-create] PR #${PR_NUMBER} 作成検出。レビュー必須。" >&2
+exit 0

--- a/hooks/post-pr-create-review-trigger.sh
+++ b/hooks/post-pr-create-review-trigger.sh
@@ -101,7 +101,7 @@ REVIEW_MSG="[AUTO-REVIEW REQUIRED] PR #${PR_NUMBER} を作成しました。マ�
    Agent(subagent_type='code-reviewer', prompt='Review PR #${PR_NUMBER} on branch ${BRANCH}')
 
 2. Codex CLI セカンドオピニオン:
-   bash codex exec review --base develop
+   codex exec review --base develop
 
 3. 全CRITICAL/HIGH指摘を修正
 

--- a/hooks/post-pr-create-review-trigger.sh
+++ b/hooks/post-pr-create-review-trigger.sh
@@ -46,11 +46,16 @@ fi
 if [[ -z "$PR_NUMBER" ]]; then
   BRANCH=$(git branch --show-current 2>/dev/null || echo "")
   if [[ -n "$BRANCH" ]]; then
-    PR_NUMBER=$(gh pr list --head "$BRANCH" --state open --json number -q '.[0].number' 2>/dev/null || echo "")
+    PR_NUMBER=$(gh pr list --head "$BRANCH" --state open --json number -q '.[0].number // empty' 2>/dev/null || echo "")
   fi
 fi
 
 [[ -z "$PR_NUMBER" ]] && exit 0
+
+# Validate PR number is numeric
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  exit 0
+fi
 
 # Set review_pending in state file
 if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
@@ -70,17 +75,22 @@ LOCK_STATE="$STATE_DIR/pr-review-lock.json"
 
 if command -v python3 &>/dev/null; then
   _PR="$PR_NUMBER" _BRANCH="$BRANCH" _LOCK="$LOCK_STATE" python3 -c "
-import json, os
+import json, os, fcntl
 lock_file = os.environ['_LOCK']
-with open(lock_file) as f: s = json.load(f)
-s[os.environ['_PR']] = {
-  'status': 'review_pending',
-  'branch': os.environ['_BRANCH'],
-  'ci_green': False,
-  'review_lgtm': False,
-  'verified': False
-}
-with open(lock_file, 'w') as f: json.dump(s, f, indent=2)
+with open(lock_file, 'r+') as f:
+    fcntl.flock(f, fcntl.LOCK_EX)
+    s = json.load(f)
+    s[os.environ['_PR']] = {
+        'status': 'review_pending',
+        'branch': os.environ['_BRANCH'],
+        'ci_green': False,
+        'review_lgtm': False,
+        'verified': False
+    }
+    f.seek(0)
+    f.truncate()
+    json.dump(s, f, indent=2)
+    fcntl.flock(f, fcntl.LOCK_UN)
 " 2>/dev/null
 fi
 

--- a/settings.json
+++ b/settings.json
@@ -360,6 +360,17 @@
             "statusMessage": "Checking settings.local.json for hooks override..."
           }
         ]
+      },
+      {
+        "matcher": "mcp__codex__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/block-codex-mcp.sh",
+            "timeout": 5,
+            "statusMessage": "Checking Codex usage policy..."
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -502,6 +513,17 @@
             "command": "bash ~/.claude/hooks/post-lint-format.sh",
             "timeout": 5,
             "statusMessage": "Running PostToolUse Quality Loop (lint + format)..."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ~/.claude/hooks/post-pr-create-review-trigger.sh",
+            "timeout": 15,
+            "statusMessage": "Checking if PR was created..."
           }
         ]
       }


### PR DESCRIPTION
## Summary

Closes #72

PR作成だけで作業終了してしまう問題とCodex MCP使用禁止ルール違反を構造的に防止。

- **post-pr-create-review-trigger.sh**: PR作成検出→review_pending設定→レビュー指示注入
- **block-codex-mcp.sh**: mcp__codex__* をexit 2でブロック、CLI代替を提示

## Test plan

- [x] bash -n シンタックスチェック全パス
- [x] settings.json valid JSON
- [ ] gh pr create 実行後にadditionalContextが注入される
- [ ] mcp__codex__codex 使用時にブロックされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Codex MCP利用のブロック、安全ガード、PR作成後の自動レビュートリガーなどの新しいフック機能を追加しました。
  * PR作成→レビュー、編集後のリント/フォーマット実行、テスト検証などのワークフロー強化を導入しました。

* **ドキュメント**
  * フックシステム説明を再構成し、フックスクリプト総数を44→52に更新しました。セッション初期化や品質ゲート、コンテキスト管理に関する記載を拡充しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->