### PR TITLE
fix: Wave 2 — severity dedup, negation gap, anti-quit injection (#169, #170, #171)

### DIFF
--- a/hooks/context-budget-edit-write-gate.sh
+++ b/hooks/context-budget-edit-write-gate.sh
@@ -176,6 +176,7 @@ if [[ "$COUNT" -ge 4 ]]; then
   echo "  → bash ~/.claude/scripts/codex-parallel.sh <repo> <branch> \"<prompt>\"" >&2
   echo "  読み込み済みファイル: ${FILES//|/, }" >&2
   echo "  例外: mode=planning に変更可（bash ~/.claude/hooks/context-budget-set-mode.sh planning）" >&2
+  echo "  ℹ️ サブエージェント (CLAUDE_AGENT_DEPTH>=1) はこのゲートを免除されています。Agent tool で委任してください。" >&2
   exit 2
 elif [[ "$COUNT" -ge 3 ]]; then
   echo "⚠️ [CONTEXT BUDGET WARNING] ソースコード${COUNT}ファイル読み込み済み。次のEditでブロックされます。" >&2
@@ -188,6 +189,7 @@ if [[ "$EDIT_COUNT" -ge 8 ]]; then
   echo "🚫 [BULK EDIT BLOCK] ${EDIT_COUNT}回のEdit/Write実行済み。機械的な一括変更はCodexに委任してください。" >&2
   echo "  → bash ~/.claude/scripts/codex-parallel.sh <repo> <branch> \"<prompt>\"" >&2
   echo "  2+ 独立タスクの場合は Agent Team (TeamCreate) を使用。" >&2
+  echo "  ℹ️ サブエージェント (CLAUDE_AGENT_DEPTH>=1) はこのゲートを免除されています。Agent tool で委任してください。" >&2
   exit 2
 elif [[ "$EDIT_COUNT" -ge 5 ]]; then
   echo "⚠️ [BULK EDIT WARNING] ${EDIT_COUNT}回のEdit/Write実行済み。同じパターンの繰り返しならCodex委任を検討。" >&2

--- a/hooks/context-budget-read-gate.sh
+++ b/hooks/context-budget-read-gate.sh
@@ -147,6 +147,7 @@ if count == 3:
 elif count >= 4:
     print("🚫 [BLOCK] ソースコード{}ファイル読み込み。強制停止。Codex CLI 経路C に委任してください。".format(count), file=sys.stderr)
     print("  → 対話的判断が必要な場合のみ mode=planning に変更可", file=sys.stderr)
+    print("  ℹ️ サブエージェント (CLAUDE_AGENT_DEPTH>=1) はこのゲートを免除されています。Agent tool で委任してください。", file=sys.stderr)
     sys.exit(2)
 
 PYEOF

--- a/hooks/inject-claude-review-helper.py
+++ b/hooks/inject-claude-review-helper.py
@@ -81,6 +81,8 @@ def _strip_negation_lines(text: str) -> str:
         r"(?i)critical.*(?:free|なし|ありません|ゼロ|0件)",
         r"(?i)high.*(?:free|なし|ありません|ゼロ|0件)",
         r"(?i)no\s+(?:bug|warning|suggestion)",
+        r"(?i)critical\s+\w+.*:\s*0\s*$",
+        r"(?i)high\s+\w+.*:\s*0\s*$",
     ]
     lines = text.split("\n")
     filtered = []

--- a/hooks/inject-claude-review-on-checks.sh
+++ b/hooks/inject-claude-review-on-checks.sh
@@ -23,6 +23,22 @@ fi
 mkdir -p "$STATE_DIR"
 PENDING_FILE="$STATE_DIR/pending-review-comments.json"
 
+# Issue #169: Shared severity reader — replaces duplicated python3 one-liners
+_read_severity() {
+  local file="$1"
+  _PENDING_FILE="$file" python3 -c "
+import json, os
+with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
+ai = d.get('ai_classification') or {}
+method = d.get('classification_method', 'regex')
+if method == 'ai':
+    c, h = ai.get('critical', d.get('critical', 0)), ai.get('high', d.get('high', 0))
+else:
+    c, h = d.get('critical', 0), d.get('high', 0)
+print(f'{c}|{h}|{d.get(\"pr\", \"\")}|{d.get(\"head_sha\", \"\")}|{d.get(\"total\", 0)}|{method}')
+" 2>/dev/null || echo "0|0|||0|regex"
+}
+
 input=""
 [[ ! -t 0 ]] && input=$(cat)
 cmd=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
