### PR TITLE
feat: add factcheck enforcement for GitHub Issue/PR ops

### DIFF
--- a/hooks/enforce-factcheck-github-ops.sh
+++ b/hooks/enforce-factcheck-github-ops.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# enforce-factcheck-github-ops.sh
+# BLOCKING: gh issue/pr 操作前にファクトチェックを強制
+#
+# トリガー: PreToolUse:Bash (gh issue comment/create, gh pr create)
+# 目的: 外部に公開される情報（Issue コメント、PR 説明文）に
+#        未検証の事実が含まれないことを保証する
+#
+# 検出パターン:
+#   - gh issue comment / gh issue create
+#   - gh pr create
+#
+# ファクトチェック済みの判定:
+#   - factcheck-status.json の factchecked = true かつ有効期限内
+#
+# 例外:
+#   - gh issue close (クローズ操作自体は enforce-issue-close-verification.sh が担当)
+#   - gh issue list / gh issue view (読み取り操作)
+#   - gh pr merge / gh pr checks (マージ/確認操作)
+set -euo pipefail
+
+STATE_FILE="${HOME}/.claude/state/factcheck-status.json"
+
+input=$(cat)
+command=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+
+# gh issue/pr の書き込み操作のみ対象
+if ! echo "$command" | grep -qE 'gh (issue (comment|create)|pr create)'; then
+    exit 0
+fi
+
+# 読み取り操作は除外
+if echo "$command" | grep -qE 'gh (issue (list|view|close)|pr (list|view|merge|checks))'; then
+    exit 0
+fi
+
+# State file 存在チェック
+if [ ! -f "$STATE_FILE" ]; then
+    echo '{"factchecked": false, "source": "", "timestamp": 0, "edit_count_since_check": 0}' > "$STATE_FILE"
+fi
+
+factchecked=$(jq -r '.factchecked // false' "$STATE_FILE" 2>/dev/null || echo "false")
+timestamp=$(jq -r '.timestamp // 0' "$STATE_FILE" 2>/dev/null || echo "0")
+now=$(date +%s)
+
+# 有効期限: 10分
+expired=false
+if [ "$factchecked" = "true" ]; then
+    elapsed=$((now - timestamp))
+    if [ "$elapsed" -gt 600 ]; then
+        expired=true
+    fi
+fi
+
+if [ "$factchecked" = "false" ] || [ "$expired" = "true" ]; then
+    echo "🚫 [BLOCK] GitHub Issue/PR への書き込み前にファクトチェックが必要です。"
+    echo ""
+    echo "  検出コマンド: $(echo "$command" | head -c 100)..."
+    echo ""
+    echo "  外部に公開される情報には、検証済みの事実のみを含めてください。"
+    echo "  以下のいずれかを実行してからやり直してください:"
+    echo ""
+    echo "  1. gcloud / CLI コマンドで事実を確認"
+    echo "  2. WebSearch で公式ドキュメントを確認"
+    echo "  3. context7 でライブラリドキュメントを確認"
+    echo "  4. コードベースで grep/Read で実装を確認"
+    echo ""
+    echo "  ⚠️ 推測に基づくIssueコメントやPR説明文は禁止です。"
+    echo "  📋 インシデント事例: Issue #329 で「Generative Language API」の名称を"
+    echo "     GCPコンソールで検証せずに記載し、不正確な情報を投稿"
+    exit 2
+fi
+
+exit 0

--- a/hooks/enforce-factcheck-github-ops.sh
+++ b/hooks/enforce-factcheck-github-ops.sh
@@ -20,6 +20,13 @@
 set -euo pipefail
 
 STATE_FILE="${HOME}/.claude/state/factcheck-status.json"
+mkdir -p "$(dirname "$STATE_FILE")"
+
+# jq必須: fail-closed（jqなしでは判定不能 → ブロック）
+if ! command -v jq &>/dev/null; then
+    echo "[BLOCK] jq が見つかりません。ファクトチェック判定に必要です。" >&2
+    exit 2
+fi
 
 input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")

--- a/hooks/mark-factcheck-done.sh
+++ b/hooks/mark-factcheck-done.sh
@@ -33,10 +33,10 @@ case "$tool" in
         ;;
     Bash)
         # Bashはgcloud/kubectl/aws CLIコマンドの場合のみカウント（事実確認用）
+        # パターン1: コマンド先頭がCLIツール（単純実行）
+        # パターン2: パイプ/チェーン内のCLIツール（例: cd /tmp && gcloud services list）
         bash_command=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
