### PR TITLE
fix: 監査指摘安全修正 — flock統一・interpolation・MCP文言 (Closes #91, refs #93)

### DIFF
--- a/hooks/block-manual-merge-ops.sh
+++ b/hooks/block-manual-merge-ops.sh
@@ -26,7 +26,16 @@ _write_rebase_state() {
     local target="$1"
     local now_epoch
     now_epoch=$(date +%s)
-    cat > "$REBASE_STATE_FILE" <<EOJSON
+    _STATE="$REBASE_STATE_FILE" _TARGET="$target" _EPOCH="$now_epoch" python3 -c "
+import json, os, fcntl
+f_path = os.environ['_STATE']
+data = {'rebase_in_progress': True, 'rebase_target': os.environ['_TARGET'], 'started_epoch': int(os.environ['_EPOCH'])}
+fd = os.open(f_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+with os.fdopen(fd, 'w') as f:
+    fcntl.flock(f, fcntl.LOCK_EX)
+    json.dump(data, f)
+    fcntl.flock(f, fcntl.LOCK_UN)
+" 2>/dev/null || cat > "$REBASE_STATE_FILE" <<EOJSON
 {"rebase_in_progress":true,"rebase_target":"${target}","started_epoch":${now_epoch}}
 EOJSON
 }

--- a/hooks/pr-guard.sh
+++ b/hooks/pr-guard.sh
@@ -58,7 +58,7 @@ fi
 # --- 2. Codex review check ---
 TOOL_INPUT="${CLAUDE_TOOL_INPUT:-$cmd}"
 if ! echo "$TOOL_INPUT" | grep -qi "codex"; then
-    WARNINGS+=("[Review] Codex レビュー記載なし。mcp__codex__codex でレビュー実施を推奨")
+    WARNINGS+=("[Review] Codex レビュー記載なし。codex exec でレビュー実施を推奨")
 fi
 
 # --- 3. Terraform check ---

--- a/hooks/record-codex-review.sh
+++ b/hooks/record-codex-review.sh
@@ -44,12 +44,17 @@ write_codex_review() {
     fi
   else
     _STATE="$target" _BR="$BRANCH" _NOW="$NOW" python3 -c "
-import json, os
+import json, os, fcntl
 f_path = os.environ['_STATE']
-with open(f_path) as f: s = json.load(f)
-s.setdefault(os.environ['_BR'], {})['codex_review'] = True
-s[os.environ['_BR']]['codex_review_at'] = os.environ['_NOW']
-with open(f_path, 'w') as f: json.dump(s, f, indent=2)
+with open(f_path, 'r+') as f:
+    fcntl.flock(f, fcntl.LOCK_EX)
+    s = json.load(f)
+    s.setdefault(os.environ['_BR'], {})['codex_review'] = True
+    s[os.environ['_BR']]['codex_review_at'] = os.environ['_NOW']
+    f.seek(0)
+    f.truncate()
+    json.dump(s, f, indent=2)
+    fcntl.flock(f, fcntl.LOCK_UN)
 " 2>/dev/null || true
   fi
 }

--- a/hooks/reset-factcheck.sh
+++ b/hooks/reset-factcheck.sh
@@ -5,5 +5,14 @@ set -euo pipefail
 
 STATE_FILE="${HOME}/.claude/state/factcheck-status.json"
 mkdir -p "$(dirname "$STATE_FILE")"
-echo '{"factchecked": false, "source": "", "timestamp": 0, "edit_count_since_check": 0}' > "$STATE_FILE"
+_STATE="$STATE_FILE" python3 -c "
+import json, os, fcntl
+f_path = os.environ['_STATE']
+data = {'factchecked': False, 'source': '', 'timestamp': 0, 'edit_count_since_check': 0}
+fd = os.open(f_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+with os.fdopen(fd, 'w') as f:
+    fcntl.flock(f, fcntl.LOCK_EX)
+    json.dump(data, f, indent=2)
+    fcntl.flock(f, fcntl.LOCK_UN)
+" 2>/dev/null || echo '{"factchecked": false, "source": "", "timestamp": 0, "edit_count_since_check": 0}' > "$STATE_FILE"
 exit 0

--- a/hooks/stop-test-gate.sh
+++ b/hooks/stop-test-gate.sh
@@ -109,11 +109,11 @@ fi
 TEST_OUTPUT=""
 TEST_EXIT=0
 if [ -n "$TIMEOUT_CMD" ]; then
-  TEST_OUTPUT=$($TIMEOUT_CMD bash -c "$TEST_CMD" 2>&1) || TEST_EXIT=$?
+  _TEST_CMD="$TEST_CMD" TEST_OUTPUT=$($TIMEOUT_CMD bash -c 'eval "$_TEST_CMD"' 2>&1) || TEST_EXIT=$?
 else
   # macOS fallback: background process with timer
   _tmp_out="/tmp/stop-test-output.$$"
-  bash -c "$TEST_CMD" > "$_tmp_out" 2>&1 &
+  _TEST_CMD="$TEST_CMD" bash -c 'eval "$_TEST_CMD"' > "$_tmp_out" 2>&1 &
   _test_pid=$!
   (sleep 60 && kill "$_test_pid" 2>/dev/null) &
   _timer_pid=$!

--- a/scripts/verify-pr-review.sh
+++ b/scripts/verify-pr-review.sh
@@ -33,11 +33,13 @@ mkdir -p "$(dirname "$REVIEW_LOCK")"
 echo "🔍 PR #${PR_NUM} claude-review 3ソース検証中..."
 
 # --- Check if auto-review was needed (no claude-review workflow) ---
-AUTO_REVIEW_NEEDED=$(python3 -c "
-import json
-with open('$REVIEW_LOCK') as f:
+AUTO_REVIEW_NEEDED=$(_LOCK="$REVIEW_LOCK" _PR="$PR_NUM" python3 -c "
+import json, os, fcntl
+with open(os.environ['_LOCK']) as f:
+    fcntl.flock(f, fcntl.LOCK_SH)
     s = json.load(f)
-print('yes' if s.get('$PR_NUM', {}).get('auto_review_needed', False) else 'no')
+    fcntl.flock(f, fcntl.LOCK_UN)
+print('yes' if s.get(os.environ['_PR'], {}).get('auto_review_needed', False) else 'no')
 " 2>/dev/null || echo "no")
 
 # Source 1: Review bodies
@@ -103,34 +105,40 @@ fi
 if [ "$BLOCKING" -gt 0 ] || [ "$MUST_FIX" -gt 0 ] || [ "$CRITICAL" -gt 0 ]; then
     echo "❌ PR #${PR_NUM} にBlocking/MustFix/Critical指摘が残っています。ロック解除できません。"
 
-    python3 -c "
-import json
-f = '$REVIEW_LOCK'
-with open(f) as fh:
-    s = json.load(fh)
-s.setdefault('$PR_NUM', {})
-s['$PR_NUM']['blocking_count'] = $BLOCKING
-s['$PR_NUM']['must_fix_count'] = $MUST_FIX
-s['$PR_NUM']['verified'] = False
-with open(f, 'w') as fh:
-    json.dump(s, fh, indent=2)
+    _LOCK="$REVIEW_LOCK" _PR="$PR_NUM" _BLOCKING="$BLOCKING" _MUST_FIX="$MUST_FIX" python3 -c "
+import json, os, fcntl
+f_path = os.environ['_LOCK']
+with open(f_path, 'r+') as f:
+    fcntl.flock(f, fcntl.LOCK_EX)
+    s = json.load(f)
+    s.setdefault(os.environ['_PR'], {})
+    s[os.environ['_PR']]['blocking_count'] = int(os.environ['_BLOCKING'])
+    s[os.environ['_PR']]['must_fix_count'] = int(os.environ['_MUST_FIX'])
+    s[os.environ['_PR']]['verified'] = False
+    f.seek(0)
+    f.truncate()
+    json.dump(s, f, indent=2)
+    fcntl.flock(f, fcntl.LOCK_UN)
 " 2>/dev/null
     exit 1
 fi
 
 # ALL CLEAN — release lock
-python3 -c "
-import json
-f = '$REVIEW_LOCK'
-with open(f) as fh:
-    s = json.load(fh)
-s.setdefault('$PR_NUM', {})
-s['$PR_NUM']['blocking_count'] = 0
-s['$PR_NUM']['must_fix_count'] = 0
-s['$PR_NUM']['verified'] = True
-s['$PR_NUM']['verified_at'] = '$(date -u +%Y-%m-%dT%H:%M:%SZ)'
-with open(f, 'w') as fh:
-    json.dump(s, fh, indent=2)
+_LOCK="$REVIEW_LOCK" _PR="$PR_NUM" _NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)" python3 -c "
+import json, os, fcntl
+f_path = os.environ['_LOCK']
+with open(f_path, 'r+') as f:
+    fcntl.flock(f, fcntl.LOCK_EX)
+    s = json.load(f)
+    s.setdefault(os.environ['_PR'], {})
+    s[os.environ['_PR']]['blocking_count'] = 0
+    s[os.environ['_PR']]['must_fix_count'] = 0
+    s[os.environ['_PR']]['verified'] = True
+    s[os.environ['_PR']]['verified_at'] = os.environ['_NOW']
+    f.seek(0)
+    f.truncate()
+    json.dump(s, f, indent=2)
+    fcntl.flock(f, fcntl.LOCK_UN)
 " 2>/dev/null
 
 echo "✅ PR #${PR_NUM} ロック解除。claude-review クリーン確認済み。マージ可能。"


### PR DESCRIPTION
## Summary
- 残存4ファイルに`fcntl.flock`追加（race condition防止）: record-codex-review.sh, reset-factcheck.sh, block-manual-merge-ops.sh, verify-pr-review.sh
- verify-pr-review.sh: python3 -c内の変数直接interpolationをenv var(`os.environ[]`)経由に変更（shell injection防止）
- pr-guard.sh: Codex MCP推奨文言をCLI推奨に修正（delegation.md準拠）
- stop-test-gate.sh: `bash -c "$TEST_CMD"` を env var経由 `bash -c 'eval "$_TEST_CMD"'` に変更（二重展開防止）

## 根拠
- 公式Hooks仕様: "No built-in file locking mechanism – implement your own if needed"
- 公式best practices: "use environment variables for portability"
- 既存パターン（record-code-review.sh, codex-task-gate.sh等12+ファイル）に準拠
- delegation.md (2026-03-22): "Codex MCP使用禁止（CLI経由のみ）"

## Test plan
- [x] `bash -n` 構文検証: 6ファイル全てパス
- [x] flock パターン: 既存12+ファイルと同一パターン（fcntl.LOCK_EX/LOCK_UN + seek(0)/truncate()）
- [x] env var変換: block-merge-without-review.sh:65-74の既存実装をリファレンスとして使用
- [ ] CI green 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * PR レビュープロセスの並行実行時の安定性を向上

* **Chores**
  * ファイルロック機構を強化し、リベース状態、レビュー状態、ファクトチェック状態の更新時の競合を防止
  * Codex レビュー推奨メッセージを更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->