### PR TITLE
chore: compliance audit — README stats update + Skills Inventory fix (#178)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 [Claude Code](https://claude.com/claude-code)（Anthropic 公式 CLI）のためのスキル・ルール・フック集です。
 
-26 のカスタムスキル、59 の hook スクリプト（+ 7 ゲートモードモジュール）、5 つのルールセット、6 つのユーティリティスクリプトを含む、本番環境レベルの Claude Code 設定を提供します。
+27 のカスタムスキル、72 の hook スクリプト（64 シェル + 7 ゲートモードモジュール + 1 Python）、6 つのルールセット、6 つのユーティリティスクリプトを含む、本番環境レベルの Claude Code 設定を提供します。
 
 [English](README.md) | **日本語**
 
@@ -21,9 +21,9 @@ chmod +x setup.sh
 
 ```
 claude-code-skills/
-├── skills/           # 26 カスタムスキル定義 (SKILL.md + scripts + references)
-├── rules/            # 5 グローバルルール (コーディング規約, Git, 品質, テスト, 委任)
-├── hooks/            # 59 hook スクリプト + 7 ゲートモードモジュール (品質ゲート, 安全ガード, ワークフロー強制)
+├── skills/           # 27 カスタムスキル定義 (SKILL.md + scripts + references)
+├── rules/            # 6 グローバルルール (コーディング規約, Git, 品質, テスト, 委任, hookデプロイ)
+├── hooks/            # 72 hook スクリプト (64 シェル + 7 ゲートモードモジュール + 1 Python) (品質ゲート, 安全ガード, ワークフロー強制)
 ├── scripts/          # 6 ユーティリティ (Codex 連携, PR レビュー, コンテキスト監視)
 ├── setup.sh          # ワンコマンドインストール
 ├── settings.json     # 設定テンプレート (パス等サニタイズ済み)
@@ -82,6 +82,7 @@ Reflect (gstack)
 | スキル | 機能 | トリガー |
 |-------|------|---------|
 | `code-reviewer` | OWASP セキュリティチェック付き PR レビュー | "review this PR", "code review" |
+| `classify-review` | AI による PR レビュー severity 再分類（偽陽性フィルター） | /classify-review [PR番号] |
 | `review-loop` | CI グリーン + レビュー LGTM まで自動ループ | /review-loop |
 | `bugfix` | 根本原因分析 + 全インスタンス修正 | /bugfix [説明] |
 | `tdd-workflow` | RED-GREEN-REFACTOR サイクル強制 | "write tests first", "TDD" |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A curated collection of skills, rules, and hooks for [Claude Code](https://claude.com/claude-code) — Anthropic's official CLI for Claude.
 
-This repository provides a production-ready Claude Code configuration with 26 custom skills, 59 hook scripts (+ 7 gate-mode modules), 5 rule sets, 6 utility scripts, and integration with third-party skill frameworks.
+This repository provides a production-ready Claude Code configuration with 27 custom skills, 72 hook scripts (64 shell + 7 gate-mode modules + 1 Python), 6 rule sets, 6 utility scripts, and integration with third-party skill frameworks.
 
 > **Design Philosophy**: This project implements the principles from [Harness Engineering Best Practices 2026](https://nyosegawa.com/posts/harness-engineering-best-practices-2026/) — deterministic quality gates via hooks, pointer-based documentation (ADR-002), and the feedback speed hierarchy (PostToolUse > pre-commit > CI > human review).
 
@@ -23,9 +23,9 @@ Restart Claude Code after installation.
 
 ```
 claude-code-skills/
-├── skills/           # 26 custom skill definitions (SKILL.md + scripts + references)
-├── rules/            # 5 global rule files (coding-style, git-workflow, quality, testing, delegation)
-├── hooks/            # 59 hook scripts + 7 gate-mode modules (quality gates, safety guards, workflow enforcement)
+├── skills/           # 27 custom skill definitions (SKILL.md + scripts + references)
+├── rules/            # 6 global rule files (coding-style, git-workflow, quality, testing, delegation, hook-deployment)
+├── hooks/            # 72 hook scripts (64 shell + 7 gate-mode modules + 1 Python) (quality gates, safety guards, workflow enforcement)
 ├── scripts/          # 6 utility scripts (Codex orchestration, PR review, context monitoring)
 ├── setup.sh          # One-command installation
 ├── settings.json     # Template settings (sanitized, no personal paths)
@@ -83,6 +83,7 @@ Reflect (gstack)
 | Skill | Purpose | Trigger |
 |-------|---------|---------|
 | `code-reviewer` | PR review with OWASP security checks | "review this PR", "code review" |
+| `classify-review` | AI-based PR review severity re-classification (false positive filter) | /classify-review [PR#] |
 | `review-loop` | CI green + review LGTM auto-loop | /review-loop |
 | `bugfix` | Root cause analysis + fix all instances | /bugfix [description] |
 | `tdd-workflow` | RED-GREEN-REFACTOR cycle enforcement | "write tests first", "TDD" |


### PR DESCRIPTION
## Summary

- **README statistics updated** to match actual file counts: 27 skills, 72 hooks (64 shell + 7 gate-mode modules + 1 Python), 6 rules (was: 26 skills, 59 hooks + 7 gate-modes, 5 rules)
- **classify-review skill added** to Skills Inventory table in both README.md and README.ja.md
- **Template README.md files kept** — the 3 README.md files in `skills/adk-engineer/assets/templates/` are scaffolding templates (project output), not skill documentation, so they do not violate the PDF guide's "No README.md inside skill folder" rule

## Verification

Counts verified via CLI:
- `ls -d skills/*/ | wc -l` = 27
- `ls hooks/*.sh | wc -l` = 64
- `ls hooks/gate-modes/*.sh | wc -l` = 7
- `ls hooks/*.py | wc -l` = 1
- `ls rules/*.md | wc -l` = 6

## Reference analysis (Task 2 reasoning)

The Anthropic PDF (p10) states: "Don't include README.md inside your skill folder." The 3 found README.md files are at:
- `skills/adk-engineer/assets/templates/single-agent/README.md`
- `skills/adk-engineer/assets/templates/multi-agent/README.md`
- `skills/adk-engineer/assets/templates/workflow/README.md`

These are inside `assets/templates/` subdirectories — they are part of the scaffolding output that gets copied when a user creates a new ADK project. They are NOT skill documentation (which belongs in SKILL.md). Deleting them would break the template functionality. Decision: **KEEP**.

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)