### PR TITLE
fix: hook公式仕様違反 + timeout/flock + soak time + CI (Closes #120, #129, #123, #122)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI — Hook Quality
+
+on:
+  pull_request:
+  push:
+    branches: [main, develop]
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Run shellcheck on hook scripts
+        run: |
+          # First pass: show all findings (warnings + errors) for visibility
+          shellcheck hooks/*.sh || true
+          # Second pass: fail only on errors (severity "error")
+          shellcheck -S error hooks/*.sh
+
+  syntax-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Bash syntax check
+        run: |
+          errors=0
+          for f in hooks/*.sh scripts/*.sh setup.sh; do
+            if [ -f "$f" ]; then
+              if ! bash -n "$f" 2>/dev/null; then
+                echo "SYNTAX ERROR: $f"
+                bash -n "$f" 2>&1 || true
+                errors=$((errors + 1))
+              fi
+            fi
+          done
+          if [ "$errors" -gt 0 ]; then
+            echo "$errors file(s) have syntax errors"
+            exit 1
+          fi
+          echo "All files passed syntax check"
+
+  json-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate JSON files
+        run: |
+          errors=0
+          for f in settings.json .claude/settings.local.json; do
+            if [ -f "$f" ]; then
+              if ! python3 -m json.tool "$f" > /dev/null 2>&1; then
+                echo "INVALID JSON: $f"
+                python3 -m json.tool "$f" 2>&1 || true
+                errors=$((errors + 1))
+              else
+                echo "OK: $f"
+              fi
+            fi
+          done
+          if [ "$errors" -gt 0 ]; then
+            echo "$errors file(s) have JSON syntax errors"
+            exit 1
+          fi
+          echo "All JSON files are valid"

--- a/hooks/block-merge-without-ci.sh
+++ b/hooks/block-merge-without-ci.sh
@@ -3,6 +3,15 @@
 # PreToolUse hook for gh pr merge commands
 set -euo pipefail
 
+# Portable timeout: macOS has no timeout command (GNU coreutils)
+if command -v timeout &>/dev/null; then
+  _timeout() { timeout "$@"; }
+elif command -v gtimeout &>/dev/null; then
+  _timeout() { gtimeout "$@"; }
+else
+  _timeout() { shift; "$@"; }  # skip timeout arg, run command directly
+fi
+
 input=$(cat)
 cmd=$(echo "$input" | jq -r '.tool_input.command // ""')
 cmd_first_line=$(echo "$cmd" | head -1)
@@ -22,7 +31,7 @@ fi
 # Check CI status
 echo "[Merge Guard] PR #${PR_NUM} の CI/CD ステータスを確認中..." >&2
 
-CHECK_STATUS=$(gh pr checks "$PR_NUM" 2>&1 || true)
+CHECK_STATUS=$(_timeout 10 gh pr checks "$PR_NUM" 2>&1 || true)
 
 # Check for failures
 if echo "$CHECK_STATUS" | grep -qi "fail\|error"; then
@@ -46,7 +55,7 @@ if echo "$CHECK_STATUS" | grep -qi "no checks"; then
 fi
 
 # Check mergeable status
-MERGEABLE=$(gh pr view "$PR_NUM" --json mergeable -q '.mergeable' 2>/dev/null || echo "UNKNOWN")
+MERGEABLE=$(_timeout 10 gh pr view "$PR_NUM" --json mergeable -q '.mergeable' 2>/dev/null || echo "UNKNOWN")
 if [ "$MERGEABLE" = "CONFLICTING" ]; then
     echo "[BLOCK] PR #${PR_NUM} にコンフリクトがあります。Codex CLIでリベースしてください。" >&2
     exit 2

--- a/hooks/context-budget-write-gate.sh
+++ b/hooks/context-budget-write-gate.sh
@@ -115,24 +115,24 @@ with open(state_file, "r+") as f:
 file_type = "テスト" if is_test else "ドキュメント"
 
 if count == 1:
-    print(f"⚠️ [Context Budget Gate] {file_type}ファイル作成を検出: {basename}")
-    print(f"  → delegation.md ルール: {file_type}作成は原則 Codex CLI 経路C に委任してください。")
+    print(f"⚠️ [Context Budget Gate] {file_type}ファイル作成を検出: {basename}", file=sys.stderr)
+    print(f"  → delegation.md ルール: {file_type}作成は原則 Codex CLI 経路C に委任してください。", file=sys.stderr)
     if is_test:
-        print("  → 例外: TDD Red-Greenサイクル中、1ファイル10行未満、対話的判断が必要な場合")
-    print("  → bash ~/.claude/scripts/codex-parallel.sh <repo> <branch> \"プロンプト\"")
+        print("  → 例外: TDD Red-Greenサイクル中、1ファイル10行未満、対話的判断が必要な場合", file=sys.stderr)
+    print("  → bash ~/.claude/scripts/codex-parallel.sh <repo> <branch> \"プロンプト\"", file=sys.stderr)
     # 1件目は警告のみ、続行許可
     sys.exit(0)
 elif count >= 2:
-    print(f"🚫 [Context Budget Gate] {file_type}ファイル{count}件目の作成をブロックしました。")
-    print(f"  → delegation.md ルール: 2件以上の{file_type}/ドキュメント作成は Codex CLI 経路C に委任必須。")
-    print("  → bash ~/.claude/scripts/codex-parallel.sh <repo> <branch> \"プロンプト\"")
-    print("  → 例外事由がある場合: mode=planning に設定してください")
-    print("    bash ~/.claude/hooks/context-budget-set-mode.sh planning")
-    # 2件目以降はブロック（exit 1）
+    print(f"🚫 [Context Budget Gate] {file_type}ファイル{count}件目の作成をブロックしました。", file=sys.stderr)
+    print(f"  → delegation.md ルール: 2件以上の{file_type}/ドキュメント作成は Codex CLI 経路C に委任必須。", file=sys.stderr)
+    print("  → bash ~/.claude/scripts/codex-parallel.sh <repo> <branch> \"プロンプト\"", file=sys.stderr)
+    print("  → 例外事由がある場合: mode=planning に設定してください", file=sys.stderr)
+    print("    bash ~/.claude/hooks/context-budget-set-mode.sh planning", file=sys.stderr)
+    # 2件目以降はブロック（exit 2 = block per official spec）
     sys.exit(2)
 
 PYEOF
 
 # Hook exit code is determined by Python script above
-# If Python exits 0, hook allows; if Python exits 1, hook blocks
+# exit 0 = allow, exit 2 = block (official spec)
 exit $?

--- a/hooks/enforce-soak-time.sh
+++ b/hooks/enforce-soak-time.sh
@@ -12,6 +12,15 @@
 # =========================================================================
 set -euo pipefail
 
+# Portable timeout: macOS has no timeout command (GNU coreutils)
+if command -v timeout &>/dev/null; then
+  _timeout() { timeout "$@"; }
+elif command -v gtimeout &>/dev/null; then
+  _timeout() { gtimeout "$@"; }
+else
+  _timeout() { shift; "$@"; }  # skip timeout arg, run command directly
+fi
+
 input=$(cat)
 cmd=$(echo "$input" | jq -r '.tool_input.command // ""')
 
@@ -39,18 +48,29 @@ if [[ -z "$PR_JSON" ]]; then
 fi
 
 BASE_BRANCH=$(echo "$PR_JSON" | jq -r '.base.ref // ""')
-UPDATED_AT=$(echo "$PR_JSON" | jq -r '.updated_at // ""')
+HEAD_SHA=$(echo "$PR_JSON" | jq -r '.head.sha // ""')
 
-if [[ -z "$UPDATED_AT" ]]; then
+# Get head commit's committer date (not updated_at which changes on comments/labels)
+# Note: committer.date is commit creation time, not push time.
+# This is better than updated_at but may undercount soak time if commit
+# was created long before pushing. Acceptable trade-off per #123.
+if [[ -n "$HEAD_SHA" ]]; then
+  COMMIT_JSON=$(_timeout 10 gh api "repos/${REPO}/commits/${HEAD_SHA}" 2>/dev/null || echo "")
+  PUSH_TIME=$(echo "$COMMIT_JSON" | jq -r '.commit.committer.date // ""' 2>/dev/null || echo "")
+else
+  PUSH_TIME=""
+fi
+
+if [[ -z "$PUSH_TIME" ]]; then
   exit 0
 fi
 
 # --- Calculate elapsed time ---
 # macOS compatible date parsing
-if date -jf "%Y-%m-%dT%H:%M:%SZ" "$UPDATED_AT" +%s >/dev/null 2>&1; then
-  PUSH_EPOCH=$(date -jf "%Y-%m-%dT%H:%M:%SZ" "$UPDATED_AT" +%s)
-elif date -d "$UPDATED_AT" +%s >/dev/null 2>&1; then
-  PUSH_EPOCH=$(date -d "$UPDATED_AT" +%s)
+if date -jf "%Y-%m-%dT%H:%M:%SZ" "$PUSH_TIME" +%s >/dev/null 2>&1; then
+  PUSH_EPOCH=$(date -jf "%Y-%m-%dT%H:%M:%SZ" "$PUSH_TIME" +%s)
+elif date -d "$PUSH_TIME" +%s >/dev/null 2>&1; then
+  PUSH_EPOCH=$(date -d "$PUSH_TIME" +%s)
 else
   # Cannot parse date, skip enforcement
   exit 0
@@ -90,7 +110,7 @@ if [[ "$REQUIRED_SOAK" -gt 0 ]] && [[ "$ELAPSED" -lt "$REQUIRED_SOAK" ]]; then
   echo "" >&2
   echo "⏳ [SOAK TIME] PR #${PR_NUM} のマージをブロック。" >&2
   echo "   理由: ${SOAK_REASON}" >&2
-  echo "   最終更新: ${UPDATED_AT}" >&2
+  echo "   最終push: ${PUSH_TIME}" >&2
   echo "   経過時間: $((ELAPSED / 3600))h $((ELAPSED % 3600 / 60))m" >&2
   echo "   残り時間: ${REMAINING_H}h ${REMAINING_M}m" >&2
   echo "" >&2

--- a/hooks/pr-ci-review-gate.sh
+++ b/hooks/pr-ci-review-gate.sh
@@ -19,6 +19,16 @@ export GH_NO_UPDATE_NOTIFIER=1
 
 GATE_MODE="${GATE_MODE:-STOP}"
 
+# Portable timeout: macOS has no timeout command (GNU coreutils)
+if command -v timeout &>/dev/null; then
+  _timeout() { timeout "$@"; }
+elif command -v gtimeout &>/dev/null; then
+  _timeout() { gtimeout "$@"; }
+else
+  _timeout() { shift; "$@"; }  # skip timeout arg, run command directly
+fi
+
+
 # DIAGNOSTIC: Log every invocation regardless of mode
 
 # =========================================================================
@@ -294,7 +304,7 @@ if [[ "$GATE_MODE" == "PRE_MERGE" ]]; then
   # the PR's source branch to check review-status.json correctly.
   REPO_FOR_BRANCH=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||' || echo "")
   if [[ -n "$REPO_FOR_BRANCH" ]]; then
-    BRANCH=$(gh api "repos/${REPO_FOR_BRANCH}/pulls/${PR_NUMBER}" --jq '.head.ref' 2>/dev/null || echo "")
+    BRANCH=$(_timeout 10 gh api "repos/${REPO_FOR_BRANCH}/pulls/${PR_NUMBER}" --jq '.head.ref' 2>/dev/null || echo "")
   fi
   if [[ -z "$BRANCH" ]]; then
     BRANCH=$(current_branch)
@@ -303,12 +313,12 @@ if [[ "$GATE_MODE" == "PRE_MERGE" ]]; then
 
   # Check CI status
   REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||' || echo "")
-  HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha' 2>/dev/null || echo "")
+  HEAD_SHA=$(_timeout 10 gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha' 2>/dev/null || echo "")
 
   if [[ -n "$REPO" ]] && [[ -n "$HEAD_SHA" ]]; then
-    CI_FAILURES=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+    CI_FAILURES=$(_timeout 10 gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
       --jq '[.check_runs[] | select(.conclusion=="failure")] | length' 2>/dev/null || echo "0")
-    CI_PENDING=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+    CI_PENDING=$(_timeout 10 gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
       --jq '[.check_runs[] | select(.status!="completed")] | length' 2>/dev/null || echo "0")
 
     if [[ "$CI_FAILURES" -gt 0 ]]; then
@@ -601,15 +611,15 @@ if [[ "$GATE_MODE" == "VERIFY" ]] || [[ "${1:-}" == "VERIFY" ]]; then
   [ -z "$PR" ] && { echo "Usage: $0 VERIFY <PR_NUMBER>" >&2; exit 1; }
 
   REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||' || echo "")
-  HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha' 2>/dev/null || echo "")
+  HEAD_SHA=$(_timeout 10 gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha' 2>/dev/null || echo "")
   if [[ -z "$REPO" ]] || [[ -z "$HEAD_SHA" ]]; then
     echo "⚠️ PR #${PR}: リポジトリ/SHA取得失敗。手動確認してください。" >&2
     exit 1
   fi
 
-  CI_FAILURES=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+  CI_FAILURES=$(_timeout 10 gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
     --jq '[.check_runs[] | select(.conclusion=="failure")] | length' 2>/dev/null || echo "0")
-  CI_PENDING=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+  CI_PENDING=$(_timeout 10 gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
     --jq '[.check_runs[] | select(.status!="completed")] | length' 2>/dev/null || echo "0")
 
   if [[ "$CI_FAILURES" -gt 0 ]]; then
@@ -629,7 +639,7 @@ print(s.get(os.environ['_PR'], {}).get('branch', ''))
 
   # If branch not in lock state, try GitHub API
   if [[ -z "$BRANCH" ]]; then
-    BRANCH=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.ref' 2>/dev/null || echo "")
+    BRANCH=$(_timeout 10 gh api "repos/${REPO}/pulls/${PR}" --jq '.head.ref' 2>/dev/null || echo "")
   fi
 
   # Classify review tier
@@ -770,4 +780,4 @@ else:
 fi
 
 echo "Unknown GATE_MODE: $GATE_MODE" >&2
-exit 1
+exit 2

--- a/hooks/record-codex-review.sh
+++ b/hooks/record-codex-review.sh
@@ -27,20 +27,48 @@ write_codex_review() {
   [ ! -f "$target" ] && echo '{}' > "$target"
 
   if command -v jq &>/dev/null; then
-    local tmp
-    tmp=$(mktemp)
-    if jq --arg b "$BRANCH" --arg t "$NOW" \
-      '.[$b] = ((.[$b] // {}) + {"codex_review": true, "codex_review_at": $t})' \
-      "$target" > "$tmp" 2>/dev/null; then
-      mv "$tmp" "$target"
+    # Atomic read-modify-write with portable locking (Issue #129)
+    # macOS: use Python fcntl; Linux: use flock command
+    if command -v flock &>/dev/null; then
+      (
+        flock -x 200
+        local tmp
+        tmp=$(mktemp)
+        if jq --arg b "$BRANCH" --arg t "$NOW" \
+          '.[$b] = ((.[$b] // {}) + {"codex_review": true, "codex_review_at": $t})' \
+          "$target" > "$tmp" 2>/dev/null; then
+          mv "$tmp" "$target"
+        else
+          rm -f "$tmp"
+          echo '{}' > "$target"
+          tmp=$(mktemp)
+          jq --arg b "$BRANCH" --arg t "$NOW" \
+            '.[$b] = {"codex_review": true, "codex_review_at": $t}' \
+            "$target" > "$tmp" 2>/dev/null && mv "$tmp" "$target" || rm -f "$tmp"
+        fi
+      ) 200>"${target}.lock"
     else
-      rm -f "$tmp"
-      # Reset corrupted file and retry once
-      echo '{}' > "$target"
-      tmp=$(mktemp)
-      jq --arg b "$BRANCH" --arg t "$NOW" \
-        '.[$b] = {"codex_review": true, "codex_review_at": $t}' \
-        "$target" > "$tmp" 2>/dev/null && mv "$tmp" "$target" || rm -f "$tmp"
+      # macOS fallback: use Python fcntl.flock for locking + jq for transform
+      _STATE="$target" _BR="$BRANCH" _NOW="$NOW" python3 -c "
+import json, os, fcntl
+f_path = os.environ['_STATE']
+br = os.environ['_BR']
+now = os.environ['_NOW']
+with open(f_path, 'r+') as f:
+    fcntl.flock(f, fcntl.LOCK_EX)
+    try:
+        data = json.load(f)
+    except json.JSONDecodeError:
+        data = {}
+    if br not in data:
+        data[br] = {}
+    data[br]['codex_review'] = True
+    data[br]['codex_review_at'] = now
+    f.seek(0)
+    f.truncate()
+    json.dump(data, f, indent=2)
+    fcntl.flock(f, fcntl.LOCK_UN)
+" 2>/dev/null || true
     fi
   else
     _STATE="$target" _BR="$BRANCH" _NOW="$NOW" python3 -c "


### PR DESCRIPTION
## Summary

- **#120 (P0)**: stdout汚染→stderr修正, exit 1→exit 2
- **#129 (P1)**: portable `_timeout()` wrapper + flock macOS guard
- **#123 (P1)**: soak time updated_at→head commit committer.date
- **#122 (P1)**: GitHub Actions CI (shellcheck + syntax + JSON)

## Review fixes applied

- code-reviewer HIGH-1: flock macOS guard (command -v + Python fcntl fallback)
- code-reviewer HIGH-2: portable _timeout (timeout/gtimeout/direct fallback)
- Codex CLI P1: _timeout定義をpr-ci-review-gate.sh先頭に追加
- Codex CLI P2: committer.date制限をコメント文書化

## Test plan

- [x] bash -n 構文チェック: 全ファイル PASS
- [x] validate-hook-deployment.sh: 0 issues
- [x] ~/.claude/hooks/ インストール済み
- [ ] CI workflow発火確認

Closes #120, Closes #129, Closes #123, Closes #122
Refs #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)