### PR TITLE
fix: PROJECT_DIRクォート + setup.sh実行順修正 (Closes #101)

### DIFF
--- a/hooks/stop-test-gate.sh
+++ b/hooks/stop-test-gate.sh
@@ -116,24 +116,24 @@ TEST_CMD=""
 if [ -f "$PROJECT_DIR/package.json" ] && command -v jq >/dev/null 2>&1 && jq -e '.scripts.test' "$PROJECT_DIR/package.json" >/dev/null 2>&1; then
   # Node.js project with test script
   if [ -f "$PROJECT_DIR/pnpm-lock.yaml" ]; then
-    TEST_CMD="cd $PROJECT_DIR && pnpm test"
+    TEST_CMD="cd \"$PROJECT_DIR\" && pnpm test"
   elif [ -f "$PROJECT_DIR/yarn.lock" ]; then
-    TEST_CMD="cd $PROJECT_DIR && yarn test"
+    TEST_CMD="cd \"$PROJECT_DIR\" && yarn test"
   else
-    TEST_CMD="cd $PROJECT_DIR && npm test"
+    TEST_CMD="cd \"$PROJECT_DIR\" && npm test"
   fi
 elif [ -f "$PROJECT_DIR/pyproject.toml" ] || [ -f "$PROJECT_DIR/setup.py" ]; then
   if command -v pytest >/dev/null 2>&1; then
-    TEST_CMD="cd $PROJECT_DIR && pytest --tb=short -q"
+    TEST_CMD="cd \"$PROJECT_DIR\" && pytest --tb=short -q"
   elif [ -d "$PROJECT_DIR/tests" ]; then
-    TEST_CMD="cd $PROJECT_DIR && python3 -m pytest --tb=short -q"
+    TEST_CMD="cd \"$PROJECT_DIR\" && python3 -m pytest --tb=short -q"
   fi
 elif [ -f "$PROJECT_DIR/go.mod" ]; then
-  TEST_CMD="cd $PROJECT_DIR && go test ./... -count=1 -short"
+  TEST_CMD="cd \"$PROJECT_DIR\" && go test ./... -count=1 -short"
 elif [ -f "$PROJECT_DIR/Cargo.toml" ]; then
-  TEST_CMD="cd $PROJECT_DIR && cargo test"
+  TEST_CMD="cd \"$PROJECT_DIR\" && cargo test"
 elif [ -f "$PROJECT_DIR/Makefile" ] && grep -q '^test:' "$PROJECT_DIR/Makefile"; then
-  TEST_CMD="cd $PROJECT_DIR && make test"
+  TEST_CMD="cd \"$PROJECT_DIR\" && make test"
 fi
 
 # No test framework detected — allow stop

--- a/setup.sh
+++ b/setup.sh
@@ -61,8 +61,7 @@ fi
 if [ ! -d "$SKILLS_DIR/gstack" ]; then
   echo "  + gstack (cloning from garrytan/gstack)..."
   git clone https://github.com/garrytan/gstack.git "$SKILLS_DIR/gstack"
-  cd "$SKILLS_DIR/gstack" && git checkout f4bbfaa5bdfd2d6ce59541c2145432febde57fed  # v0.11.10.0
-  ./setup
+  cd "$SKILLS_DIR/gstack" && git checkout f4bbfaa5bdfd2d6ce59541c2145432febde57fed && ./setup  # v0.11.10.0
   ~/.claude/skills/gstack/bin/gstack-config set telemetry off
   cd "$REPO_DIR"
   echo "  ✅ gstack installed (telemetry disabled)"


### PR DESCRIPTION
## Summary
Closes #101

- `hooks/stop-test-gate.sh`: TEST_CMD構築8箇所で `$PROJECT_DIR` をダブルクォート（パスにスペース含む場合のcd失敗防止）
- `setup.sh`: gstack の `git checkout` と `./setup` を `&&` チェイン（checkout失敗時にsetup実行防止）

## Why
- CodeRabbit PR #95 inline指摘: PROJECT_DIR unquoted in TEST_CMD
- code-reviewer PR #97 Issue 2: setup.sh ordering

## Test plan
- [x] `bash -n hooks/stop-test-gate.sh` — syntax OK
- [x] `bash -n setup.sh` — syntax OK
- [x] クォート箇所: 8箇所確認
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)