@@ -69,47 +85,8 @@ fi
 if echo "$(echo "$cmd" | head -1)" | grep -qE 'gh\s+pr\s+merge'; then
   if [[ -f "$PENDING_FILE" ]]; then
     REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||' || echo "")
-    # Issue #165: Check classification_method — prefer AI classification if available
-    CLASSIFICATION_METHOD=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
-import json, os
-with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
-print(d.get('classification_method', 'regex'))
-" 2>/dev/null || echo "regex")
-    if [[ "$CLASSIFICATION_METHOD" == "ai" ]]; then
-      CRITICAL=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
-import json, os
-with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
-ai = d.get('ai_classification') or {}
-print(ai.get('critical', d.get('critical', 0)))
-" 2>/dev/null || echo "0")
-      HIGH=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
-import json, os
-with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
-ai = d.get('ai_classification') or {}
-print(ai.get('high', d.get('high', 0)))
-" 2>/dev/null || echo "0")
-    else
-      CRITICAL=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
-import json, os
-with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
-print(d.get('critical', 0))
-" 2>/dev/null || echo "0")
-      HIGH=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
-import json, os
-with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
-print(d.get('high', 0))
-" 2>/dev/null || echo "0")
-    fi
-    PR=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
-import json, os
-with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
-print(d.get('pr', ''))
-" 2>/dev/null || echo "")
-    PENDING_HEAD_SHA=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
-import json, os
-with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
-print(d.get('head_sha', ''))
-" 2>/dev/null || echo "")
+    # Issue #169: Use shared severity reader instead of duplicated python3 one-liners
+    IFS='|' read -r CRITICAL HIGH PR PENDING_HEAD_SHA _TOTAL _METHOD <<< "$(_read_severity "$PENDING_FILE")"
 
     if [[ -n "$REPO" ]] && [[ -n "$PR" ]] && [[ -n "$PENDING_HEAD_SHA" ]]; then
       CURRENT_HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha' 2>/dev/null || echo "")
@@ -140,38 +117,11 @@ if echo "$(echo "$cmd" | head -1)" | grep -qE '^(git |ls |cat |echo |python3 |he
 fi
 
 if [[ -f "$PENDING_FILE" ]]; then
-  TOTAL=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
-import json, os
-with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
-print(d.get('total', 0))
-" 2>/dev/null || echo "0")
-  CLASSIFICATION_METHOD=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
-import json, os
-with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
-print(d.get('classification_method', 'regex'))
-" 2>/dev/null || echo "regex")
-  if [[ "$CLASSIFICATION_METHOD" == "ai" ]]; then
-    CRITICAL=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
-import json, os
-with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
-ai = d.get('ai_classification') or {}
-print(ai.get('critical', d.get('critical', 0)))
-" 2>/dev/null || echo "0")
-  else
-    CRITICAL=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
-import json, os
-with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
-print(d.get('critical', 0))
-" 2>/dev/null || echo "0")
-  fi
+  # Issue #169: Use shared severity reader instead of duplicated python3 one-liners
+  IFS='|' read -r CRITICAL _HIGH _PR _SHA TOTAL _METHOD <<< "$(_read_severity "$PENDING_FILE")"
 
   if [[ "$TOTAL" -gt 0 ]] && [[ "$CRITICAL" -gt 0 ]]; then
-    PR=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
-import json, os
-with open(os.environ['_PENDING_FILE']) as f: d = json.load(f)
-print(d.get('pr', ''))
-" 2>/dev/null || echo "")
-    echo "[REMINDER] PR #${PR}: ${TOTAL}件のレビューコメント（CRITICAL=${CRITICAL}）が未対応です。" >&2
+    echo "[REMINDER] PR #${_PR}: ${TOTAL}件のレビューコメント（CRITICAL=${CRITICAL}）が未対応です。" >&2
   fi
 fi
 


### PR DESCRIPTION
## Summary

- **#169**: `inject-claude-review-on-checks.sh` の severity 読み取りコード重複を `_read_severity()` 共通関数に抽出。python3 サブプロセス呼び出しをモードあたり1回に削減（-50行）
- **#170**: `_strip_negation_lines()` に zero-count パターンを追加。"CRITICAL security vulnerabilities: 0" 形式の偽陽性を防止
- **#171**: context-budget gate の BLOCK メッセージにサブエージェント免除情報を追加。Agent tool での委任を促す

## Test plan

- [x] `count_severity()` 9テストケース全PASS（#170 の新パターン含む）
- [x] `setup.sh` デプロイ成功
- [x] Anti-Quit メッセージ発火確認（context-budget-read-gate BLOCK時に表示）
- [ ] CI green 確認

Closes #169, Closes #170, Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)