### PR TITLE
fix: npx許可削除 + third-party version pin (Closes #92)

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -21,7 +21,6 @@
       "Bash(openssl rand:*)",
       "Bash(source:*)",
       "Bash(curl:*)",
-      "Bash(npx:*)",
       "Bash(node:*)",
       "Bash(npm:*)",
       "Bash(pnpm:*)",

--- a/setup.sh
+++ b/setup.sh
@@ -49,10 +49,20 @@ echo "  Copied $(ls "$REPO_DIR"/scripts/* 2>/dev/null | wc -l | tr -d ' ') scrip
 echo "[5/5] Installing third-party dependencies..."
 
 # gstack
+# --- ctx7 (Context7 CLI) ---
+if ! command -v ctx7 &>/dev/null; then
+  echo "  + ctx7 (installing globally)..."
+  npm install -g ctx7@0.3.6
+  echo "  ✅ ctx7 installed"
+else
+  echo "  ↻ ctx7 (already installed: $(ctx7 --version 2>/dev/null || echo 'unknown'))"
+fi
+
 if [ ! -d "$SKILLS_DIR/gstack" ]; then
   echo "  + gstack (cloning from garrytan/gstack)..."
   git clone https://github.com/garrytan/gstack.git "$SKILLS_DIR/gstack"
-  cd "$SKILLS_DIR/gstack" && ./setup
+  cd "$SKILLS_DIR/gstack" && git checkout f4bbfaa5bdfd2d6ce59541c2145432febde57fed  # v0.11.10.0
+  ./setup
   ~/.claude/skills/gstack/bin/gstack-config set telemetry off
   cd "$REPO_DIR"
   echo "  ✅ gstack installed (telemetry disabled)"
@@ -63,7 +73,7 @@ fi
 # ui-ux-pro-max
 if ! command -v uipro &>/dev/null; then
   echo "  + ui-ux-pro-max (installing via npm)..."
-  npm install -g uipro-cli
+  npm install -g uipro-cli@2.2.3
   cd "$HOME/.claude" && uipro init --ai claude
   # Fix nested directory if created
   if [ -d "$HOME/.claude/.claude/skills/ui-ux-pro-max" ]; then

--- a/skills/context7-skills/SKILL.md
+++ b/skills/context7-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: context7-skills
-description: "Manage Context7 CLI skills: search, install, list, remove, info via npx ctx7. Use when the user wants to find, install, list, remove, or inspect Context7 skills. Triggers: 'search skills', 'install skill', 'list my skills', 'remove skill', 'ctx7', 'context7'. Do NOT use for general package management (npm, pip), non-Context7 CLI commands, or skill authoring."
+description: "Manage Context7 CLI skills: search, install, list, remove, info via ctx7. Use when the user wants to find, install, list, remove, or inspect Context7 skills. Triggers: 'search skills', 'install skill', 'list my skills', 'remove skill', 'ctx7', 'context7'. Do NOT use for general package management (npm, pip), non-Context7 CLI commands, or skill authoring."
 allowed-tools: [Bash, WebFetch]
 ---
 
@@ -12,11 +12,11 @@ Execute Context7 CLI commands directly. Printing commands without execution is f
 
 | Intent | Command |
 |--------|---------|
-| Search | `npx ctx7 skills search <keywords...>` |
-| Install | `npx ctx7 skills install <repository> [skill] [--all] [target]` |
-| List | `npx ctx7 skills list [target]` |
-| Remove | `npx ctx7 skills remove <name> [target]` |
-| Info | `npx ctx7 skills info <repository>` |
+| Search | `ctx7 skills search <keywords...>` |
+| Install | `ctx7 skills install <repository> [skill] [--all] [target]` |
+| List | `ctx7 skills list [target]` |
+| Remove | `ctx7 skills remove <name> [target]` |
+| Info | `ctx7 skills info <repository>` |
 
 No other commands may be executed.
 
@@ -34,7 +34,7 @@ If multiple targets are requested, stop and ask the user to pick one.
 
 ## Execution Rules
 
-1. Always execute via `npx ctx7`. The `skills` namespace is mandatory.
+1. Always execute via `ctx7`. The `skills` namespace is mandatory.
 2. Only commands listed above may be executed.
 3. At most one target flag per command.
 4. `--all` is only valid with `install`.
@@ -63,7 +63,7 @@ Commands requiring network access (`search`, `info`, remote `install`):
    1. `--claude`  2. `--cursor`  3. `--codex`  4. `--opencode`  5. `--amp`  6. `--antigravity`  7. `--global`
 5. Do NOT use `--all` for single skill install.
 6. Request network permission if remote, then execute:
-   `npx ctx7 skills install <repository> <skill_name> <target_flag>`
+   `ctx7 skills install <repository> <skill_name> <target_flag>`
 7. Display raw CLI output as-is.
 
 ## Error Handling


### PR DESCRIPTION
## Summary
- `settings.json`: `Bash(npx:*)` 許可を削除（サプライチェーンリスク排除）
- `setup.sh`: gstack を commit SHA `f4bbfaa5` (v0.11.10.0) に pin、uipro-cli を `@2.2.3` に pin
- `setup.sh`: ctx7 グローバルインストール追加（`npm install -g ctx7@0.3.6`）
- `skills/context7-skills/SKILL.md`: `npx ctx7` → `ctx7` に8箇所置換

## Why
監査レポート P3 (HIGH H-3): `Bash(npx:*)` 許可がベストプラクティス（npx禁止）と矛盾。third-party統合（gstack, uipro-cli）がHEAD clone/version pin なしで再現性・サプライチェーンリスクあり。

## Verification
- ctx7 パッケージ名: `npm view ctx7 version` → 0.3.6 確認
- uipro-cli バージョン: `uipro --version` → 2.2.3 確認
- gstack 最新commit: `gh api repos/garrytan/gstack/commits` → f4bbfaa5 確認
- hooks内npx使用: ゼロ（post-lint-format.sh:11 が明示的に禁止）

## Test plan
- [x] `python3 -c "import json; json.load(open('settings.json'))"` → valid JSON
- [x] `bash -n setup.sh` → syntax OK
- [x] `grep -c "npx ctx7" skills/context7-skills/SKILL.md` → 0
- [ ] CI green 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)