### PR TITLE
refactor: state file操作のatomic化 — flock統一 (Closes #76)

### DIFF
--- a/hooks/codex-task-gate.sh
+++ b/hooks/codex-task-gate.sh
@@ -7,6 +7,66 @@ set -euo pipefail
 
 input=$(cat)
 
+ensure_json_file() {
+    local state_file="$1"
+    [[ -f "$state_file" ]] || echo '{}' > "$state_file"
+}
+
+reserve_codex_call() {
+    local budget_file="$1"
+    ensure_json_file "$budget_file"
+
+    _BUDGET_FILE="$budget_file" python3 -c '
+import json, os, fcntl, sys
+f_path = os.environ["_BUDGET_FILE"]
+with open(f_path, "r+") as f:
+    fcntl.flock(f, fcntl.LOCK_EX)
+    try:
+        s = json.load(f)
+    except json.JSONDecodeError:
+        s = {}
+    try:
+        count = int(s.get("codex_call_count", 0))
+        if count >= 1:
+            print(count)
+            sys.exit(1)
+        s["codex_call_count"] = count + 1
+        f.seek(0)
+        f.truncate()
+        json.dump(s, f, indent=2)
+        print(count + 1)
+    finally:
+        fcntl.flock(f, fcntl.LOCK_UN)
+' 2>/dev/null
+}
+
+increment_json_counter() {
+    local state_file="$1"
+    local counter_key="$2"
+    ensure_json_file "$state_file"
+
+    _STATE_FILE="$state_file" _COUNTER_KEY="$counter_key" python3 -c '
+import json, os, fcntl
+f_path = os.environ["_STATE_FILE"]
+counter_key = os.environ["_COUNTER_KEY"]
+with open(f_path, "r+") as f:
+    fcntl.flock(f, fcntl.LOCK_EX)
+    try:
+        s = json.load(f)
+    except json.JSONDecodeError:
+        s = {}
+    try:
+        new_count = int(s.get(counter_key, 0)) + 1
+        s[counter_key] = new_count
+        f.seek(0)
+        f.truncate()
+        json.dump(s, f, indent=2)
+        print(new_count)
+    finally:
+        fcntl.flock(f, fcntl.LOCK_UN)
+' 2>/dev/null
+}
+
 # --- Rule: Codex batch enforcement (for Bash tool) ---
 # Detect codex-parallel.sh / codex exec calls and block 2nd+ call
 tool_name=$(echo "$input" | jq -r '.tool_name // ""' 2>/dev/null || echo "")
@@ -25,31 +85,15 @@ fi
 
 if [[ "$tool_name" == "Bash" ]] && [[ "$is_codex_exec" == "true" ]]; then
     BUDGET_FILE="${HOME}/.claude/state/context-budget.json"
-    if [[ -f "$BUDGET_FILE" ]]; then
-        codex_count=$(_BUDGET_FILE="$BUDGET_FILE" python3 -c "
-import json, os
-with open(os.environ['_BUDGET_FILE']) as f:
-    print(json.load(f).get('codex_call_count', 0))
-" 2>/dev/null || echo "0")
-        if [[ "$codex_count" -ge 1 ]]; then
-            echo "🚫 [Codex Batch Required] 2回目のCodex呼び出しをブロック。" >&2
-            echo "" >&2
-            echo "ルール: Codexには1つの統合タスクとして委任してください。" >&2
-            echo "  → 複数小分けではなく、1プロンプトにまとめる" >&2
-            echo "  → Codex内部サブエージェントが分割を担当" >&2
-            echo "  → codex-orchestrate.sh + tasks.json で一括委任" >&2
-            exit 2
-        fi
-        # Increment codex call count
-        _BUDGET_FILE="$BUDGET_FILE" python3 -c "
-import json, os
-f = os.environ['_BUDGET_FILE']
-with open(f) as fh:
-    s = json.load(fh)
-s['codex_call_count'] = s.get('codex_call_count', 0) + 1
-with open(f, 'w') as fh:
-    json.dump(s, fh, indent=2)
-" 2>/dev/null
+    mkdir -p "$(dirname "$BUDGET_FILE")"
+    if ! reserve_codex_call "$BUDGET_FILE" >/dev/null; then
+        echo "🚫 [Codex Batch Required] 2回目のCodex呼び出しをブロック。" >&2
+        echo "" >&2
+        echo "ルール: Codexには1つの統合タスクとして委任してください。" >&2
+        echo "  → 複数小分けではなく、1プロンプトにまとめる" >&2
+        echo "  → Codex内部サブエージェントが分割を担当" >&2
+        echo "  → codex-orchestrate.sh + tasks.json で一括委任" >&2
+        exit 2
     fi
     exit 0
 fi
@@ -66,7 +110,7 @@ fi
 # State file for tracking
 STATE_FILE="${HOME}/.claude/state/codex-task-gate.json"
 mkdir -p "$(dirname "$STATE_FILE")"
-[ ! -f "$STATE_FILE" ] && echo '{"test_files_created":0,"doc_files_created":0}' > "$STATE_FILE"
+ensure_json_file "$STATE_FILE"
 
 # Detect test file creation
 is_test=false
@@ -81,9 +125,7 @@ if echo "$file_path" | grep -qE '\.(md|rst|txt)$' && echo "$file_path" | grep -q
 fi
 
 if [ "$is_test" = true ]; then
-    count=$(jq -r '.test_files_created // 0' "$STATE_FILE")
-    new_count=$((count + 1))
-    jq --argjson c "$new_count" '.test_files_created = $c' "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+    new_count=$(increment_json_counter "$STATE_FILE" "test_files_created")
 
     if [ "$new_count" -ge 3 ]; then
         echo "" >&2
@@ -102,9 +144,7 @@ if [ "$is_test" = true ]; then
 fi
 
 if [ "$is_doc" = true ]; then
-    count=$(jq -r '.doc_files_created // 0' "$STATE_FILE")
-    new_count=$((count + 1))
-    jq --argjson c "$new_count" '.doc_files_created = $c' "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+    new_count=$(increment_json_counter "$STATE_FILE" "doc_files_created")
 
     if [ "$new_count" -ge 2 ]; then
         echo "" >&2

--- a/hooks/codex-task-release.sh
+++ b/hooks/codex-task-release.sh
@@ -40,17 +40,25 @@ fi
 
 # Decrement codex_call_count (release the lock)
 BUDGET_FILE="${HOME}/.claude/state/context-budget.json"
+if [[ ! -f "$BUDGET_FILE" ]]; then
+    mkdir -p "$(dirname "$BUDGET_FILE")"
+    echo '{}' > "$BUDGET_FILE"
+fi
+
 if [[ -f "$BUDGET_FILE" ]]; then
     _BUDGET_FILE="$BUDGET_FILE" python3 -c "
-import json, os
-f = os.environ['_BUDGET_FILE']
-with open(f) as fh:
-    s = json.load(fh)
-count = s.get('codex_call_count', 0)
-if count > 0:
-    s['codex_call_count'] = count - 1
-with open(f, 'w') as fh:
-    json.dump(s, fh, indent=2)
+import fcntl, json, os
+f_path = os.environ['_BUDGET_FILE']
+with open(f_path, 'r+') as f:
+    fcntl.flock(f, fcntl.LOCK_EX)
+    s = json.load(f)
+    count = s.get('codex_call_count', 0)
+    if count > 0:
+        s['codex_call_count'] = count - 1
+    f.seek(0)
+    f.truncate()
+    json.dump(s, f, indent=2)
+    fcntl.flock(f, fcntl.LOCK_UN)
 " 2>/dev/null
 fi
 

--- a/hooks/mark-factcheck-done.sh
+++ b/hooks/mark-factcheck-done.sh
@@ -34,9 +34,27 @@ case "$tool" in
 esac
 
 if [ -n "$source_name" ]; then
-    cat > "$STATE_FILE" <<EOJSON
-{"factchecked": true, "source": "$source_name", "timestamp": $now, "edit_count_since_check": 0}
-EOJSON
+    if [[ ! -f "$STATE_FILE" ]]; then
+        echo '{}' > "$STATE_FILE"
+    fi
+    _STATE_FILE="$STATE_FILE" _SOURCE_NAME="$source_name" _NOW="$now" python3 -c "
+import json, os, fcntl
+f_path = os.environ['_STATE_FILE']
+with open(f_path, 'r+') as f:
+    fcntl.flock(f, fcntl.LOCK_EX)
+    try:
+        data = json.load(f)
+    except json.JSONDecodeError:
+        data = {}
+    data['factchecked'] = True
+    data['source'] = os.environ['_SOURCE_NAME']
+    data['timestamp'] = int(os.environ['_NOW'])
+    data['edit_count_since_check'] = 0
+    f.seek(0)
+    f.truncate()
+    json.dump(data, f)
+    fcntl.flock(f, fcntl.LOCK_UN)
+" 2>/dev/null
 fi
 
 exit 0

--- a/hooks/record-code-review.sh
+++ b/hooks/record-code-review.sh
@@ -73,51 +73,57 @@ fi
 
 # Update review-status.json: mark code_review as true for this branch
 NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-if command -v jq &>/dev/null; then
+if command -v python3 &>/dev/null; then
+  # Primary: python3 + fcntl for atomic flock write
+  _STATE="$REVIEW_STATE" _BR="$BRANCH" _NOW="$NOW" python3 -c "
+import json, os, fcntl
+f_path = os.environ['_STATE']
+with open(f_path, 'r+') as f:
+    fcntl.flock(f, fcntl.LOCK_EX)
+    try:
+        s = json.load(f)
+    except json.JSONDecodeError:
+        s = {}
+    s.setdefault(os.environ['_BR'], {})['code_review'] = True
+    s[os.environ['_BR']]['code_review_at'] = os.environ['_NOW']
+    f.seek(0); f.truncate()
+    json.dump(s, f, indent=2)
+    fcntl.flock(f, fcntl.LOCK_UN)
+" 2>/dev/null || true
+elif command -v jq &>/dev/null; then
+  # Fallback: jq (not atomic — no flock)
   tmp=$(mktemp)
   jq --arg b "$BRANCH" --arg t "$NOW" \
     '.[$b] = ((.[$b] // {}) + {"code_review": true, "code_review_at": $t})' \
     "$REVIEW_STATE" > "$tmp" 2>/dev/null && mv "$tmp" "$REVIEW_STATE"
-else
-  # Fallback: python3 (safe: env vars, not string interpolation)
-  _STATE="$REVIEW_STATE" _BR="$BRANCH" _NOW="$NOW" python3 -c "
-import json, os
-f_path = os.environ['_STATE']
-with open(f_path) as f: s = json.load(f)
-s.setdefault(os.environ['_BR'], {})['code_review'] = True
-s[os.environ['_BR']]['code_review_at'] = os.environ['_NOW']
-with open(f_path, 'w') as f: json.dump(s, f, indent=2)
-" 2>/dev/null || true
 fi
 
 # Also write to project-scoped state if it exists (dual-write for CWD consistency)
 if [[ -n "$PROJECT_STATE_DIR" ]] && [[ "$PROJECT_STATE_DIR" != "$GLOBAL_STATE_DIR" ]]; then
   PROJECT_REVIEW="$PROJECT_STATE_DIR/review-status.json"
-  if command -v jq &>/dev/null; then
-    tmp=$(mktemp)
-    if jq --arg b "$BRANCH" --arg t "$NOW" \
-      '.[$b] = ((.[$b] // {}) + {"code_review": true, "code_review_at": $t})' \
-      "$PROJECT_REVIEW" > "$tmp" 2>/dev/null; then
-      mv "$tmp" "$PROJECT_REVIEW"
-    else
-      rm -f "$tmp"
-      # Reset corrupted file and retry once
-      echo '{}' > "$PROJECT_REVIEW"
-      tmp=$(mktemp)
-      jq --arg b "$BRANCH" --arg t "$NOW" \
-        '.[$b] = {"code_review": true, "code_review_at": $t}' \
-        "$PROJECT_REVIEW" > "$tmp" 2>/dev/null && mv "$tmp" "$PROJECT_REVIEW" || rm -f "$tmp"
-    fi
-  else
-    # Fallback: python3 (same as global write path)
+  if command -v python3 &>/dev/null; then
+    # Primary: python3 + fcntl for atomic flock write
     _STATE="$PROJECT_REVIEW" _BR="$BRANCH" _NOW="$NOW" python3 -c "
-import json, os
+import json, os, fcntl
 f_path = os.environ['_STATE']
-with open(f_path) as f: s = json.load(f)
-s.setdefault(os.environ['_BR'], {})['code_review'] = True
-s[os.environ['_BR']]['code_review_at'] = os.environ['_NOW']
-with open(f_path, 'w') as f: json.dump(s, f, indent=2)
+with open(f_path, 'r+') as f:
+    fcntl.flock(f, fcntl.LOCK_EX)
+    try:
+        s = json.load(f)
+    except json.JSONDecodeError:
+        s = {}
+    s.setdefault(os.environ['_BR'], {})['code_review'] = True
+    s[os.environ['_BR']]['code_review_at'] = os.environ['_NOW']
+    f.seek(0); f.truncate()
+    json.dump(s, f, indent=2)
+    fcntl.flock(f, fcntl.LOCK_UN)
 " 2>/dev/null || true
+  elif command -v jq &>/dev/null; then
+    # Fallback: jq (not atomic — no flock)
+    tmp=$(mktemp)
+    jq --arg b "$BRANCH" --arg t "$NOW" \
+      '.[$b] = ((.[$b] // {}) + {"code_review": true, "code_review_at": $t})' \
+      "$PROJECT_REVIEW" > "$tmp" 2>/dev/null && mv "$tmp" "$PROJECT_REVIEW"
   fi
 fi
 

--- a/hooks/track-agent-team.sh
+++ b/hooks/track-agent-team.sh
@@ -20,34 +20,43 @@ mkdir -p "$STATE_DIR"
 NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 if [[ ! -f "$SIGNAL_FILE" ]]; then
-  # First agent launch — create signal with count=1
-  cat > "$SIGNAL_FILE" << EOF
-{
-  "tasks": ["agent-1"],
-  "created_at": "$NOW",
-  "last_agent_at": "$NOW",
-  "agent_count": 1
-}
-EOF
-else
-  # Increment agent count and update timestamp
-  _SIGNAL_FILE="$SIGNAL_FILE" _NOW="$NOW" python3 -c "
-import json, os, sys
-
-with open(os.environ['_SIGNAL_FILE']) as f:
-    data = json.load(f)
-
-count = data.get('agent_count', 0) + 1
-data['agent_count'] = count
-data['last_agent_at'] = os.environ['_NOW']
-data['tasks'].append(f'agent-{count}')
-
-# Keep only last 10 task entries
-data['tasks'] = data['tasks'][-10:]
-
-with open(os.environ['_SIGNAL_FILE'], 'w') as f:
-    json.dump(data, f, indent=2)
-" 2>/dev/null || true
+  echo '{}' > "$SIGNAL_FILE"
 fi
+
+# Create or increment the parallel-team signal atomically.
+_SIGNAL_FILE="$SIGNAL_FILE" _NOW="$NOW" python3 -c "
+import fcntl
+import json
+import os
+
+f_path = os.environ['_SIGNAL_FILE']
+with open(f_path, 'r+') as f:
+    fcntl.flock(f, fcntl.LOCK_EX)
+    try:
+        data = json.load(f)
+    except json.JSONDecodeError:
+        data = {}
+
+    if not isinstance(data, dict):
+        data = {}
+
+    count = data.get('agent_count', 0) + 1
+    tasks = data.get('tasks', [])
+    if not isinstance(tasks, list):
+        tasks = []
+
+    data['agent_count'] = count
+    data['created_at'] = data.get('created_at', os.environ['_NOW'])
+    data['last_agent_at'] = os.environ['_NOW']
+    tasks.append(f'agent-{count}')
+
+    # Keep only last 10 task entries
+    data['tasks'] = tasks[-10:]
+
+    f.seek(0)
+    f.truncate()
+    json.dump(data, f, indent=2)
+    fcntl.flock(f, fcntl.LOCK_UN)
+" 2>/dev/null || true
 
 exit 0


### PR DESCRIPTION
## Summary
- 5ファイルにPython fcntlベースのflockを追加
- record-code-review.sh: python3+fcntlをprimary、jqをfallbackに変更
- mark-factcheck-done.sh: cat heredocをpython3+fcntlに置換
- codex-task-gate.sh: codex_call_countインクリメントにfcntl追加
- codex-task-release.sh: codex_call_countデクリメントにfcntl追加
- track-agent-team.sh: agent_countインクリメントにfcntl追加
- JSONDecodeErrorハンドラ追加（mark-factcheck-done, track-agent-team）

## Test plan
- [x] `bash -n` 構文検証パス（全5ファイル）
- [x] code-reviewer エージェントレビュー: HIGH指摘修正済み → APPROVE
- [x] Codex CLI セカンドオピニオン: LGTM
- [ ] CI green 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)