### PR TITLE
fix: AI severity classification + context budget .sh tracking (#165, #167)

### DIFF
--- a/hooks/context-budget-edit-write-gate.sh
+++ b/hooks/context-budget-edit-write-gate.sh
@@ -91,7 +91,7 @@ transcript_path = os.environ.get("TRANSCRIPT_PATH", "")
 
 source_exts = {'.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs', '.swift',
                '.kt', '.java', '.rb', '.php', '.vue', '.svelte', '.css',
-               '.scss', '.sql', '.prisma', '.graphql'}
+               '.scss', '.sql', '.prisma', '.graphql', '.sh'}  # Issue #167: added .sh
 
 exempt_patterns = [
     '/.claude/', '/node_modules/', '/memory/', 'CLAUDE.md', 'MEMORY.md',

--- a/hooks/context-budget-read-gate.sh
+++ b/hooks/context-budget-read-gate.sh
@@ -115,7 +115,7 @@ file_path = os.environ['_FILE']
 now = os.environ['_NOW']
 
 # Only track source code files
-source_exts = {'.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs', '.swift', '.kt', '.java', '.rb', '.php', '.vue', '.svelte', '.css', '.scss', '.sql', '.prisma', '.graphql'}
+source_exts = {'.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs', '.swift', '.kt', '.java', '.rb', '.php', '.vue', '.svelte', '.css', '.scss', '.sql', '.prisma', '.graphql', '.sh'}  # Issue #167: added .sh
 ext = os.path.splitext(file_path)[1].lower()
 if ext not in source_exts:
     sys.exit(0)

--- a/hooks/enforce-review-reading.sh
+++ b/hooks/enforce-review-reading.sh
@@ -33,8 +33,14 @@ print(json.dumps(d))
 " 2>/dev/null || echo "{}")
 
 TOTAL=$(echo "$REVIEW_DATA" | jq -r '.total // 0' 2>/dev/null || echo "0")
-CRITICAL=$(echo "$REVIEW_DATA" | jq -r '.critical // 0' 2>/dev/null || echo "0")
-HIGH=$(echo "$REVIEW_DATA" | jq -r '.high // 0' 2>/dev/null || echo "0")
+CLASSIFICATION_METHOD=$(echo "$REVIEW_DATA" | jq -r '.classification_method // "regex"' 2>/dev/null || echo "regex")
+if [[ "$CLASSIFICATION_METHOD" == "ai" ]]; then
+  CRITICAL=$(echo "$REVIEW_DATA" | jq -r '.ai_classification.critical // 0' 2>/dev/null || echo "0")
+  HIGH=$(echo "$REVIEW_DATA" | jq -r '.ai_classification.high // 0' 2>/dev/null || echo "0")
+else
+  CRITICAL=$(echo "$REVIEW_DATA" | jq -r '.critical // 0' 2>/dev/null || echo "0")
+  HIGH=$(echo "$REVIEW_DATA" | jq -r '.high // 0' 2>/dev/null || echo "0")
+fi
 PR=$(echo "$REVIEW_DATA" | jq -r '.pr // ""' 2>/dev/null || echo "")
 
 [[ "$TOTAL" -eq 0 ]] && exit 0

--- a/hooks/gate-modes/pre-merge.sh
+++ b/hooks/gate-modes/pre-merge.sh
@@ -103,8 +103,15 @@ if [[ -f "$PENDING_FILE" ]] && command -v jq &>/dev/null; then
   _head_sha_in_file=$(jq -r '.head_sha // ""' "$PENDING_FILE" 2>/dev/null || echo "")
   # Validate scope: pending-review-comments must match current PR
   if [[ "$_pr_in_file" == "$PR_NUMBER" ]] && [[ -n "$HEAD_SHA" ]] && [[ "$_head_sha_in_file" == "$HEAD_SHA" ]]; then
-    _critical=$(jq -r '.critical // 0' "$PENDING_FILE" 2>/dev/null || echo "0")
-    _high=$(jq -r '.high // 0' "$PENDING_FILE" 2>/dev/null || echo "0")
+    # Issue #165: Check classification_method — prefer AI classification if available
+    _method=$(jq -r '.classification_method // "regex"' "$PENDING_FILE" 2>/dev/null || echo "regex")
+    if [[ "$_method" == "ai" ]]; then
+      _critical=$(jq -r '.ai_classification.critical // 0' "$PENDING_FILE" 2>/dev/null || echo "0")
+      _high=$(jq -r '.ai_classification.high // 0' "$PENDING_FILE" 2>/dev/null || echo "0")
+    else
+      _critical=$(jq -r '.critical // 0' "$PENDING_FILE" 2>/dev/null || echo "0")
+      _high=$(jq -r '.high // 0' "$PENDING_FILE" 2>/dev/null || echo "0")
+    fi
     _total=$(jq -r '.total // 0' "$PENDING_FILE" 2>/dev/null || echo "0")
     if [[ "$_critical" -eq 0 ]] && [[ "$_high" -eq 0 ]] && [[ "$_total" -gt 0 ]]; then
       PASS_B="yes"

--- a/hooks/gate-modes/verify.sh
+++ b/hooks/gate-modes/verify.sh
@@ -64,8 +64,15 @@ else
       if [[ -f "$pf" ]] && command -v jq &>/dev/null; then
         PR_MATCH=$(jq -r --arg p "$PR" '.pr // ""' "$pf" 2>/dev/null)
         PENDING_HEAD_SHA=$(jq -r '.head_sha // ""' "$pf" 2>/dev/null)
-        CR=$(jq -r '.critical // 0' "$pf" 2>/dev/null)
-        HI=$(jq -r '.high // 0' "$pf" 2>/dev/null)
+        # Issue #165: Check classification_method — prefer AI classification
+        _vmethod=$(jq -r '.classification_method // "regex"' "$pf" 2>/dev/null || echo "regex")
+        if [[ "$_vmethod" == "ai" ]]; then
+          CR=$(jq -r '.ai_classification.critical // 0' "$pf" 2>/dev/null)
+          HI=$(jq -r '.ai_classification.high // 0' "$pf" 2>/dev/null)
+        else
+          CR=$(jq -r '.critical // 0' "$pf" 2>/dev/null)
+          HI=$(jq -r '.high // 0' "$pf" 2>/dev/null)
+        fi
         if [[ "$PR_MATCH" == "$PR" ]] && [[ -n "$HEAD_SHA" ]] && [[ "$PENDING_HEAD_SHA" == "$HEAD_SHA" ]] && [[ "$CR" == "0" ]] && [[ "$HI" == "0" ]]; then
           CODE_REVIEW="yes"
           echo "  ℹ️ claude-review CRITICAL/HIGH=0 → code_review=yes として扱う" >&2

--- a/hooks/inject-claude-review-helper.py
+++ b/hooks/inject-claude-review-helper.py
@@ -30,6 +30,9 @@ class ReviewSummary:
     issue_comments: list = field(default_factory=list)
     has_claude_review: bool = False
     has_any_review: bool = False
+    raw_comments: list = field(
+        default_factory=list
+    )  # Issue #165: raw data for AI classification
     head_sha: str = ""  # Issue #66 Fix #5: track HEAD SHA for scope validation
 
 
@@ -60,24 +63,85 @@ def gh_api_list(path: str) -> list:
     return result if isinstance(result, list) else []
 
 
-def count_severity(text: str) -> tuple[int, int, int, int]:
-    """Count severity markers in text.
+def _strip_negation_lines(text: str) -> str:
+    """Remove lines/phrases that mention severity keywords in negation context.
 
-    Detects both traditional keywords (CRITICAL, HIGH, etc.) and
-    claude-review header format (### Bug:, ### Security:, etc.).
+    Issue #165: "No CRITICAL/HIGH issues" was counted as CRITICAL=1 HIGH=1.
+    This function strips negation-context lines BEFORE severity counting.
+    """
+    negation_patterns = [
+        r"(?i)no\s+critical",
+        r"(?i)no\s+high",
+        r"(?i)no\s+critical/high",
+        r"(?i)critical[=/]high\s*(?:issues?|findings?|指摘)?\s*(?::|=|なし|ゼロ|0)",
+        r"(?i)critical\s*=\s*0",
+        r"(?i)high\s*=\s*0",
+        r"(?i)0\s+critical",
+        r"(?i)0\s+high",
+        r"(?i)critical.*(?:free|なし|ありません|ゼロ|0件)",
+        r"(?i)high.*(?:free|なし|ありません|ゼロ|0件)",
+        r"(?i)no\s+(?:bug|warning|suggestion)",
+    ]
+    lines = text.split("\n")
+    filtered = []
+    for line in lines:
+        if any(re.search(p, line) for p in negation_patterns):
+            continue
+        filtered.append(line)
+    return "\n".join(filtered)
+
+
+def count_severity(text: str) -> tuple[int, int, int, int]:
+    """Count severity markers in text using structured patterns.
+
+    Issue #165: Replaced bare keyword matching (\\bcritical\\b) with
+    structured severity-prefix patterns to eliminate false positives.
+    Aligned with block-merge-without-review.sh patterns (PR #166).
+
+    Detects:
+    - Structured patterns: [CRITICAL], severity: CRITICAL, **CRITICAL**, etc.
+    - claude-review header format: ### Bug:, ### Security:, etc.
     Issue #57: claude-review uses header format that was previously undetected.
-    Issue #84: Strip HTML details/summary and bot metadata before counting
-    to prevent false positives from CodeRabbit template text.
+    Issue #84: Strip HTML details/summary and bot metadata before counting.
     """
     # Strip HTML blocks and comments to avoid false positives from bot metadata
     cleaned = re.sub(r"<details>.*?</details>", "", text, flags=re.DOTALL)
     cleaned = re.sub(r"<!--.*?-->", "", cleaned, flags=re.DOTALL)
     cleaned = re.sub(r"<[^>]+>", "", cleaned)
 
-    critical = len(re.findall(r"(?i)\bcritical\b", cleaned))
-    high = len(re.findall(r"(?i)\b(?:P1|high)\b", cleaned))
-    warning = len(re.findall(r"(?i)\bwarning\b", cleaned))
-    suggestion = len(re.findall(r"(?i)\bsuggestion\b", cleaned))
+    # Issue #165: Strip negation-context lines before counting
+    cleaned = _strip_negation_lines(cleaned)
+
+    # Issue #165: Use structured severity-prefix patterns instead of bare keywords
+    # Aligned with block-merge-without-review.sh L100 (PR #166)
+    critical = len(
+        re.findall(
+            r"(?i)\[CRITICAL\]|severity:\s*CRITICAL|\*\*CRITICAL\*\*|^\s*CRITICAL:|>\s*CRITICAL",
+            cleaned,
+            re.MULTILINE,
+        )
+    )
+    high = len(
+        re.findall(
+            r"(?i)\[HIGH\]|severity:\s*HIGH|\*\*HIGH\*\*|^\s*HIGH[:\s-]|>\s*HIGH|\bP1\b",
+            cleaned,
+            re.MULTILINE,
+        )
+    )
+    warning = len(
+        re.findall(
+            r"(?i)\[WARNING\]|severity:\s*WARNING|\*\*WARNING\*\*|^\s*WARNING:",
+            cleaned,
+            re.MULTILINE,
+        )
+    )
+    suggestion = len(
+        re.findall(
+            r"(?i)\[SUGGESTION\]|severity:\s*SUGGESTION|\*\*SUGGESTION\*\*|^\s*SUGGESTION:",
+            cleaned,
+            re.MULTILINE,
+        )
+    )
 
     # claude-review (Claude Sonnet 4.6) header format
     high += len(re.findall(r"###\s*Bug:", text))
@@ -172,6 +236,24 @@ def fetch_reviews(repo: str, pr: str) -> ReviewSummary:
         count_severity(all_text)
     )
 
+    # Issue #165: Store raw comments for AI classification skill
+    for c in summary.inline_comments:
+        summary.raw_comments.append(
+            {
+                "user": c.get("user", "?"),
+                "body_preview": c.get("body", "")[:500],
+                "source": "inline",
+            }
+        )
+    for c in summary.issue_comments:
+        summary.raw_comments.append(
+            {
+                "user": c.get("user", "?"),
+                "body_preview": c.get("body", "")[:500],
+                "source": "issue_comment",
+            }
+        )
+
     if summary.total > 0:
         summary.has_any_review = True
 
@@ -232,10 +314,18 @@ def format_output(repo: str, pr: str, summary: ReviewSummary) -> str:
         lines.append("")
 
     if summary.critical > 0 or summary.high > 0:
+        lines.append("")
+        lines.append("⚠️ REGEX分類による検出です（偽陽性の可能性あり）。")
+        lines.append(
+            f"/classify-review {pr} を実行して Haiku AI による偽陽性チェックを行ってください。"
+        )
+        lines.append("AI が全て偽陽性と判定した場合のみ、マージゲートは解除されます。")
+        lines.append("本物の指摘が1つでもあればブロックは維持されます。")
+        lines.append("")
         lines.append("次のアクション:")
-        lines.append("  1. 上記CRITICAL/HIGH指摘を全て修正")
-        lines.append("  2. 修正push後、再度 gh pr checks で確認")
-        lines.append(f"  3. 全コメント再確認: gh api repos/{repo}/pulls/{pr}/comments")
+        lines.append(f"  1. /classify-review {pr} を実行（AI偽陽性チェック）")
+        lines.append("  2. 本物の指摘があれば修正")
+        lines.append("  3. 修正push後、再度 gh pr checks で確認")
     else:
         lines.append("CRITICAL/HIGH指摘なし。MEDIUM以下はfollow-up可。")
 
@@ -274,6 +364,7 @@ def main() -> None:
     pending_file = os.path.join(state_dir, "pending-review-comments.json")
 
     # Issue #66 Fix #5: Include head_sha for scope validation
+    # Issue #165: Include raw_comments + classification_method for AI skill
     # Consumers validate that state matches current PR/SHA before trusting it.
     with open(pending_file, "w") as f:
         json.dump(
@@ -285,6 +376,9 @@ def main() -> None:
                 "critical": summary.critical,
                 "high": summary.high,
                 "output": output,
+                "classification_method": "regex",
+                "raw_comments": summary.raw_comments,
+                "ai_classification": None,
             },
             f,
             indent=2,

--- a/hooks/inject-claude-review-on-checks.sh
+++ b/hooks/inject-claude-review-on-checks.sh
@@ -69,16 +69,37 @@ fi
 if echo "$(echo "$cmd" | head -1)" | grep -qE 'gh\s+pr\s+merge'; then
   if [[ -f "$PENDING_FILE" ]]; then
     REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||' || echo "")
-    CRITICAL=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
+    # Issue #165: Check classification_method — prefer AI classification if available
+    CLASSIFICATION_METHOD=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
+import json, os
+with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
+print(d.get('classification_method', 'regex'))
+" 2>/dev/null || echo "regex")
+    if [[ "$CLASSIFICATION_METHOD" == "ai" ]]; then
+      CRITICAL=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
+import json, os
+with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
+ai = d.get('ai_classification') or {}
+print(ai.get('critical', d.get('critical', 0)))
+" 2>/dev/null || echo "0")
+      HIGH=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
+import json, os
+with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
+ai = d.get('ai_classification') or {}
+print(ai.get('high', d.get('high', 0)))
+" 2>/dev/null || echo "0")
+    else
+      CRITICAL=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
 import json, os
 with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
 print(d.get('critical', 0))
 " 2>/dev/null || echo "0")
-    HIGH=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
+      HIGH=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
 import json, os
 with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
 print(d.get('high', 0))
 " 2>/dev/null || echo "0")
+    fi
     PR=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
 import json, os
 with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
@@ -124,11 +145,25 @@ import json, os
 with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
 print(d.get('total', 0))
 " 2>/dev/null || echo "0")
-  CRITICAL=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
+  CLASSIFICATION_METHOD=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
+import json, os
+with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
+print(d.get('classification_method', 'regex'))
+" 2>/dev/null || echo "regex")
+  if [[ "$CLASSIFICATION_METHOD" == "ai" ]]; then
+    CRITICAL=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
+import json, os
+with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
+ai = d.get('ai_classification') or {}
+print(ai.get('critical', d.get('critical', 0)))
+" 2>/dev/null || echo "0")
+  else
+    CRITICAL=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
 import json, os
 with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
 print(d.get('critical', 0))
 " 2>/dev/null || echo "0")
+  fi
 
   if [[ "$TOTAL" -gt 0 ]] && [[ "$CRITICAL" -gt 0 ]]; then
     PR=$(_PENDING_FILE="$PENDING_FILE" python3 -c "

--- a/hooks/mark-factcheck-done.sh
+++ b/hooks/mark-factcheck-done.sh
@@ -21,6 +21,9 @@ case "$tool" in
     WebFetch)
         source_name="WebFetch"
         ;;
+    Grep)
+        source_name="CodeGrep"
+        ;;
     mcp__claude_ai_Vercel__search_vercel_documentation)
         source_name="VercelDocs"
         ;;

--- a/skills/classify-review/SKILL.md
+++ b/skills/classify-review/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: classify-review
+description: "PR review severity を Haiku AI で再分類。regex 偽陽性を除外する片方向ゲート。/classify-review [PR番号] で実行。regex が CRITICAL/HIGH 検出した際の偽陽性チェック専用。"
+user-invocable: true
+argument-hint: "[PR番号]"
+allowed-tools: [Read, Write, Bash, Grep, Agent]
+---
+
+# /classify-review — AI Severity Re-classification (False Positive Filter)
+
+regex ベースの severity 検出が CRITICAL/HIGH を報告した際に、Haiku AI で偽陽性かどうかを判定する。
+
+## 設計原則: 片方向ゲート (fail-closed)
+
+- AI は severity を**下げる方向にのみ**動ける（偽陽性の除外）
+- AI が severity を**上げることはない**
+- 不確実な場合は**ブロック維持**（安全側に倒す）
+- 全判定は reasoning 付きでログ
+
+## 実行手順
+
+### Step 1: State File 読み取り
+
+`.claude/state/pending-review-comments.json` を Read する。
+なければ `~/.claude/state/pending-review-comments.json` を試す。
+
+必須フィールド: `pr`, `critical`, `high`, `raw_comments`, `head_sha`
+
+### Step 2: 分類が必要か判定
+
+- `critical == 0` AND `high == 0` の場合 → 「偽陽性なし。分類不要。」と報告して終了
+- `raw_comments` が空の場合 → 「コメントデータなし。分類不要。」と報告して終了
+
+### Step 3: Haiku サブエージェントで偽陽性判定
+
+regex が CRITICAL/HIGH を検出したコメントのみを Haiku に提示する。
+以下のように Agent tool を使用:
+
+```
+Agent(
+  model="haiku",
+  subagent_type="general-purpose",
+  prompt="""
+あなたはコードレビューコメントの severity 分類器です。
+以下のコメントが REGEX パターンマッチで CRITICAL または HIGH として検出されました。
+各コメントについて、これが「本物のコード品質/セキュリティ指摘」か「偽陽性」かを判定してください。
+
+## 判定基準
+
+「本物の指摘」(real):
+- コードの実際のバグ、脆弱性、データ損失リスクを報告している
+- 具体的なファイル名・行番号・問題の説明がある
+- [CRITICAL], **HIGH**, severity: CRITICAL 等の構造化マーカー付きの指摘
+
+「偽陽性」(false_positive):
+- 否定文脈: "No CRITICAL issues", "CRITICAL=0", "0 HIGH findings"
+- メタ言及: "CRITICALの検出パターンを追加", "severity検出ロジック"
+- ボットテンプレート/メタデータ: CodeRabbit の HTML テンプレート
+- 承認メッセージ: "LGTM", "Approved for merge"
+- サマリー: "No actionable comments were generated"
+
+不明な場合は必ず「本物の指摘」(real) として扱ってください。
+
+## コメント一覧
+{raw_comments の内容をここに展開}
+
+## 出力形式
+各コメントに対して以下の JSON を返してください:
+[
+  { "index": 0, "user": "...", "verdict": "real" | "false_positive", "reasoning": "判定理由を1文で" },
+  ...
+]
+"""
+)
+```
+
+### Step 4: 判定結果で State File 更新
+
+Haiku の判定結果に基づいて `pending-review-comments.json` を Write で更新:
+
+1. `classification_method` を `"ai"` に変更
+2. 偽陽性と判定されたコメントの severity カウントを除外して再計算
+3. 「本物」「不明」のコメントの severity はそのまま維持
+4. `ai_classification` ブロックに詳細を格納:
+
+```json
+{
+  "ai_classification": {
+    "critical": 0,
+    "high": 0,
+    "classified_at": "2026-03-27T...",
+    "classified_by": "haiku",
+    "verdicts": [
+      { "index": 0, "user": "terisuke", "verdict": "false_positive", "reasoning": "承認メッセージ。否定文脈で CRITICAL/HIGH を言及しているだけ" }
+    ]
+  }
+}
+```
+
+5. トップレベルの `critical`/`high` も AI 判定結果で更新（下流 consumer との互換性維持）
+
+### Step 5: 結果報告
+
+分類結果のサマリーを出力:
+
+```
+## /classify-review 結果 (PR #XX)
+
+| # | User | Regex判定 | AI判定 | 理由 |
+|---|------|----------|--------|------|
+| 1 | @terisuke | CRITICAL | false_positive | 承認メッセージ内の否定文脈 |
+
+Regex: CRITICAL=1 HIGH=1 → AI: CRITICAL=0 HIGH=0
+State file 更新済み。マージゲートは解除されます。
+```
+
+## 安全性保証
+
+- Haiku が 1 つでも `"real"` と判定 → その severity はカウント維持 → ブロック維持
+- Haiku が判定不能/エラー → 全て `"real"` 扱い → ブロック維持
+- `head_sha` が変わったら AI 分類は無効（push 後は再分類必要）
+- 全判定に `reasoning` ログ → 事後監査可能


### PR DESCRIPTION
## Summary

- **Issue #165**: `inject-claude-review-helper.py` の `count_severity()` がbare keyword regex (`\bcritical\b`) で偽陽性を発生させていた問題を修正。構造化パターン + 否定文脈フィルタリングに置換。さらに Haiku AI による偽陽性判定スキル `/classify-review` を新規作成し、片方向ゲート（severity下方修正のみ）で安全にマージゲートを解除可能に
- **Issue #167**: `context-budget-read-gate.sh` と `context-budget-edit-write-gate.sh` の `source_exts` に `.sh` が欠落。本プロジェクトの主要ソースコード60ファイルが追跡対象外だった。併せて `mark-factcheck-done.sh` に Grep ハンドラを追加

## Changes (7 files, +279/-19)

| File | Change |
|------|--------|
| `hooks/inject-claude-review-helper.py` | `count_severity()` 構造化regex化 + `_strip_negation_lines()` 追加 + state file拡張 (`classification_method`, `raw_comments`, `ai_classification`) + additionalContext に `/classify-review` 指示 |
| `hooks/inject-claude-review-on-checks.sh` | MODE 2/3 で `classification_method=ai` 優先読み取り |
| `hooks/enforce-review-reading.sh` | 同上 |
| `skills/classify-review/SKILL.md` | Haiku AI 偽陽性判定スキル（新規） |
| `hooks/context-budget-read-gate.sh` | `.sh` を `source_exts` に追加 |
| `hooks/context-budget-edit-write-gate.sh` | 同上 |
| `hooks/mark-factcheck-done.sh` | `Grep` ハンドラ追加 |

## Test plan

- [x] `count_severity()` 15テストケース全PASS（偽陽性ゼロ + 本物の指摘検出維持）
- [x] `_strip_negation_lines()` が否定文脈を除去しつつ本物の指摘を保持
- [x] `setup.sh` でデプロイ成功（`classify-review` スキル登録確認）
- [ ] CI green 確認
- [ ] `/classify-review` スキルの手動実行テスト（次セッション）

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * /classify-review コマンドで AI による再分類を実行し、誤検出を除外して状態を更新。

* **改善**
  * 正規表現ベースの重大度検出精度向上（否定文の除外・構造化マッチング）。
  * AI分類結果を利用する運用フローを追加（表示・ゲート条件に反映）。
  * シェルスクリプト（.sh）をソースカウント対象に追加。
  * 新たに CodeGrep ツールを事実確認済みとして記録。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->