### PR TITLE
fix: 監査HIGH指摘一括修正 — flock追加・バイパス防止・タイムアウト (Closes #87)

### DIFF
--- a/hooks/block-local-hooks-write.sh
+++ b/hooks/block-local-hooks-write.sh
@@ -5,6 +5,8 @@
 # Write/Edit ツールで settings.local.json を変更する際、hooks が含まれていたらブロック。
 # =========================================================================
 
+set -euo pipefail
+
 input=""
 if [[ ! -t 0 ]]; then
   input=$(cat 2>/dev/null || echo "")

--- a/hooks/block-state-file-tampering-bash.sh
+++ b/hooks/block-state-file-tampering-bash.sh
@@ -9,24 +9,19 @@ set -euo pipefail
 
 INPUT=$(cat)
 CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
-CMD_FIRST_LINE=$(echo "$CMD" | head -1)
 
 # 保護対象のファイル名パターン
 PROTECTED="review-status\.json|pr-review-lock\.json|pr-review-read\.json|context-budget\.json|factcheck-status\.json|rebase-session\.json"
 
 # Bashコマンドが保護対象ファイルに書き込むか検出
-if echo "$CMD_FIRST_LINE" | grep -qE "$PROTECTED"; then
-  # 読み取り操作（cat, jq -r で読むだけ）は許可
-  if echo "$CMD_FIRST_LINE" | grep -qE '^\s*(cat|jq\s+-r|python3\s+-c.*json\.load|less|head|tail)\s'; then
-    exit 0
-  fi
+if echo "$CMD" | grep -qE "$PROTECTED"; then
   # 書き込みパターンを検出
   if echo "$CMD" | grep -qE '(>|json\.dump|echo.*>|tee|sed\s+-i|write_text|open.*\"w\")'; then
     cat >&2 <<ERRMSG
 
 ⛔ [BLOCKED] Bash経由の状態ファイル改ざンを検出
 
-コマンド: $(echo "$CMD_FIRST_LINE" | head -c 120)
+コマンド: $(echo "$CMD" | head -c 120)
 理由: ゲート状態ファイルへの直接書き込みは禁止されています。
 
 正しい方法:
@@ -37,6 +32,10 @@ if echo "$CMD_FIRST_LINE" | grep -qE "$PROTECTED"; then
 
 ERRMSG
     exit 2
+  fi
+  # 読み取り操作（cat, jq -r で読むだけ）は許可
+  if echo "$CMD" | grep -qE '^\s*(cat|jq\s+-r|python3\s+-c.*json\.load|less|head|tail)\s'; then
+    exit 0
   fi
 fi
 

--- a/hooks/context-budget-agent-gate.sh
+++ b/hooks/context-budget-agent-gate.sh
@@ -70,7 +70,7 @@ NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 # Pass all dynamic values via environment variables (not string interpolation)
 # to prevent shell injection via crafted JSON input
 _STATE_FILE="$STATE_FILE" _NOW="$NOW" _INPUT_JSON="$INPUT_JSON" python3 << 'PYEOF'
-import json, sys, os
+import json, sys, os, fcntl
 
 state_file = os.environ["_STATE_FILE"]
 now = os.environ["_NOW"]
@@ -87,12 +87,6 @@ RESEARCH_KEYWORDS = [
     "調査", "確認", "check", "review", "explore", "research",
     "read", "verify", "分析", "検証", "compare",
 ]
-
-with open(state_file) as f:
-    state = json.load(f)
-
-if not state.get("started_at"):
-    state["started_at"] = now
 
 # Parse Agent tool input
 tool_input = {}
@@ -166,36 +160,53 @@ is_background = bool(tool_input.get("run_in_background", False))
 # - 1st foreground impl: WARN (suggest background/TeamCreate for next)
 # - 2nd+ foreground impl: BLOCK
 has_team = bool(tool_input.get("team_name", ""))
-if not is_research and not has_team and not is_background:
-    impl_count = state.get("impl_agent_count", 0)
-    if impl_count >= 1:
-        print("🚫 [Foreground Impl Blocked] 2つ目のforeground実装Agentをブロック。", file=sys.stderr)
-        print("", file=sys.stderr)
-        print("前回のforeground Agentでメインセッションがブロックされました。", file=sys.stderr)
-        print("独立タスクは並列実行が必須です。", file=sys.stderr)
-        print("", file=sys.stderr)
-        print("修正方法:", file=sys.stderr)
-        print("  1. run_in_background: true を指定（推奨）", file=sys.stderr)
-        print("  2. TeamCreate で並列チームを構成", file=sys.stderr)
-        print("  3. Codex CLI 経路C で委任", file=sys.stderr)
-        print("", file=sys.stderr)
-        print("Ref: Issue #31 — foreground実装Agentの逐次実行を防止", file=sys.stderr)
-        with open(state_file, "w") as f:
-            json.dump(state, f, indent=2)
-        sys.exit(2)
-    state["impl_agent_count"] = impl_count + 1
-    state["fg_impl_agent_count"] = state.get("fg_impl_agent_count", 0) + 1
-    # WARN on 1st foreground impl
+block_foreground_impl = False
+warn_foreground_impl = False
+
+with open(state_file, "r+") as f:
+    fcntl.flock(f, fcntl.LOCK_EX)
+    state = json.load(f)
+
+    if not state.get("started_at"):
+        state["started_at"] = now
+
+    if not is_research and not has_team and not is_background:
+        impl_count = state.get("impl_agent_count", 0)
+        if impl_count >= 1:
+            block_foreground_impl = True
+        else:
+            state["impl_agent_count"] = impl_count + 1
+            state["fg_impl_agent_count"] = state.get("fg_impl_agent_count", 0) + 1
+            warn_foreground_impl = True
+
+    # --- Count total agents ---
+    if not block_foreground_impl:
+        state["agent_count"] = state.get("agent_count", 0) + 1
+        count = state["agent_count"]
+
+    f.seek(0)
+    f.truncate()
+    json.dump(state, f, indent=2)
+    fcntl.flock(f, fcntl.LOCK_UN)
+
+if block_foreground_impl:
+    print("🚫 [Foreground Impl Blocked] 2つ目のforeground実装Agentをブロック。", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("前回のforeground Agentでメインセッションがブロックされました。", file=sys.stderr)
+    print("独立タスクは並列実行が必須です。", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("修正方法:", file=sys.stderr)
+    print("  1. run_in_background: true を指定（推奨）", file=sys.stderr)
+    print("  2. TeamCreate で並列チームを構成", file=sys.stderr)
+    print("  3. Codex CLI 経路C で委任", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Ref: Issue #31 — foreground実装Agentの逐次実行を防止", file=sys.stderr)
+    sys.exit(2)
+
+if warn_foreground_impl:
     print("⚠️ [Foreground Impl] 実装Agentがforegroundで起動されます。", file=sys.stderr)
     print("  → 2つ目以降はrun_in_background: trueまたはTeamCreateを使用してください。", file=sys.stderr)
     print("  → foreground実行はメインセッションをブロックします。", file=sys.stderr)
-
-# --- Count total agents ---
-state["agent_count"] = state.get("agent_count", 0) + 1
-count = state["agent_count"]
-
-with open(state_file, "w") as f:
-    json.dump(state, f, indent=2)
 
 # --- Rule 3: WARN at 3+ total agents ---
 if count == 3:

--- a/hooks/context-budget-read-gate.sh
+++ b/hooks/context-budget-read-gate.sh
@@ -106,8 +106,9 @@ fi
 NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # Update state and check thresholds — only for SOURCE CODE reads
+[[ ! -f "$STATE_FILE" ]] && echo '{}' > "$STATE_FILE"
 _STATE="$STATE_FILE" _FILE="$FILE_PATH" _NOW="$NOW" python3 << PYEOF
-import json, sys, os, re
+import json, sys, os, re, fcntl
 
 state_file = os.environ['_STATE']
 file_path = os.environ['_FILE']
@@ -119,21 +120,24 @@ ext = os.path.splitext(file_path)[1].lower()
 if ext not in source_exts:
     sys.exit(0)
 
-with open(state_file) as f:
+with open(state_file, "r+") as f:
+    fcntl.flock(f, fcntl.LOCK_EX)
     state = json.load(f)
 
-if not state.get("started_at"):
-    state["started_at"] = now
+    if not state.get("started_at"):
+        state["started_at"] = now
 
-# Track unique file reads only
-if file_path and file_path not in state.get("read_files", []):
-    state.setdefault("read_files", []).append(file_path)
-    state["read_count"] = len(state["read_files"])
+    # Track unique file reads only
+    if file_path and file_path not in state.get("read_files", []):
+        state.setdefault("read_files", []).append(file_path)
+        state["read_count"] = len(state["read_files"])
 
-count = state["read_count"]
+    count = state.get("read_count", 0)
 
-with open(state_file, "w") as f:
+    f.seek(0)
+    f.truncate()
     json.dump(state, f, indent=2)
+    fcntl.flock(f, fcntl.LOCK_UN)
 
 # Threshold warnings
 if count == 3:

--- a/hooks/context-budget-write-gate.sh
+++ b/hooks/context-budget-write-gate.sh
@@ -76,8 +76,9 @@ fi
 
 NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
+[[ ! -f "$STATE_FILE" ]] && echo '{}' > "$STATE_FILE"
 _STATE_FILE="$STATE_FILE" _FILE_PATH="$FILE_PATH" _NOW="$NOW" python3 << PYEOF
-import json, sys, os, re
+import json, sys, os, re, fcntl
 
 state_file = os.environ['_STATE_FILE']
 file_path = os.environ['_FILE_PATH']
@@ -96,17 +97,20 @@ if re.search(r'(CLAUDE\.md|Plans\.md|MEMORY\.md|AGENTS\.md)', file_path):
 if not is_test and not is_doc:
     sys.exit(0)
 
-with open(state_file) as f:
+with open(state_file, "r+") as f:
+    fcntl.flock(f, fcntl.LOCK_EX)
     state = json.load(f)
 
-if not state.get("started_at"):
-    state["started_at"] = now
+    if not state.get("started_at"):
+        state["started_at"] = now
 
-state["write_test_doc_count"] = state.get("write_test_doc_count", 0) + 1
-count = state["write_test_doc_count"]
+    state["write_test_doc_count"] = state.get("write_test_doc_count", 0) + 1
+    count = state["write_test_doc_count"]
 
-with open(state_file, "w") as f:
+    f.seek(0)
+    f.truncate()
     json.dump(state, f, indent=2)
+    fcntl.flock(f, fcntl.LOCK_UN)
 
 file_type = "テスト" if is_test else "ドキュメント"
 

--- a/hooks/enforce-develop-base.sh
+++ b/hooks/enforce-develop-base.sh
@@ -80,7 +80,7 @@ if echo "$(echo "$cmd" | head -1)" | grep -qE 'gh\s+pr\s+create'; then
   # (GitHub defaults to repo's default branch, which is often main)
   if [[ -z "$pr_base" ]]; then
     # Get the repo's default branch
-    repo_default=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "")
+    repo_default=$(timeout 8 gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "")
     if [[ "$repo_default" == "main" ]] || [[ "$repo_default" == "master" ]]; then
       echo "" >&2
       echo "[BLOCKED] enforce-develop-base: --baseが未指定です（デフォルト: ${repo_default}）。" >&2

--- a/hooks/enforce-factcheck-before-edit.sh
+++ b/hooks/enforce-factcheck-before-edit.sh
@@ -18,6 +18,24 @@ if [ ! -f "$STATE_FILE" ]; then
     echo '{"factchecked": false, "source": "", "timestamp": 0, "edit_count_since_check": 0}' > "$STATE_FILE"
 fi
 
+increment_edit_count() {
+    _STATE_FILE="$STATE_FILE" _COUNT="$1" python3 <<'PYEOF'
+import fcntl, json, os
+
+state_file = os.environ["_STATE_FILE"]
+count = int(os.environ["_COUNT"])
+
+with open(state_file, "r+") as f:
+    fcntl.flock(f, fcntl.LOCK_EX)
+    state = json.load(f)
+    state["edit_count_since_check"] = count
+    f.seek(0)
+    f.truncate()
+    json.dump(state, f)
+    fcntl.flock(f, fcntl.LOCK_UN)
+PYEOF
+}
+
 input=$(cat)
 file_path=$(echo "$input" | jq -r '.tool_input.file_path // ""' 2>/dev/null || echo "")
 
@@ -87,7 +105,7 @@ if [ "$factchecked" = "false" ] || [ "$expired" = "true" ]; then
     fi
 
     # edit_countを増加
-    jq --argjson count "$((edit_count + 1))" '.edit_count_since_check = $count' "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+    increment_edit_count "$((edit_count + 1))"
 
     if [ "$factchecked" = "false" ] && [ "$edit_count" -eq 0 ]; then
         echo "⚠️ [WARN] ファクトチェックが未実施です。修正内容が最新ドキュメントに沿っているか確認してください。" >&2
@@ -95,7 +113,7 @@ if [ "$factchecked" = "false" ] || [ "$expired" = "true" ]; then
     fi
 else
     # ファクトチェック済み: edit_countを増加
-    jq --argjson count "$((edit_count + 1))" '.edit_count_since_check = $count' "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+    increment_edit_count "$((edit_count + 1))"
 fi
 
 exit 0

--- a/hooks/post-lint-format.sh
+++ b/hooks/post-lint-format.sh
@@ -133,3 +133,5 @@ if [[ -n "$diagnostics" ]] \
     }
   }'
 fi
+
+exit 0

--- a/hooks/pr-merge-claude-review-gate.sh
+++ b/hooks/pr-merge-claude-review-gate.sh
@@ -118,8 +118,8 @@ print(s.get(os.environ['_PR'], {}).get('fallback_review_done', False))
     echo "" >&2
     echo "  B) code-reviewer エージェントで代替レビューを実行:" >&2
     echo "     Agent(subagent_type='code-reviewer', prompt='Review PR #${PR_NUMBER} ...')" >&2
-    echo "     完了後に既読マーク:" >&2
-    echo "     _REVIEW_FILE='$REVIEW_FILE' _PR='$PR_NUMBER' python3 -c \"import json, os; p=os.environ['_REVIEW_FILE']; s=json.load(open(p)); d=s.setdefault(os.environ['_PR'],{}); d['fallback_review_done']=True; d['review_read']=True; json.dump(s,open(p,'w'),indent=2)\"" >&2
+    echo "     完了後、必要に応じて VERIFY を実行してから再試行してください:" >&2
+    echo "     bash ~/.claude/hooks/pr-ci-review-gate.sh VERIFY ${PR_NUMBER}" >&2
     echo "" >&2
     exit 2
   fi
@@ -142,8 +142,8 @@ if [[ "$REVIEW_READ" != "True" ]]; then
   echo "  必ず以下の手順を踏んでください:" >&2
   echo "  1. レビューを読む:" >&2
   echo "     gh api repos/${REPO}/issues/${PR_NUMBER}/comments --jq '.[].body'" >&2
-  echo "  2. 既読マーク:" >&2
-  echo "     _REVIEW_FILE='$REVIEW_FILE' _PR='$PR_NUMBER' python3 -c \"import json, os; p=os.environ['_REVIEW_FILE']; s=json.load(open(p)); s.setdefault(os.environ['_PR'],{})['review_read']=True; json.dump(s,open(p,'w'),indent=2)\"" >&2
+  echo "  2. code-reviewer を実行済みなら、記録処理完了後に再試行:" >&2
+  echo "     bash ~/.claude/hooks/pr-ci-review-gate.sh VERIFY ${PR_NUMBER}" >&2
   echo "" >&2
   exit 2
 fi
@@ -192,8 +192,9 @@ print(s.get(os.environ['_PR'], {}).get('critical_acknowledged', False))
     echo "" >&2
     echo "[BLOCKED] PR #${PR_NUMBER}: CRITICAL 指摘が未対応です。" >&2
     echo "" >&2
-    echo "  修正 push → レビュー再読 → acknowledge:" >&2
-    echo "  _REVIEW_FILE='$REVIEW_FILE' _PR='$PR_NUMBER' python3 -c \"import json, os; p=os.environ['_REVIEW_FILE']; s=json.load(open(p)); s.setdefault(os.environ['_PR'],{})['critical_acknowledged']=True; json.dump(s,open(p,'w'),indent=2)\"" >&2
+    echo "  修正を push し、レビューを再確認したうえで正規フローを完了してください。" >&2
+    echo "  code-reviewer の再実行、または必要な確認後に VERIFY を再実行してください:" >&2
+    echo "  bash ~/.claude/hooks/pr-ci-review-gate.sh VERIFY ${PR_NUMBER}" >&2
     echo "" >&2
     exit 2
   fi


### PR DESCRIPTION
## Summary
監査HIGH指摘11件の一括修正（9ファイル）:

### flock追加（race condition修正）
- `context-budget-read-gate.sh`: python3ブロックにfcntl追加
- `context-budget-write-gate.sh`: 同上
- `context-budget-agent-gate.sh`: state file書込みにfcntl追加
- `enforce-factcheck-before-edit.sh`: jq+tmpパターンをpython3+fcntlに置換

### セキュリティ
- `block-state-file-tampering-bash.sh`: CMD_FIRST_LINE→CMD全行チェック（バイパス防止）
- `pr-merge-claude-review-gate.sh`: inline state file書込み指示を正しい手順に置換

### タイムアウト・設定
- `enforce-develop-base.sh`: `timeout 8` 追加
- `block-local-hooks-write.sh`: `set -euo pipefail` 追加
- `post-lint-format.sh`: 末尾 `exit 0` 追加

## Test plan
- [x] `bash -n` 全9ファイル構文検証パス
- [x] Codex CLI による実装
- [ ] CI green 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)