-        if echo "$bash_command" | grep -qE '^(gcloud |kubectl |aws )'; then
-            source_name="CLI"
-        elif echo "$bash_command" | grep -qE '(gcloud |kubectl |aws ) .*(list|describe|get|show|info|services|projects)'; then
+        if echo "$bash_command" | grep -qE '(^|&&|\|\||;)\s*(gcloud|kubectl|aws) '; then
             source_name="CLI"
         fi
         ;;

--- a/hooks/mark-factcheck-done.sh
+++ b/hooks/mark-factcheck-done.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # mark-factcheck-done.sh
-# PostToolUse: context7/WebSearch/WebFetch/Read(docs) 使用後にファクトチェック済みフラグを立てる
+# PostToolUse: context7/WebSearch/WebFetch/Read(docs)/Bash(gcloud/kubectl/aws) 使用後にファクトチェック済みフラグを立てる
 set -euo pipefail
 
 STATE_FILE="${HOME}/.claude/state/factcheck-status.json"
@@ -29,6 +29,15 @@ case "$tool" in
         file_path=$(echo "$input" | jq -r '.tool_input.file_path // ""' 2>/dev/null || echo "")
         if echo "$file_path" | grep -qEi 'README|CLAUDE\.md|docs/|\.md$'; then
             source_name="DocRead"
+        fi
+        ;;
+    Bash)
+        # Bashはgcloud/kubectl/aws CLIコマンドの場合のみカウント（事実確認用）
+        bash_command=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+        if echo "$bash_command" | grep -qE '^(gcloud |kubectl |aws )'; then
+            source_name="CLI"
+        elif echo "$bash_command" | grep -qE '(gcloud |kubectl |aws ) .*(list|describe|get|show|info|services|projects)'; then
+            source_name="CLI"
         fi
         ;;
 esac

--- a/tests/enforce-factcheck-github-ops.test.sh
+++ b/tests/enforce-factcheck-github-ops.test.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Test: enforce-factcheck-github-ops.sh
+set -euo pipefail
+
+HOOK="hooks/enforce-factcheck-github-ops.sh"
+STATE_FILE="${HOME}/.claude/state/factcheck-status.json"
+
+# Ensure state directory exists
+mkdir -p "$(dirname "$STATE_FILE")"
+
+echo "=== Test: Block gh issue comment without factcheck ==="
+echo '{"factchecked": false, "source": "", "timestamp": 0, "edit_count_since_check": 0}' > "$STATE_FILE"
+result=$(echo '{"tool_input":{"command":"gh issue comment 329 --body \"test\""}}' | bash "$HOOK" 2>&1) || true
+if echo "$result" | grep -q "BLOCK"; then
+    echo "✅ PASS: Blocked gh issue comment without factcheck"
+else
+    echo "❌ FAIL: Did not block gh issue comment"
+    exit 1
+fi
+
+echo "=== Test: Allow gh issue comment with factcheck ==="
+now=$(date +%s)
+echo "{\"factchecked\": true, \"source\": \"gcloud\", \"timestamp\": $now, \"edit_count_since_check\": 0}" > "$STATE_FILE"
+result=$(echo '{"tool_input":{"command":"gh issue comment 329 --body \"test\""}}' | bash "$HOOK" 2>&1) || true
+if echo "$result" | grep -q "BLOCK"; then
+    echo "❌ FAIL: Blocked despite factcheck done"
+    exit 1
+else
+    echo "✅ PASS: Allowed gh issue comment with factcheck"
+fi
+
+echo "=== Test: Allow gh issue list (read operation) ==="
+echo '{"factchecked": false, "source": "", "timestamp": 0, "edit_count_since_check": 0}' > "$STATE_FILE"
+result=$(echo '{"tool_input":{"command":"gh issue list --state open"}}' | bash "$HOOK" 2>&1) || true
+if echo "$result" | grep -q "BLOCK"; then
+    echo "❌ FAIL: Blocked read-only operation"
+    exit 1
+else
+    echo "✅ PASS: Allowed read-only gh issue list"
+fi
+
+echo "=== Test: Block gh pr create without factcheck ==="
+echo '{"factchecked": false, "source": "", "timestamp": 0, "edit_count_since_check": 0}' > "$STATE_FILE"
+result=$(echo '{"tool_input":{"command":"gh pr create --title \"test\" --body \"test\""}}' | bash "$HOOK" 2>&1) || true
+if echo "$result" | grep -q "BLOCK"; then
+    echo "✅ PASS: Blocked gh pr create without factcheck"
+else
+    echo "❌ FAIL: Did not block gh pr create"
+    exit 1
+fi
+
+echo "=== Test: Block gh issue create without factcheck ==="
+echo '{"factchecked": false, "source": "", "timestamp": 0, "edit_count_since_check": 0}' > "$STATE_FILE"
+result=$(echo '{"tool_input":{"command":"gh issue create --title \"bug\" --body \"description\""}}' | bash "$HOOK" 2>&1) || true
+if echo "$result" | grep -q "BLOCK"; then
+    echo "✅ PASS: Blocked gh issue create without factcheck"
+else
+    echo "❌ FAIL: Did not block gh issue create"
+    exit 1
+fi
+
+echo "=== Test: Allow gh issue view (read operation) ==="
+echo '{"factchecked": false, "source": "", "timestamp": 0, "edit_count_since_check": 0}' > "$STATE_FILE"
+result=$(echo '{"tool_input":{"command":"gh issue view 329"}}' | bash "$HOOK" 2>&1) || true
+if echo "$result" | grep -q "BLOCK"; then
+    echo "❌ FAIL: Blocked read-only gh issue view"
+    exit 1
+else
+    echo "✅ PASS: Allowed read-only gh issue view"
+fi
+
+echo "=== Test: Allow non-gh commands ==="
+echo '{"factchecked": false, "source": "", "timestamp": 0, "edit_count_since_check": 0}' > "$STATE_FILE"
+result=$(echo '{"tool_input":{"command":"npm test"}}' | bash "$HOOK" 2>&1) || true
+if echo "$result" | grep -q "BLOCK"; then
+    echo "❌ FAIL: Blocked non-gh command"
+    exit 1
+else
+    echo "✅ PASS: Allowed non-gh command"
+fi
+
+echo "=== Test: Block when factcheck expired (>10 min) ==="
+expired_ts=$(($(date +%s) - 700))
+echo "{\"factchecked\": true, \"source\": \"WebSearch\", \"timestamp\": $expired_ts, \"edit_count_since_check\": 0}" > "$STATE_FILE"
+result=$(echo '{"tool_input":{"command":"gh issue comment 329 --body \"test\""}}' | bash "$HOOK" 2>&1) || true
+if echo "$result" | grep -q "BLOCK"; then
+    echo "✅ PASS: Blocked expired factcheck"
+else
+    echo "❌ FAIL: Did not block expired factcheck"
+    exit 1
+fi
+
+echo ""
+echo "All tests passed ✅"


