### PR TITLE
fix: factcheck content validation + state-file-tampering gh exemption (#179)

### DIFF
--- a/hooks/block-state-file-tampering-bash.sh
+++ b/hooks/block-state-file-tampering-bash.sh
@@ -9,6 +9,7 @@
 # 2026-03-21: 初版（AI自己バイパス防止）
 # 2026-03-25: インシデント — CMD_FIRST_LINE のみチェックで多行python3 -c バイパス
 # 2026-03-26: Issue #157 修正 — CMD全体スキャン + fail-closed化
+# 2026-03-27: Issue #179 修正 — gh CLI 免除（API操作はローカルFS書き込みではない）
 #
 # バイパス防止の構造:
 #   1. CMD全体（多行）をスキャン → 1行目だけでは逃げられない
@@ -27,6 +28,16 @@ fi
 
 # 保護対象のファイル名パターン
 PROTECTED="review-status\.json|pr-review-lock\.json|pr-review-read\.json|context-budget\.json|factcheck-status\.json|rebase-session\.json|pr-gate-diagnostic\.log"
+
+# --- gh CLI 免除 (Issue #179) ---
+# gh コマンドはGitHub API操作であり、ローカルファイルへの書き込みではない
+# --body/--title や HEREDOC 本文内で保護ファイル名が言及されても改ざんではない
+# ただし compound operator (&&, ||, ;) でチェインされている場合は免除しない
+GH_FIRST_LINE=$(echo "$CMD" | head -1)
+if echo "$GH_FIRST_LINE" | grep -qE '^\s*gh\s' && \
+   ! echo "$GH_FIRST_LINE" | grep -qE ';\s|&&|\|\|'; then
+  exit 0
+fi
 
 # コマンド全体（多行含む）で保護対象ファイルを検出
 if echo "$CMD" | grep -qE "$PROTECTED"; then

--- a/hooks/block-state-file-tampering-bash.sh
+++ b/hooks/block-state-file-tampering-bash.sh
@@ -36,10 +36,9 @@ PROTECTED="review-status\.json|pr-review-lock\.json|pr-review-read\.json|context
 # 多行コマンドは免除しない（2行目に書込みを隠せるため）
 # 注意: クォート内の ; や && も検出される（fail-closed設計）
 GH_LINE_COUNT=$(echo "$CMD" | wc -l | tr -d ' ')
-GH_FIRST_LINE=$(echo "$CMD" | head -1)
 if [[ "$GH_LINE_COUNT" -eq 1 ]] && \
-   echo "$GH_FIRST_LINE" | grep -qE '^\s*gh\s' && \
-   ! echo "$GH_FIRST_LINE" | grep -qE ';\s|&&|\|\|'; then
+   echo "$CMD" | grep -qE '^\s*gh\s' && \
+   ! echo "$CMD" | grep -qE ';|&&|\|\|'; then
   exit 0
 fi
 

--- a/hooks/block-state-file-tampering-bash.sh
+++ b/hooks/block-state-file-tampering-bash.sh
@@ -32,9 +32,13 @@ PROTECTED="review-status\.json|pr-review-lock\.json|pr-review-read\.json|context
 # --- gh CLI 免除 (Issue #179) ---
 # gh コマンドはGitHub API操作であり、ローカルファイルへの書き込みではない
 # --body/--title や HEREDOC 本文内で保護ファイル名が言及されても改ざんではない
-# ただし compound operator (&&, ||, ;) でチェインされている場合は免除しない
+# 免除条件: 単一行 + ghで開始 + compound operator なし
+# 多行コマンドは免除しない（2行目に書込みを隠せるため）
+# 注意: クォート内の ; や && も検出される（fail-closed設計）
+GH_LINE_COUNT=$(echo "$CMD" | wc -l | tr -d ' ')
 GH_FIRST_LINE=$(echo "$CMD" | head -1)
-if echo "$GH_FIRST_LINE" | grep -qE '^\s*gh\s' && \
+if [[ "$GH_LINE_COUNT" -eq 1 ]] && \
+   echo "$GH_FIRST_LINE" | grep -qE '^\s*gh\s' && \
    ! echo "$GH_FIRST_LINE" | grep -qE ';\s|&&|\|\|'; then
   exit 0
 fi

--- a/hooks/enforce-factcheck-github-ops.sh
+++ b/hooks/enforce-factcheck-github-ops.sh
@@ -82,7 +82,7 @@ fi
 # インシデント事例: Issue #343 で #xxx 未置換、Issue #344 で具体名未記載
 CONTENT_ISSUES=""
 
-if echo "$command" | grep -qiE '#[xX]{2,3}\b|#000\b'; then
+if echo "$command" | grep -qiE '#[xX]{2,3}\b'; then
   CONTENT_ISSUES="${CONTENT_ISSUES}  - 未解決のIssue/PR参照 (#xxx) が含まれています\n"
 fi
 

--- a/hooks/enforce-factcheck-github-ops.sh
+++ b/hooks/enforce-factcheck-github-ops.sh
@@ -77,4 +77,37 @@ if [ "$factchecked" = "false" ] || [ "$expired" = "true" ]; then
     exit 2
 fi
 
+# --- コンテンツ検証: 未解決プレースホルダー検出 (Issue #179) ---
+# ファクトチェック済みでも、本文にプレースホルダーが残っていればブロック
+# インシデント事例: Issue #343 で #xxx 未置換、Issue #344 で具体名未記載
+CONTENT_ISSUES=""
+
+if echo "$command" | grep -qiE '#[xX]{2,3}\b|#000\b'; then
+  CONTENT_ISSUES="${CONTENT_ISSUES}  - 未解決のIssue/PR参照 (#xxx) が含まれています\n"
+fi
+
+if echo "$command" | grep -qiE '\bTBD\b'; then
+  CONTENT_ISSUES="${CONTENT_ISSUES}  - 未確定マーカー (TBD) が含まれています\n"
+fi
+
+if echo "$command" | grep -qiE '\bFIXME\b|\bPLACEHOLDER\b'; then
+  CONTENT_ISSUES="${CONTENT_ISSUES}  - 未解決マーカー (FIXME/PLACEHOLDER) が含まれています\n"
+fi
+
+if echo "$command" | grep -qE '（未検証）|〇〇|××'; then
+  CONTENT_ISSUES="${CONTENT_ISSUES}  - 未検証マーカー（（未検証）/〇〇/××）が含まれています\n"
+fi
+
+if [[ -n "$CONTENT_ISSUES" ]]; then
+  echo "🚫 [BLOCK] Issue/PR本文に未解決のプレースホルダーが検出されました。" >&2
+  echo "" >&2
+  echo "  検出された問題:" >&2
+  echo -e "$CONTENT_ISSUES" >&2
+  echo "  コマンド: $(echo "$command" | head -c 100)..." >&2
+  echo "" >&2
+  echo "  対処: プレースホルダーを実際の値に置き換えてください。" >&2
+  echo "  📋 インシデント事例: Issue #343 で Dependencies に #xxx が残存" >&2
+  exit 2
+fi
+
 exit 0

--- a/hooks/enforce-factcheck-github-ops.sh
+++ b/hooks/enforce-factcheck-github-ops.sh
@@ -90,8 +90,8 @@ if echo "$command" | grep -qiE '\bTBD\b'; then
   CONTENT_ISSUES="${CONTENT_ISSUES}  - 未確定マーカー (TBD) が含まれています\n"
 fi
 
-if echo "$command" | grep -qiE '\bFIXME\b|\bPLACEHOLDER\b'; then
-  CONTENT_ISSUES="${CONTENT_ISSUES}  - 未解決マーカー (FIXME/PLACEHOLDER) が含まれています\n"
+if echo "$command" | grep -qiE '\bTODO\b|\bFIXME\b|\bPLACEHOLDER\b'; then
+  CONTENT_ISSUES="${CONTENT_ISSUES}  - 未解決マーカー (TODO/FIXME/PLACEHOLDER) が含まれています\n"
 fi
 
 if echo "$command" | grep -qE '（未検証）|〇〇|××'; then

--- a/tests/test-issue-179.sh
+++ b/tests/test-issue-179.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# test-issue-179.sh — Issue #179: factcheck content validation + state-file-tampering gh exemption
+set -uo pipefail
+
+PASS=0; FAIL=0
+HOOK_DIR="${HOME}/.claude/hooks"
+
+check_exit() {
+  local expected=$1 actual=$2 label="$3"
+  echo "--- $label ---"
+  if [ "$actual" -eq "$expected" ]; then
+    PASS=$((PASS+1)); echo "  PASS"
+  else
+    FAIL=$((FAIL+1)); echo "  FAIL (expected $expected, got $actual)"
+  fi
+}
+
+mk_json() {
+  jq -n --arg cmd "$1" '{"tool_input":{"command":$cmd}}'
+}
+
+set_factcheck() {
+  local val="$1"
+  python3 -c "
+import json, time, os, fcntl
+sf = os.path.expanduser('~/.claude/state/factcheck-status.json')
+os.makedirs(os.path.dirname(sf), exist_ok=True)
+ts = int(time.time()) if $val else 0
+d = {'factchecked': $val, 'source': 'test', 'timestamp': ts, 'edit_count_since_check': 0}
+fd = open(sf, 'w')
+fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
+json.dump(d, fd)
+fd.close()
+"
+}
+
+echo "==================================="
+echo "Bug 2: block-state-file-tampering-bash.sh"
+echo "==================================="
+echo ""
+
+H2="${HOOK_DIR}/block-state-file-tampering-bash.sh"
+
+mk_json 'gh issue create --title "Bug" --body "factcheck-status.json needs fix"' | bash "$H2" >/dev/null 2>&1
+check_exit 0 $? "T1: gh issue create mentioning state file in body -> PASS"
+
+mk_json 'gh pr create --title "Fix" --body "review-status.json scoping"' | bash "$H2" >/dev/null 2>&1
+check_exit 0 $? "T2: gh pr create mentioning state file in body -> PASS"
+
+mk_json 'gh issue create --title "t" && echo {} > factcheck-status.json' | bash "$H2" >/dev/null 2>&1
+check_exit 2 $? "T3: gh && write state file -> BLOCK"
+
+mk_json 'echo {} > factcheck-status.json' | bash "$H2" >/dev/null 2>&1
+check_exit 2 $? "T4: echo > state file -> BLOCK"
+
+mk_json 'cat factcheck-status.json' | bash "$H2" >/dev/null 2>&1
+check_exit 0 $? "T5: cat state file -> PASS (read-only)"
+
+mk_json 'ls -la' | bash "$H2" >/dev/null 2>&1
+check_exit 0 $? "T6: ls -la -> PASS (unrelated)"
+
+mk_json 'gh issue view 1 ; echo x > review-status.json' | bash "$H2" >/dev/null 2>&1
+check_exit 2 $? "T7: gh ; write state file -> BLOCK"
+
+echo ""
+echo "===================================="
+echo "Bug 1: enforce-factcheck-github-ops.sh"
+echo "==================================="
+echo ""
+
+H1="${HOOK_DIR}/enforce-factcheck-github-ops.sh"
+
+set_factcheck "True"
+ecN "
+(factcheck=true)"
+
+mk_json 'gh issue create --title "Fix" --body "Depends on #xxx"' | bash "$H1" >/dev/null 2>&1
+check_exit 2 $? "T8: body with #xxx -> BLOCK"
+
+mk_json 'gh issue create --title "Feature" --body "Timeline: TBD"' | bash "$H1" >/dev/null 2>&1
+check_exit 2 $? "T9: body with TBD -> BLOCK"
+
+mk_json 'gh issue create --title "Bug" --body "FIXME needs work"' | bash "$H1" >/dev/null 2>&1
+check_exit 2 $? "T10: body with FIXME -> BLOCK"
+
+mk_json 'gh issue create --title "Task" --body "PLACEHOLDER text"' | bash "$H1" >/dev/null 2>&1
+check_exit 2 $? "T11: body with PLACEHOLDER -> BLOCK"
+
+mk_json 'gh issue create --title "R" --body "API name is unverified"' | bash "$H1" >/dev/null 2>&1
+check_exit 0 $? "T12: clean body (English) -> PASS"
+
+mk_json 'gh issue create --title "Fix login" --body "Fixed auth issue in login.ts"' | bash "$H1" >/dev/null 2>&1
+check_exit 0 $? "T13: clean body -> PASS"
+
+mk_json 'gh pr create --title "Fix" --body "Resolved the issue"' | bash "$H1" >/dev/null 2>&1
+check_exit 0 $? "T14: gh pr create clean -> PASS"
+
+mk_json 'gh issue view 123' | bash "$H1" >/dev/null 2>&1
+check_exit 0 $? "T15: gh issue view -> PASS (not write op)"
+
+mk_json 'gh issue create --title "Ref" --body "See #123 for context"' | bash "$H1" >/dev/null 2>&1
+check_exit 0 $? "T16: valid #123 ref -> PASS"
+
+set_factcheck "False"
+echo "(factcheck=false)"
+
+mk_json 'gh issue create --title "Clean" --body "All good"' | bash "$H1" >/dev/null 2>&1
+check_exit 2 $? "T17: factcheck=false -> BLOCK"
+
+echo ""
+echo "===================================="
+echo "RESULTS: ${PASS} passed, ${FAIL} failed (total $((PASS+FAIL)))"
+echo "===================================="
+exit $FAIL

--- a/tests/test-issue-179.sh
+++ b/tests/test-issue-179.sh
@@ -3,7 +3,8 @@
 set -uo pipefail
 
 PASS=0; FAIL=0
-HOOK_DIR="${HOME}/.claude/hooks"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK_DIR="${SCRIPT_DIR}/../hooks"
 
 check_exit() {
   local expected=$1 actual=$2 label="$3"

--- a/tests/test-issue-179.sh
+++ b/tests/test-issue-179.sh
@@ -71,8 +71,7 @@ echo ""
 H1="${HOOK_DIR}/enforce-factcheck-github-ops.sh"
 
 set_factcheck "True"
-ecN "
-(factcheck=true)"
+echo "(factcheck=true)"
 
 mk_json 'gh issue create --title "Fix" --body "Depends on #xxx"' | bash "$H1" >/dev/null 2>&1
 check_exit 2 $? "T8: body with #xxx -> BLOCK"


### PR DESCRIPTION
## Summary

- **Bug 1**: `enforce-factcheck-github-ops.sh` にコンテンツ検証を追加。ファクトチェック済みでも未解決のプレースホルダー（ハッシュ+x文字列、未確定マーカー、未解決マーカー、日本語未検証マーカー）が本文に含まれていればブロック
- **Bug 2**: `block-state-file-tampering-bash.sh` の `gh` CLI 誤検知を修正。GitHub API操作の本文内でstate file名が言及されても改ざんと判定しない。compound operator チェイン攻撃は引き続きブロック
- テストスクリプト追加: 17ケース全合格 (`tests/test-issue-179.sh`)

## Test plan

- [x] T1-T2: `gh issue/pr create` で本文にstate file名言及 → 許可
- [x] T3, T7: compound operator チェイン攻撃 → ブロック
- [x] T4: 直接書込み → ブロック（既存動作維持）
- [x] T5: read-only → 許可（既存動作維持）
- [x] T8-T11: 各種プレースホルダーパターン → ブロック
- [x] T12-T16: クリーンな本文、有効なIssue参照 → 許可
- [x] T17: factcheck=false → ブロック（既存動作維持）

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 単一行のghコマンドを不要な検査から早期に通過させ、誤検出を減らしました。

* **改善事項**
  * コメント内の未完了プレースホルダーや未検証マーカーを検出して提出をブロックする検証を追加しました。

* **Tests**
  * 上記の挙動を検証する自動テストを追加し、許可/ブロックの期待値を網羅的に確認します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->