### PR TITLE
fix: Tiered Review自己例外化を削除 (Closes #90)

### DIFF
--- a/hooks/block-merge-without-review.sh
+++ b/hooks/block-merge-without-review.sh
@@ -45,12 +45,7 @@ TIER="FULL"
 case "$PR_BRANCH" in
     docs/*|chore/*|ci/*) TIER="EXEMPT" ;;
     *)
-        # Check if repo is claude-code-skills (meta-task → LIGHT)
         # Use remote URL for defense-in-depth (aligned with classify_review_tier)
-        remote_url=$(git remote get-url origin 2>/dev/null || echo "")
-        if [[ "$remote_url" == *"/claude-code-skills"* ]] || [[ "$remote_url" == *"/claude-code-skills.git"* ]]; then
-            TIER="LIGHT"
-        fi
         ;;
 esac
 

--- a/hooks/pr-ci-review-gate.sh
+++ b/hooks/pr-ci-review-gate.sh
@@ -95,16 +95,6 @@ classify_review_tier() {
   # Tier 3: Branch-based exemption
   case "$branch" in docs/*|chore/*|ci/*) echo "EXEMPT"; return ;; esac
 
-  # Meta-task exemption (Issue #7): if the repo IS the hook system itself
-  # (claude-code-skills), treat all changes as LIGHT tier. Hook infrastructure
-  # changes are config/tooling, not application source code.
-  # Defense in depth: check remote URL (not just directory name) to prevent spoofing.
-  local remote_url
-  remote_url=$(git remote get-url origin 2>/dev/null || echo "")
-  if [[ "$remote_url" == *"/claude-code-skills"* ]] || [[ "$remote_url" == *"/claude-code-skills.git"* ]]; then
-    echo "LIGHT"
-    return
-  fi
 
   # Determine base branch for diff
   local base_branch="main"


### PR DESCRIPTION
## Summary
- `pr-ci-review-gate.sh`: meta-task exemption (remote URL判定で claude-code-skills を blanket LIGHT に強制) を削除
- `block-merge-without-review.sh`: 同様の exemption を削除
- これにより、hooks/scripts 変更は FULL tier (code-reviewer + Codex CLI) でレビューされる
- docs/config/.claude/* 変更は引き続き LIGHT tier (file-based 分類で自動判定)

## Why
監査レポート P1 (HIGH H-1): このリポジトリの exemption がレビューゲートの信頼性を根幹から崩していた。hooks/scripts はこのリポジトリの中核成果物であり、FULL review が妥当。

## Test plan
- [x] `bash -n` 構文検証パス
- [x] grep で "claude-code-skills" 参照がゼロであることを確認
- [x] classify_review_tier() の file-based 分類ロジックが正しく機能することを検証済み
  - `.md`, `.github/*`, `.claude/*` → LIGHT
  - `hooks/*.sh`, `scripts/*.py` → FULL (catch-all)
- [ ] CI green 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * コードレビュープロセスの判定ロジックを簡素化しました。リポジトリの特定条件に基づく特例処理を削除し、統一された基準に統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->