### PR DESCRIPTION
## Summary
- GitHub Issue/PR への書き込み操作前にファクトチェックを強制する新しい hook を追加
- mark-factcheck-done.sh を更新し gcloud/kubectl/aws CLI コマンドもファクトチェックソースとして認識
- 8テストケースで検証済み

Closes #159

## Background
既存の enforce-factcheck-before-edit.sh は Write/Edit ツールのみを監視しているが、
gh コマンドは Bash ツール経由で実行されるため、ファクトチェックをバイパスできてしまう。

### インシデント
Issue #329 (creative-flow-studio) に「Generative Language API の有効化を確認」と記載したが、
GCPコンソールでは該当APIは「Gemini API」として表示される。
gcloud services list で事前検証していれば防げたミス。

## Changes
- hooks/enforce-factcheck-github-ops.sh -- 新規 hook (PreToolUse:Bash)
- hooks/mark-factcheck-done.sh -- Bash(gcloud/kubectl/aws) をファクトチェックソースに追加
- tests/enforce-factcheck-github-ops.test.sh -- テスト (8ケース)

## How it works
1. PreToolUse:Bash で gh issue comment/create または gh pr create を検出
2. factcheck state の状態を確認
3. ファクトチェック未実施 or 期限切れ（10分）の場合はブロック
4. 読み取り操作（gh issue list/view, gh pr list/view/merge）は除外
5. gcloud services list 等の CLI コマンド実行で factcheck フラグが自動的に立つ

## Code Review
- CRITICAL: 0, HIGH: 0, MEDIUM: 3 (all addressed in fix commit)
- mkdir -p 追加 (fresh machine対応)
- jq 可用性チェック追加 (fail-closed)
- CLI grep パターン簡素化

## Test plan
- [x] gh issue comment ブロックテスト
- [x] ファクトチェック済みでの許可テスト
- [x] gh issue list 読み取り除外テスト
- [x] gh pr create ブロックテスト
- [x] gh issue create ブロックテスト
- [x] gh issue view 読み取り除外テスト
- [x] 非gh コマンドの除外テスト
- [x] ファクトチェック期限切れブロックテスト


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * GitHub操作の検証レイヤーを追加し、特定の操作を実行する前に確認プロセスを強化しました

* **テスト**
  * 検証ロジックの信頼性を確保するための包括的なテストスイートを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->