### PR TITLE
fix: deploy 11 dead hooks + add deployment validation (Closes #119, #124, #121)

### DIFF
--- a/hooks/validate-hook-deployment.sh
+++ b/hooks/validate-hook-deployment.sh
@@ -48,14 +48,11 @@ is_excluded() {
   return 1
 }
 
-# --- Phase 1: Collect project hook files (excluding _unused/, __pycache__) ---
+# --- Phase 1: Collect project hook files ---
+# -maxdepth 1 inherently excludes _unused/ and __pycache__/ subdirectories
 project_files=()
 while IFS= read -r -d '' filepath; do
   filename=$(basename "$filepath")
-  # Skip files inside _unused/ or __pycache__/
-  case "$filepath" in
-    */_unused/*|*/__pycache__/*) continue ;;
-  esac
   project_files+=("$filename")
 done < <(find "$PROJECT_HOOKS_DIR" -maxdepth 1 \( -name '*.sh' -o -name '*.py' \) -print0 2>/dev/null | sort -z)
 
@@ -72,22 +69,20 @@ if [[ -f "$SETTINGS_FILE" ]]; then
   # Read settings.json content once
   settings_content=$(cat "$SETTINGS_FILE")
 
+  # -maxdepth 1 inherently excludes _unused/ and __pycache__/ subdirectories
   while IFS= read -r -d '' filepath; do
     filename=$(basename "$filepath")
-    # Skip non-script files and special entries
+    # Skip non-script files
     case "$filename" in
       README.md|*.pyc) continue ;;
-    esac
-    # Skip _unused/ and __pycache__
-    case "$filepath" in
-      */_unused/*|*/__pycache__/*) continue ;;
     esac
     # Skip known exclusions
     if is_excluded "$filename"; then
       continue
     fi
-    # Check if registered in settings.json (pattern: bash ~/.claude/hooks/FILENAME)
-    if ! echo "$settings_content" | grep -q "bash ~/.claude/hooks/$filename"; then
+    # Check if registered in settings.json
+    # Supports both bash and python3 invocation patterns
+    if ! echo "$settings_content" | grep -q "~/.claude/hooks/$filename"; then
       issues+=("NOT REGISTERED: $filename")
     fi
   done < <(find "$INSTALLED_HOOKS_DIR" -maxdepth 1 \( -name '*.sh' -o -name '*.py' \) -print0 2>/dev/null | sort -z)

--- a/hooks/validate-hook-deployment.sh
+++ b/hooks/validate-hook-deployment.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# validate-hook-deployment.sh — SessionStart hook: verify hook deployment integrity
+# =========================================================================
+# Checks that all hook scripts in the project are:
+#   1. Installed to ~/.claude/hooks/
+#   2. Registered in ~/.claude/settings.json
+#
+# SessionStart hook — cannot block (exit 0 always)
+# stdout: JSON additionalContext (when issues found)
+# stderr: diagnostic information
+#
+# Ref: Epic #130 — hookデプロイメント検証の構造的欠陥
+# =========================================================================
+set -uo pipefail
+
+# --- Known exclusions (not directly registered in settings.json) ---
+EXCLUDED_FROM_REGISTRATION=(
+  "inject-claude-review-helper.py"
+  "README.md"
+)
+
+# --- Locate project hooks directory ---
+PROJECT_HOOKS_DIR=""
+for candidate in \
+  "${CLAUDE_PROJECT_DIR:-}/hooks" \
+  "$HOME/Developer/claude-code-skills/hooks" \
+; do
+  if [[ -d "$candidate" ]]; then
+    PROJECT_HOOKS_DIR="$candidate"
+    break
+  fi
+done
+
+# If no project hooks dir found, skip silently
+[[ -z "$PROJECT_HOOKS_DIR" ]] && exit 0
+
+INSTALLED_HOOKS_DIR="$HOME/.claude/hooks"
+SETTINGS_FILE="$HOME/.claude/settings.json"
+
+# --- Helper: check if a filename is in the exclusion list ---
+is_excluded() {
+  local filename="$1"
+  for excluded in "${EXCLUDED_FROM_REGISTRATION[@]}"; do
+    if [[ "$filename" == "$excluded" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# --- Phase 1: Collect project hook files (excluding _unused/, __pycache__) ---
+project_files=()
+while IFS= read -r -d '' filepath; do
+  filename=$(basename "$filepath")
+  # Skip files inside _unused/ or __pycache__/
+  case "$filepath" in
+    */_unused/*|*/__pycache__/*) continue ;;
+  esac
+  project_files+=("$filename")
+done < <(find "$PROJECT_HOOKS_DIR" -maxdepth 1 \( -name '*.sh' -o -name '*.py' \) -print0 2>/dev/null | sort -z)
+
+# --- Phase 2: Check each project file is installed ---
+issues=()
+for filename in "${project_files[@]}"; do
+  if [[ ! -f "$INSTALLED_HOOKS_DIR/$filename" ]]; then
+    issues+=("NOT INSTALLED: $filename")
+  fi
+done
+
+# --- Phase 3: Check each installed file is registered in settings.json ---
+if [[ -f "$SETTINGS_FILE" ]]; then
+  # Read settings.json content once
+  settings_content=$(cat "$SETTINGS_FILE")
+
+  while IFS= read -r -d '' filepath; do
+    filename=$(basename "$filepath")
+    # Skip non-script files and special entries
+    case "$filename" in
+      README.md|*.pyc) continue ;;
+    esac
+    # Skip _unused/ and __pycache__
+    case "$filepath" in
+      */_unused/*|*/__pycache__/*) continue ;;
+    esac
+    # Skip known exclusions
+    if is_excluded "$filename"; then
+      continue
+    fi
+    # Check if registered in settings.json (pattern: bash ~/.claude/hooks/FILENAME)
+    if ! echo "$settings_content" | grep -q "bash ~/.claude/hooks/$filename"; then
+      issues+=("NOT REGISTERED: $filename")
+    fi
+  done < <(find "$INSTALLED_HOOKS_DIR" -maxdepth 1 \( -name '*.sh' -o -name '*.py' \) -print0 2>/dev/null | sort -z)
+fi
+
+# --- Phase 4: Output results ---
+if [[ ${#issues[@]} -gt 0 ]]; then
+  # Build the warning message
+  issue_count=${#issues[@]}
+  warning_lines=""
+  for issue in "${issues[@]}"; do
+    warning_lines="${warning_lines}\\n- ${issue}"
+  done
+  message="[Hook Deployment Check] ${issue_count} issues found:${warning_lines}"
+
+  # stderr: diagnostic output
+  echo "[Hook Deployment Check] ${issue_count} issues found:" >&2
+  for issue in "${issues[@]}"; do
+    echo "  - ${issue}" >&2
+  done
+
+  # stdout: JSON additionalContext
+  # Use python3 for safe JSON encoding
+  python3 -c "
+import json, sys
+msg = sys.argv[1]
+output = {
+    'hookSpecificOutput': {
+        'hookEventName': 'SessionStart',
+        'additionalContext': msg
+    }
+}
+print(json.dumps(output))
+" "$message"
+fi
+
+exit 0

--- a/rules/hook-deployment.md
+++ b/rules/hook-deployment.md
@@ -1,0 +1,17 @@
+# Hook Deployment Integrity
+
+## エピック参照（全セッション必読）
+GitHub Issue #130: hookデプロイメント検証の構造的欠陥
+- hook追加時は「スクリプト作成 + ~/.claude/hooks/コピー + settings.json登録」を1 PRに含める
+- 「コードがある」≠「動作する」— デプロイ検証はコード品質検証と独立したチェックポイント
+
+## hookデプロイ3要件（全て満たさないと「実装完了」ではない）
+1. `hooks/xxx.sh` がプロジェクトに存在する
+2. `~/.claude/hooks/xxx.sh` にインストール済み（setup.sh経由）
+3. `~/.claude/settings.json` の適切なmatcher/eventに登録済み
+
+## Issue完了判定（hookタイプ）
+- [ ] スクリプトが hooks/ に追加された
+- [ ] setup.sh 再実行で ~/.claude/hooks/ にコピーされる
+- [ ] settings.json にmatcher/event登録が追加された
+- [ ] hookが実際に発火することを確認（トリガー操作→stderrメッセージ確認）

--- a/setup.sh
+++ b/setup.sh
@@ -33,8 +33,11 @@ echo "  Copied $(ls "$REPO_DIR"/rules/*.md | wc -l | tr -d ' ') rule files"
 echo "[3/5] Installing hooks..."
 mkdir -p "$HOOKS_DIR"
 cp "$REPO_DIR"/hooks/*.sh "$HOOKS_DIR/"
+cp "$REPO_DIR"/hooks/*.py "$HOOKS_DIR/" 2>/dev/null || true
 chmod +x "$HOOKS_DIR"/*.sh
-echo "  Copied $(ls "$REPO_DIR"/hooks/*.sh | wc -l | tr -d ' ') hook scripts"
+SH_COUNT=$(ls "$REPO_DIR"/hooks/*.sh 2>/dev/null | wc -l | tr -d ' ')
+PY_COUNT=$(ls "$REPO_DIR"/hooks/*.py 2>/dev/null | wc -l | tr -d ' ')
+echo "  Copied ${SH_COUNT} shell + ${PY_COUNT} python hook scripts"
 
 # 4. Copy scripts
 echo "[4/5] Installing scripts..."


### PR DESCRIPTION
## Summary

- **Root cause fix**: 11 hook scripts existed but were never deployed (installed to `~/.claude/hooks/` + registered in `settings.json`). Hook gate coverage went from 39% to 100%.
- **Recurrence prevention**: Added `validate-hook-deployment.sh` SessionStart hook that checks deployment integrity on every session start.
- **setup.sh fix**: Now copies `.py` files alongside `.sh` files.
- **Codex MCP contradiction resolved**: Removed `mcp__codex__codex` from `permissions.allow` and registered `block-codex-mcp.sh`.

## Changes (project files)

| File | Change |
|---|---|
| `hooks/validate-hook-deployment.sh` | New: SessionStart hook for deployment integrity verification |
| `rules/hook-deployment.md` | New: Deployment checklist referencing Epic #130 |
| `setup.sh` | Fix: `.py` file copy support added |

## Settings.json changes (user config, not in repo)

- **11 hooks registered** in correct matcher/event positions
- **3 new event types**: TaskCompleted, PostToolUseFailure, Stop (test gate)
- **Permission fix**: `mcp__codex__codex` removed from allow list

## Verification

```
設計仕様書第3章の全ゲート: 14/14 (100%) ✓
プロジェクト hooks/ → ~/.claude/hooks/ インストール: ALL INSTALLED ✓
settings.json 登録: ALL REGISTERED ✓
settings.json JSON構文: VALID JSON ✓
```

## Test plan

- [ ] `validate-hook-deployment.sh` がSessionStartで発火し、問題なし時は無出力
- [ ] `enforce-develop-base.sh` がmainからのブランチ作成をブロック
- [ ] `enforce-soak-time.sh` がsoak time不足のマージをブロック
- [ ] `stop-test-gate.sh` がセッション終了時にテストを実行
- [ ] `block-codex-mcp.sh` がCodex MCP使用をブロック

Closes #119, Closes #124, Closes #121
Refs #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * フック展開の検証機能を追加しました。インストール状況と登録状況を自動的にチェックします。
  * セットアップスクリプトがPythonフックをサポートするようになりました。シェルスクリプトとの両方に対応しています。

* **ドキュメント**
  * フック展開プロセスの要件と確認手順をまとめたガイドを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->