### PR TITLE
fix: verify-pr-review.sh にHIGH/BUG severity検出追加 (Closes #116)

### DIFF
--- a/scripts/verify-pr-review.sh
+++ b/scripts/verify-pr-review.sh
@@ -57,6 +57,8 @@ COMBINED="$REVIEWS $PR_COMMENTS $ISSUE_COMMENTS"
 BLOCKING=$(echo "$COMBINED" | grep -ciE '\[BLOCKING\]|severity:\s*BLOCKING|^\s*BLOCKING[:\s-]|>\s*BLOCKING|\*\*BLOCKING\*\*|🔴' || true)
 MUST_FIX=$(echo "$COMBINED" | grep -ciE '\[MUST.FIX\]|severity:\s*MUST.FIX|^\s*MUST.FIX[:\s-]|>\s*MUST.FIX|\*\*MUST.FIX\*\*' || true)
 CRITICAL=$(echo "$COMBINED" | grep -ciE '\[CRITICAL\]|severity:\s*CRITICAL|^\s*CRITICAL[:\s-]|>\s*CRITICAL|\*\*CRITICAL\*\*' || true)
+HIGH=$(echo "$COMBINED" | grep -ciE '\[HIGH\]|severity:\s*HIGH|^\s*HIGH[:\s-]|>\s*HIGH|\*\*HIGH\*\*|🟠' || true)
+BUG=$(echo "$COMBINED" | grep -ciE '\[BUG\]|severity:\s*BUG|^\s*BUG[:\s-]|>\s*BUG|\*\*BUG\*\*|🐛' || true)
 
 # Get latest claude-review summary
 LATEST_SUMMARY=$(echo "$ISSUE_COMMENTS" | python3 -c "
@@ -74,6 +76,8 @@ echo "=== 検証結果 ==="
 echo "  Blocking:  ${BLOCKING}"
 echo "  Must Fix:  ${MUST_FIX}"
 echo "  Critical:  ${CRITICAL}"
+echo "  High:      ${HIGH}"
+echo "  Bug:       ${BUG}"
 echo ""
 echo "=== 最新レビューサマリ (先頭500文字) ==="
 echo "$LATEST_SUMMARY"
@@ -149,8 +153,8 @@ print(len(review_bots))
     echo "  レビュー存在確認: ${TOTAL_REVIEW_EVIDENCE}件 ✓"
 fi
 
-if [ "$BLOCKING" -gt 0 ] || [ "$MUST_FIX" -gt 0 ] || [ "$CRITICAL" -gt 0 ]; then
-    echo "❌ PR #${PR_NUM} にBlocking/MustFix/Critical指摘が残っています。ロック解除できません。"
+if [ "$BLOCKING" -gt 0 ] || [ "$MUST_FIX" -gt 0 ] || [ "$CRITICAL" -gt 0 ] || [ "$HIGH" -gt 0 ] || [ "$BUG" -gt 0 ]; then
+    echo "❌ PR #${PR_NUM} にBlocking/MustFix/Critical/High/Bug指摘が残っています。ロック解除できません。"
 
     _LOCK="$REVIEW_LOCK" _PR="$PR_NUM" _BLOCKING="$BLOCKING" _MUST_FIX="$MUST_FIX" python3 -c "
 import json, os, fcntl


### PR DESCRIPTION
## Summary
Closes #116

- HIGH/BUG severity 検出パターンを追加
- ブロック条件: BLOCKING OR MUST_FIX OR CRITICAL OR **HIGH** OR **BUG** > 0
- quality.md「CRITICAL/HIGHゼロまで完了ではない」に準拠

## Test plan
- [x] `bash -n` syntax OK
- [ ] CI green
- [ ] CodeRabbit レビュー存在確認（#114 修正後の verify で検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)