### PR TITLE
fix: CI check tier order + CodeRabbit-only exclusion (#163)

### DIFF
--- a/hooks/block-merge-without-ci.sh
+++ b/hooks/block-merge-without-ci.sh
@@ -28,36 +28,56 @@ if [ -z "$PR_NUM" ]; then
     exit 2
 fi
 
-# Check CI status
+# Check CI status using commit-level check-runs API (not PR-level gh pr checks)
+# This avoids false blocking by review bots (CodeRabbit, etc.) that appear
+# as "pending" in PR checks but are not CI/CD jobs. Fixes #163 root cause.
 echo "[Merge Guard] PR #${PR_NUM} の CI/CD ステータスを確認中..." >&2
 
-CHECK_STATUS=$(_timeout 10 gh pr checks "$PR_NUM" 2>&1 || true)
+REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||' || echo "")
+HEAD_SHA=$(_timeout 10 gh api "repos/${REPO}/pulls/${PR_NUM}" --jq '.head.sha' 2>/dev/null || echo "")
 
-# Fail-closed: if CHECK_STATUS is empty (timeout or API failure), block merge
-if [ -z "$CHECK_STATUS" ]; then
-    echo "[BLOCK] PR #${PR_NUM} の CI/CD ステータスを取得できませんでした（タイムアウトまたはAPI障害）。fail-closed でブロックします。" >&2
+# Fail-closed: if HEAD_SHA is empty, block merge
+if [ -z "$HEAD_SHA" ] || [ -z "$REPO" ]; then
+    echo "[BLOCK] PR #${PR_NUM} の HEAD SHA を取得できませんでした（タイムアウトまたはAPI障害）。" >&2
     echo "  手動で確認してください: gh pr checks $PR_NUM" >&2
     exit 2
 fi
 
-# Check for failures
-if echo "$CHECK_STATUS" | grep -qi "fail\|error"; then
-    echo "[BLOCK] PR #${PR_NUM} の CI/CD にfailureがあります。オールグリーンになるまでマージ禁止。" >&2
-    echo "$CHECK_STATUS" >&2
+# Query commit-level check runs
+CHECK_RUNS=$(_timeout 10 gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" 2>/dev/null || echo "")
+
+if [ -z "$CHECK_RUNS" ]; then
+    echo "[BLOCK] PR #${PR_NUM} のチェック情報を取得できませんでした。fail-closed でブロックします。" >&2
     exit 2
 fi
 
-# Check for pending
-if echo "$CHECK_STATUS" | grep -qi "pending\|queued\|in_progress"; then
-    echo "[BLOCK] PR #${PR_NUM} の CI/CD がまだ実行中です。完了を待ってください。" >&2
-    echo "$CHECK_STATUS" >&2
-    exit 2
-fi
+# Exclude known non-CI review bots (CodeRabbit only).
+# Claude Review (GitHub Actions) is NOT excluded — it is a real CI check.
+# Pattern: case-insensitive match on "coderabbit" in check run name.
+EXCLUDED_PATTERN="coderabbit"
 
-# Check for no checks at all
-if echo "$CHECK_STATUS" | grep -qi "no checks"; then
-    echo "[BLOCK] PR #${PR_NUM} にCIチェックがありません。コンフリクトの可能性があります。" >&2
+CI_TOTAL=$(echo "$CHECK_RUNS" | jq --arg ex "$EXCLUDED_PATTERN" '[.check_runs[] | select(.name | test($ex; "i") | not)] | length' 2>/dev/null || echo "0")
+CI_FAILURES=$(echo "$CHECK_RUNS" | jq --arg ex "$EXCLUDED_PATTERN" '[.check_runs[] | select((.name | test($ex; "i") | not) and .conclusion=="failure")] | length' 2>/dev/null || echo "0")
+CI_PENDING=$(echo "$CHECK_RUNS" | jq --arg ex "$EXCLUDED_PATTERN" '[.check_runs[] | select((.name | test($ex; "i") | not) and .status!="completed")] | length' 2>/dev/null || echo "0")
+
+# No checks at all (after exclusion)
+if [ "$CI_TOTAL" -eq 0 ]; then
+    echo "[BLOCK] PR #${PR_NUM} にCIチェックがありません。" >&2
     echo "確認: gh pr view $PR_NUM --json mergeable,mergeStateStatus" >&2
+    exit 2
+fi
+
+# Check for failures (CodeRabbit excluded, Claude Review included)
+if [ "$CI_FAILURES" -gt 0 ]; then
+    FAILED_NAMES=$(echo "$CHECK_RUNS" | jq -r --arg ex "$EXCLUDED_PATTERN" '[.check_runs[] | select((.name | test($ex; "i") | not) and .conclusion=="failure") | .name] | join(", ")' 2>/dev/null || echo "unknown")
+    echo "[BLOCK] PR #${PR_NUM} の CI/CD に失敗あり ($CI_FAILURES 件: $FAILED_NAMES)。" >&2
+    exit 2
+fi
+
+# Check for pending (CodeRabbit excluded, Claude Review included)
+if [ "$CI_PENDING" -gt 0 ]; then
+    PENDING_NAMES=$(echo "$CHECK_RUNS" | jq -r --arg ex "$EXCLUDED_PATTERN" '[.check_runs[] | select((.name | test($ex; "i") | not) and .status!="completed") | .name] | join(", ")' 2>/dev/null || echo "unknown")
+    echo "[BLOCK] PR #${PR_NUM} の CI/CD がまだ実行中です ($CI_PENDING 件: $PENDING_NAMES)。" >&2
     exit 2
 fi
 

--- a/hooks/gate-modes/pre-merge.sh
+++ b/hooks/gate-modes/pre-merge.sh
@@ -49,10 +49,22 @@ if [[ -z "${BRANCH:-}" ]]; then
 fi
 [[ -z "$BRANCH" ]] && { echo "[WARN] Cannot determine branch. Blocking PR merge." >&2; exit 2; }
 
-# Check CI status
+# =========================================================================
+# Tier detection FIRST (before CI check) — fixes #163
+# EXEMPT tier must bypass CI failures to avoid chicken-and-egg problem
+# (e.g., ci/* branch fixing a broken workflow can't merge if that
+# workflow's CI failure blocks tier detection)
+# =========================================================================
 REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||' || echo "")
 HEAD_SHA=$(_timeout 10 gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha' 2>/dev/null || echo "")
+TIER=$(classify_review_tier "$BRANCH" "${PR_NUMBER:-}")
 
+if [[ "$TIER" == "EXEMPT" ]]; then
+  echo "✅ PR #${PR_NUMBER}: EXEMPT tier ($BRANCH). CIグリーンのみで許可。" >&2
+  exit 0
+fi
+
+# CI status check (non-EXEMPT tiers only)
 if [[ -n "$REPO" ]] && [[ -n "$HEAD_SHA" ]]; then
   CI_FAILURES=$(_timeout 10 gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
     --jq '[.check_runs[] | select(.conclusion=="failure")] | length' 2>/dev/null || echo "0")
@@ -67,19 +79,6 @@ if [[ -n "$REPO" ]] && [[ -n "$HEAD_SHA" ]]; then
     echo "🚫 [BLOCKED] CI に実行中ジョブあり ($CI_PENDING 件)。完了を待ってください。" >&2
     exit 2
   fi
-fi
-
-# =========================================================================
-# Tier detection via classify_review_tier (content-based)
-# EXEMPT: docs/chore/ci branches -> CI green only
-# LIGHT: config/docs file changes -> 3-pass OR (code-reviewer OR C/H=0 OR verified)
-# FULL: source code changes -> code-reviewer + Codex CLI required
-# =========================================================================
-TIER=$(classify_review_tier "$BRANCH" "${PR_NUMBER:-}")
-
-if [[ "$TIER" == "EXEMPT" ]]; then
-  echo "✅ PR #${PR_NUMBER}: EXEMPT tier ($BRANCH). CIグリーンのみで許可。" >&2
-  exit 0
 fi
 
 # =========================================================================


### PR DESCRIPTION
## Summary

Fixes two merge-blocking bugs discovered during Epic #130 stabilization.

### Bug 1: CI check before tier detection (Issue #163)
`pre-merge.sh` checked CI failures (L62) before tier classification (L78).
EXEMPT branches (`ci/*`, `docs/*`, `chore/*`) were blocked by CI failures
before reaching the EXEMPT bypass — chicken-and-egg problem for CI fix PRs.

**Fix**: Move `classify_review_tier()` before CI check. EXEMPT exits early.

### Bug 2: CodeRabbit pending blocks merge
`block-merge-without-ci.sh` used `gh pr checks` (PR-level) which includes
CodeRabbit as "pending". When CodeRabbit review takes long, all merges blocked.

**Fix**: Switch to commit-level `check-runs` API + explicit CodeRabbit exclusion.
Claude Review (GitHub Actions) is NOT excluded — only CodeRabbit is filtered out.

### Review
- code-reviewer: APPROVE (0 CRITICAL, 0 HIGH)

Fixes #163

## Test plan
- [ ] `ci/*` branch with failing CI can merge (EXEMPT tier bypass)
- [ ] CodeRabbit pending does not block merge
- [ ] Claude Review failure still blocks merge
- [ ] Non-CI commands still pass through


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * CI チェック処理をコミットレベルで実行するように改善し、より正確な検証を実現
  * 特定のチェック実行を除外する機能を追加
  * マージブロック条件を更新し、失敗または未完了のチェック状態をより確実に検出

* **Refactor**
  * マージゲーティングロジックの制御フローを最適化し、対象外ティアのチェック処理をスキップするよう改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->