### PR TITLE
fix: stop-test-gate.sh change-related tests Phase 1 — ADR-003準拠 (Closes #93)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -249,7 +249,7 @@ PR に GitHub レビューがない場合（ソロ開発など）、**ローカ�
 - `inject-claude-review-on-checks.sh` — `gh pr checks` / `gh pr merge` 時にレビューコメントを自動取得
 - `pr-guard.sh` — ベースブランチ、Issue 参照、コンフリクトチェック
 - `task-completion-gate.sh` — 早期タスク完了をブロック（CI pending または CRITICAL/HIGH 指摘あり）
-- `stop-test-gate.sh` — セッション終了前にプロジェクトテスト実行（Stop hook、stop_hook_active ガード付き）
+- `stop-test-gate.sh` — セッション終了前に change-related test gate 実行（docs/config-only はスキップ、必要時は full suite fallback、stop_hook_active ガード付き）
 
 ### 安全ガード
 - `protect-branches.sh` — 保護ブランチの削除防止

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Merged or closed PRs are automatically cleaned from the lock state:
 - `inject-claude-review-on-checks.sh` — Auto-fetch review comments on `gh pr checks` / `gh pr merge`
 - `pr-guard.sh` — Base branch, issue ref, conflict checks
 - `task-completion-gate.sh` — Block premature task completion (CI pending or CRITICAL/HIGH findings)
-- `stop-test-gate.sh` — Run project tests before session end (Stop hook with stop_hook_active guard)
+- `stop-test-gate.sh` — Run change-related test gate before session end (docs/config-only skip, full-suite fallback, stop_hook_active guard)
 
 ### Safety Guards
 - `protect-branches.sh` — Prevent deletion of protected branches

--- a/hooks/stop-test-gate.sh
+++ b/hooks/stop-test-gate.sh
@@ -67,7 +67,7 @@ fi
 # ADR-003 Phase 1: change-related file detection
 # =========================================================================
 TEST_FILE_REGEX='(_test\.(go|py|ts|tsx|js|jsx)|\.test\.(ts|tsx|js|jsx)|\.spec\.(ts|tsx|js|jsx)|test_[a-z].*\.py|/__tests__/)'
-NON_TESTABLE_REGEX='\.(md|yml|yaml|json|toml|css|scss|svg|png|jpg|gif|ico|lock|txt|rst)$|^\.github/|^\.claude/|^docs/|^\.vscode/|^\.idea/'
+NON_TESTABLE_REGEX='\.(md|yml|yaml|css|scss|svg|png|jpg|gif|ico|lock|txt|rst)$|^\.github/|^\.claude/|^docs/|^\.vscode/|^\.idea/'
 CROSS_CUTTING_SOURCE_THRESHOLD=20
 
 detect_changed_files() {
@@ -83,9 +83,9 @@ detect_changed_files() {
     base=$(git rev-parse HEAD~1)
   fi
 
-  [[ -z "$base" ]] && return 0
+  [[ -z "$base" ]] && { echo "[stop-test-gate] merge-base 未解決: full suite fallback。" >&2; return 1; }
 
-  git diff --name-only "$base"...HEAD 2>/dev/null
+  git diff --name-only "$base"..HEAD 2>/dev/null
 }
 
 classify_files() {
@@ -142,21 +142,26 @@ if [ -z "$TEST_CMD" ]; then
 fi
 
 CHANGED_FILES=()
+_detect_exit=0
 while IFS= read -r changed_file; do
   [[ -n "$changed_file" ]] && CHANGED_FILES+=("$changed_file")
-done < <(detect_changed_files)
+done < <(detect_changed_files) || _detect_exit=$?
 
-if [[ "${#CHANGED_FILES[@]}" -eq 0 ]]; then
+if [[ "$_detect_exit" -ne 0 ]]; then
+  echo "[stop-test-gate] merge-base解決失敗: full suite fallback。" >&2
+  # Fall through to full suite execution (skip classification)
+elif [[ "${#CHANGED_FILES[@]}" -eq 0 ]]; then
   echo "[stop-test-gate] 変更ファイル未検出: テスト不要。" >&2
   exit 0
 fi
 
-TEST_FILES=()
-SOURCE_FILES=()
-NON_TESTABLE_FILES=()
-classify_files "${CHANGED_FILES[@]}"
+if [[ "$_detect_exit" -eq 0 ]] && [[ "${#CHANGED_FILES[@]}" -gt 0 ]]; then
+  TEST_FILES=()
+  SOURCE_FILES=()
+  NON_TESTABLE_FILES=()
+  classify_files "${CHANGED_FILES[@]}"
 
-if [[ "${#NON_TESTABLE_FILES[@]}" -eq "${#CHANGED_FILES[@]}" ]]; then
+  if [[ "${#NON_TESTABLE_FILES[@]}" -eq "${#CHANGED_FILES[@]}" ]]; then
   echo "[stop-test-gate] docs/config-only 変更: テスト不要。" >&2
   exit 0
 fi
@@ -166,7 +171,8 @@ if [[ "${#SOURCE_FILES[@]}" -ge "$CROSS_CUTTING_SOURCE_THRESHOLD" ]]; then
 elif [[ "${#TEST_FILES[@]}" -eq 0 ]]; then
   echo "[stop-test-gate] change-related tests 0件: full suite fallback。" >&2
 else
-  echo "[stop-test-gate] Phase 1: test file ${#TEST_FILES[@]}件を検出。実行は既存TEST_CMDを維持。" >&2
+    echo "[stop-test-gate] Phase 1: test file ${#TEST_FILES[@]}件を検出。実行は既存TEST_CMDを維持。" >&2
+  fi
 fi
 
 # =========================================================================

--- a/hooks/stop-test-gate.sh
+++ b/hooks/stop-test-gate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# stop-test-gate.sh — Stop hook: run project tests before session end
+# stop-test-gate.sh — Stop hook: run change-related test gate before session end
 # ====================================================================
 # Issue #66 Fix #3: stop_hook_active check added (official docs compliance)
 #
@@ -13,8 +13,9 @@
 #   1. Check stop_hook_active to prevent infinite loops
 #   2. Skip if dirty tree (active error recovery — Issue #58)
 #   3. Detect project test framework
-#   4. Run tests with 60s timeout
-#   5. On failure, block stop and show test output
+#   4. Detect and classify changed files (ADR-003 Phase 1)
+#   5. Skip docs/config-only changes, otherwise run test gate
+#   6. On failure, block stop and show test output
 # ====================================================================
 
 set -uo pipefail
@@ -63,6 +64,51 @@ else
 fi
 
 # =========================================================================
+# ADR-003 Phase 1: change-related file detection
+# =========================================================================
+TEST_FILE_REGEX='(_test\.(go|py|ts|tsx|js|jsx)|\.test\.(ts|tsx|js|jsx)|\.spec\.(ts|tsx|js|jsx)|test_[a-z].*\.py|/__tests__/)'
+NON_TESTABLE_REGEX='\.(md|yml|yaml|json|toml|css|scss|svg|png|jpg|gif|ico|lock|txt|rst)$|^\.github/|^\.claude/|^docs/|^\.vscode/|^\.idea/'
+CROSS_CUTTING_SOURCE_THRESHOLD=20
+
+detect_changed_files() {
+  local base=""
+
+  if base=$(git merge-base HEAD develop 2>/dev/null); then
+    :
+  elif base=$(git merge-base HEAD main 2>/dev/null); then
+    :
+  elif git rev-parse --verify HEAD~10 >/dev/null 2>&1; then
+    base=$(git rev-parse HEAD~10)
+  elif git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+    base=$(git rev-parse HEAD~1)
+  fi
+
+  [[ -z "$base" ]] && return 0
+
+  git diff --name-only "$base"...HEAD 2>/dev/null
+}
+
+classify_files() {
+  local file=""
+
+  TEST_FILES=()
+  SOURCE_FILES=()
+  NON_TESTABLE_FILES=()
+
+  for file in "$@"; do
+    [[ -z "$file" ]] && continue
+
+    if printf '%s\n' "$file" | grep -Eq "$NON_TESTABLE_REGEX"; then
+      NON_TESTABLE_FILES+=("$file")
+    elif printf '%s\n' "$file" | grep -Eq "$TEST_FILE_REGEX"; then
+      TEST_FILES+=("$file")
+    else
+      SOURCE_FILES+=("$file")
+    fi
+  done
+}
+
+# =========================================================================
 # Test detection logic (priority order)
 # =========================================================================
 TEST_CMD=""
@@ -95,6 +141,34 @@ if [ -z "$TEST_CMD" ]; then
   exit 0
 fi
 
+CHANGED_FILES=()
+while IFS= read -r changed_file; do
+  [[ -n "$changed_file" ]] && CHANGED_FILES+=("$changed_file")
+done < <(detect_changed_files)
+
+if [[ "${#CHANGED_FILES[@]}" -eq 0 ]]; then
+  echo "[stop-test-gate] 変更ファイル未検出: テスト不要。" >&2
+  exit 0
+fi
+
+TEST_FILES=()
+SOURCE_FILES=()
+NON_TESTABLE_FILES=()
+classify_files "${CHANGED_FILES[@]}"
+
+if [[ "${#NON_TESTABLE_FILES[@]}" -eq "${#CHANGED_FILES[@]}" ]]; then
+  echo "[stop-test-gate] docs/config-only 変更: テスト不要。" >&2
+  exit 0
+fi
+
+if [[ "${#SOURCE_FILES[@]}" -ge "$CROSS_CUTTING_SOURCE_THRESHOLD" ]]; then
+  echo "[stop-test-gate] source file ${#SOURCE_FILES[@]}件: full suite fallback。" >&2
+elif [[ "${#TEST_FILES[@]}" -eq 0 ]]; then
+  echo "[stop-test-gate] change-related tests 0件: full suite fallback。" >&2
+else
+  echo "[stop-test-gate] Phase 1: test file ${#TEST_FILES[@]}件を検出。実行は既存TEST_CMDを維持。" >&2
+fi
+
 # =========================================================================
 # Run tests with timeout (60 seconds)
 # =========================================================================
@@ -109,7 +183,7 @@ fi
 TEST_OUTPUT=""
 TEST_EXIT=0
 if [ -n "$TIMEOUT_CMD" ]; then
-  _TEST_CMD="$TEST_CMD" TEST_OUTPUT=$($TIMEOUT_CMD bash -c 'eval "$_TEST_CMD"' 2>&1) || TEST_EXIT=$?
+  TEST_OUTPUT=$(_TEST_CMD="$TEST_CMD" $TIMEOUT_CMD bash -c 'eval "$_TEST_CMD"' 2>&1) || TEST_EXIT=$?
 else
   # macOS fallback: background process with timer
   _tmp_out="/tmp/stop-test-output.$$"


### PR DESCRIPTION
## Summary
Closes #93

- `hooks/stop-test-gate.sh` を ADR-003 準拠に修正: repo全体テスト → change-related tests に限定 (Phase 1)
- `detect_changed_files()`: merge-base chain (develop→main→HEAD~10→HEAD~1) で変更ファイル検出
- `classify_files()`: TEST_FILE_REGEX / NON_TESTABLE_REGEX でファイル分類
- **docs/config-only fast path**: 全変更ファイルが非テスト対象 → exit 0 (テストスキップ)
- **cross-cutting threshold**: 20+ソースファイル変更 → full suite fallback
- **0 test detection**: テストファイル未検出 → full suite fallback
- shell interpolation修正: `_TEST_CMD` env var経由の `eval` パターン統一
- README.md / README.ja.md: change-related gate の表現に更新

## 安全策
- 全fallbackパスは現行動作（full suite実行）と同一
- `stop_hook_active` / dirty tree チェックは変更なし
- Phase 2-3 (Jest --findRelatedTests等) は未実装 → 別Issue

## Why
- ADR-003:63-66: "Run change-related tests (detected via git diff). Timeout: 60 seconds"
- 監査レポート M-1: Stop hook が repo 全体テスト実行（ADR-003 不整合）

## 実装者
Codex CLI (Route C) に委任。Claude Code がオーケストレーション・検証を担当。

## Test plan
- [x] `bash -n hooks/stop-test-gate.sh` — 構文チェックパス
- [x] Codex CLI 論理検証: docs-only→exit 0, 20+source→fallback, 0test→fallback, stop_hook_active→exit 0, dirty tree→exit 0
- [ ] CI green 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * テストゲートの説明を更新しました（変更関連のテストゲートにフォーカス、ドキュメント/設定のみの変更はスキップしフルスイートへフォールバックする旨を明記）。

* **改善**
  * セッション終了時のテスト実行を変更関連テストゲートへ切替。変更ファイルの分類に基づき不要なテストを省略し、広範な変更時は従来のフルスイートへフォールバックするようになりました。実行とタイムアウトの扱いも調整しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->