### PR TITLE
fix: 全hookのstderr出力統一 (Closes #74)

### DIFF
--- a/hooks/block-version-downgrade.sh
+++ b/hooks/block-version-downgrade.sh
@@ -104,8 +104,8 @@ if printf '%s' "$old_string" | grep -qE ':latest' && printf '%s' "$new_string" |
 fi
 
 if [ -n "$DOWNGRADE_FOUND" ]; then
-    cat <<BLOCK_MSG
-🚫 Version DOWNGRADE detected and blocked.
+    cat >&2 <<BLOCK_MSG
+[BLOCKED] block-version-downgrade: Version DOWNGRADE detected.
 
 File: $file_path
 Downgrade: $DOWNGRADE_FOUND
@@ -115,17 +115,14 @@ Version downgrades are prohibited. If this is intentional:
 2. Confirm the downgraded version supports ALL features required by related ADRs
 3. Get explicit user approval before proceeding
 
-Related ADRs to check:
-- ADR-0011: Qwen3.5 + GLM-4.7-Flash hybrid model requirements
-- ADR-0014: llm-gateway streaming + classification requirements
-- ADR-0006: Deployment topology constraints
+解決方法: ADR-0011/0014/0006 を確認し、互換性を検証してからユーザー承認を得てください。
 BLOCK_MSG
     exit 2
 fi
 
 if [ -n "$LATEST_PIN" ]; then
-    cat <<BLOCK_MSG
-⚠️ :latest → specific version pin detected.
+    cat >&2 <<BLOCK_MSG
+[BLOCKED] block-version-downgrade: :latest → specific version pin detected.
 
 File: $file_path
 
@@ -134,7 +131,7 @@ Before pinning from :latest, verify:
 2. Check the software's supported models/features changelog
 3. State which ADR you verified and confirm compatibility
 
-Pinning to a version that lacks required features is equivalent to a downgrade.
+解決方法: 関連ADRの互換性要件を確認し、pinned versionが全要件を満たすことを検証してください。
 BLOCK_MSG
     exit 2
 fi

--- a/hooks/enforce-factcheck-before-edit.sh
+++ b/hooks/enforce-factcheck-before-edit.sh
@@ -66,21 +66,23 @@ fi
 if [ "$factchecked" = "false" ] || [ "$expired" = "true" ]; then
     # インフラ/設定ファイルの場合は完全ブロック
     if echo "$file_path" | grep -qE '\.(yml|yaml)$|Dockerfile|vercel\.json|\.env|Makefile|docker-compose|cloudbuild|terraform'; then
-        echo "🚫 [BLOCK] インフラ/設定ファイルの修正前にファクトチェックが必要です。"
-        echo "  対象ファイル: $file_path"
-        echo "  必須: context7 (resolve-library-id → query-docs) または WebSearch で公式ドキュメントを確認してから修正してください。"
-        echo ""
-        echo "  例: Vercel設定 → context7でVercel docs確認"
-        echo "  例: GitHub Actions → context7でGitHub Actions docs確認"
-        echo "  例: Cloud Run → WebSearchでCloud Run最新ドキュメント確認"
+        echo "[BLOCKED] enforce-factcheck-before-edit: インフラ/設定ファイルの修正前にファクトチェックが必要です。" >&2
+        echo "  対象ファイル: $file_path" >&2
+        echo "  必須: context7 (resolve-library-id → query-docs) または WebSearch で公式ドキュメントを確認してから修正してください。" >&2
+        echo "" >&2
+        echo "  例: Vercel設定 → context7でVercel docs確認" >&2
+        echo "  例: GitHub Actions → context7でGitHub Actions docs確認" >&2
+        echo "  例: Cloud Run → WebSearchでCloud Run最新ドキュメント確認" >&2
+        echo "解決方法: context7/WebSearch/WebFetchで公式ドキュメントを確認してから再度実行してください。" >&2
         exit 2
     fi
 
     # ソースコードの場合は警告（初回は通す、2回目以降はブロック）
     if [ "$edit_count" -ge 2 ] && [ "$factchecked" = "false" ]; then
-        echo "🚫 [BLOCK] 複数ファイルの修正前にファクトチェックが必要です。"
-        echo "  context7、WebSearch、または関連ドキュメントのReadを実行してから修正してください。"
-        echo "  ファクトチェック済みの場合: context7/WebSearch/WebFetch を1回使うとフラグが立ちます。"
+        echo "[BLOCKED] enforce-factcheck-before-edit: 複数ファイルの修正前にファクトチェックが必要です。" >&2
+        echo "  context7、WebSearch、または関連ドキュメントのReadを実行してから修正してください。" >&2
+        echo "  ファクトチェック済みの場合: context7/WebSearch/WebFetch を1回使うとフラグが立ちます。" >&2
+        echo "解決方法: context7/WebSearch/WebFetchのいずれかを1回使用してからファイル修正を実行してください。" >&2
         exit 2
     fi
 

--- a/hooks/enforce-factcheck-before-user-request.sh
+++ b/hooks/enforce-factcheck-before-user-request.sh
@@ -25,12 +25,12 @@ if echo "$question" | grep -qi "設定.*してください\|変更.*してくだ
 fi
 
 if [ ${#BLOCKERS[@]} -gt 0 ]; then
-    echo "🚫 ファクトチェック未完了の手動操作依頼を検出:"
+    echo "[BLOCKED] enforce-factcheck-before-user-request: ファクトチェック未完了の手動操作依頼を検出:" >&2
     for b in "${BLOCKERS[@]}"; do
-        echo "  $b"
+        echo "  $b" >&2
     done
-    echo ""
-    echo "対応: WebSearch/公式ドキュメントで事実確認 → 自動化検討 → 自動化不可能な場合のみ依頼"
+    echo "" >&2
+    echo "解決方法: WebSearch/公式ドキュメントで事実確認 → 自動化検討 → 自動化不可能な場合のみ依頼" >&2
     exit 2
 fi
 


### PR DESCRIPTION
## Summary
- 全hookスクリプトでexit 2前のstderr出力が欠落していた3ファイルを修正
- `[BLOCKED] hook名: 理由` + `解決方法:` のフォーマットに統一
- block-version-downgrade.sh: `cat >&2 <<BLOCK_MSG` に修正
- enforce-factcheck-before-edit.sh: echo に `>&2` 追加
- enforce-factcheck-before-user-request.sh: echo に `>&2` 追加

## Test plan
- [x] `bash -n` で全修正ファイルの構文検証パス
- [x] code-reviewer エージェントによるレビュー: APPROVE
- [ ] CI green 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

**Bug Fixes**
* エラーメッセージの出力形式を標準化し、エラー通知の処理を改善しました。
* エラー出力ストリームの適切な処理により、ブロック通知がより明確に表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->