### PR TITLE
fix: exclude non-CI check runs from merge gate (#187)

### DIFF
--- a/hooks/gate-modes/common.sh
+++ b/hooks/gate-modes/common.sh
@@ -150,6 +150,23 @@ classify_review_tier() {
 # Issue #60 Bug C: Check BOTH project-scoped AND global state (OR logic)
 # to prevent path mismatch causing permanent blocks.
 # =========================================================================
+# =========================================================================
+# Non-CI check run exclusion pattern (#187)
+# These check runs are NOT CI jobs and should be excluded from CI status checks.
+# Case-insensitive match against check run name.
+# =========================================================================
+NON_CI_CHECK_PATTERN="^(Agent|copilot|dependabot|CodeRabbit)"
+
+# jq filter to exclude non-CI check runs from CI status counting
+# Usage: gh api .../check-runs --jq "$(jq_ci_failures_filter)"
+jq_ci_failures_filter() {
+  echo "[.check_runs[] | select(.conclusion==\"failure\") | select(.name | test(\"${NON_CI_CHECK_PATTERN}\"; \"i\") | not)] | length"
+}
+
+jq_ci_pending_filter() {
+  echo "[.check_runs[] | select(.status!=\"completed\") | select(.name | test(\"${NON_CI_CHECK_PATTERN}\"; \"i\") | not)] | length"
+}
+
 read_review() {
   local branch="$1"
   local field="$2"

--- a/hooks/gate-modes/pre-merge.sh
+++ b/hooks/gate-modes/pre-merge.sh
@@ -67,16 +67,26 @@ fi
 # CI status check (non-EXEMPT tiers only)
 if [[ -n "$REPO" ]] && [[ -n "$HEAD_SHA" ]]; then
   CI_FAILURES=$(_timeout 10 gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
-    --jq '[.check_runs[] | select(.conclusion=="failure")] | length' 2>/dev/null || echo "0")
+    --jq "$(jq_ci_failures_filter)" 2>/dev/null || echo "0")
   CI_PENDING=$(_timeout 10 gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
-    --jq '[.check_runs[] | select(.status!="completed")] | length' 2>/dev/null || echo "0")
+    --jq "$(jq_ci_pending_filter)" 2>/dev/null || echo "0")
 
   if [[ "$CI_FAILURES" -gt 0 ]]; then
-    echo "🚫 [BLOCKED] CI に失敗ジョブあり ($CI_FAILURES 件)。修正してからマージしてください。" >&2
+    echo "" >&2
+    echo "🚫 [BLOCKED] CI に失敗ジョブあり ($CI_FAILURES 件)" >&2
+    echo "  WHY: マージ前にCI全ジョブの成功を確認する必要があります (Epic #130)" >&2
+    echo "  FIX: gh pr checks ${PR_NUMBER} で失敗ジョブを特定し、修正してください" >&2
+    echo "  NOTE: Agent/copilot/dependabot/CodeRabbit は自動除外済み" >&2
+    echo "" >&2
     exit 2
   fi
   if [[ "$CI_PENDING" -gt 0 ]]; then
-    echo "🚫 [BLOCKED] CI に実行中ジョブあり ($CI_PENDING 件)。完了を待ってください。" >&2
+    echo "" >&2
+    echo "🚫 [BLOCKED] CI に実行中ジョブあり ($CI_PENDING 件)" >&2
+    echo "  WHY: マージ前にCI全ジョブの完了を確認する必要があります (Epic #130)" >&2
+    echo "  FIX: gh pr checks ${PR_NUMBER} --watch で完了を待ってください" >&2
+    echo "  NOTE: Agent/copilot/dependabot/CodeRabbit は自動除外済み" >&2
+    echo "" >&2
     exit 2
   fi
 fi

--- a/hooks/gate-modes/verify.sh
+++ b/hooks/gate-modes/verify.sh
@@ -21,16 +21,26 @@ if [[ -z "$REPO" ]] || [[ -z "$HEAD_SHA" ]]; then
 fi
 
 CI_FAILURES=$(_timeout 10 gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
-  --jq '[.check_runs[] | select(.conclusion=="failure")] | length' 2>/dev/null || echo "0")
+  --jq "$(jq_ci_failures_filter)" 2>/dev/null || echo "0")
 CI_PENDING=$(_timeout 10 gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
-  --jq '[.check_runs[] | select(.status!="completed")] | length' 2>/dev/null || echo "0")
+  --jq "$(jq_ci_pending_filter)" 2>/dev/null || echo "0")
 
 if [[ "$CI_FAILURES" -gt 0 ]]; then
-  echo "❌ PR #${PR}: CI に失敗ジョブあり ($CI_FAILURES 件)。修正してください。" >&2
+  echo "" >&2
+  echo "🚫 [BLOCKED] PR #${PR}: CI に失敗ジョブあり ($CI_FAILURES 件)" >&2
+  echo "  WHY: マージ前にCI全ジョブの成功を確認する必要があります (Epic #130)" >&2
+  echo "  FIX: gh pr checks ${PR} で失敗ジョブを特定し、修正してください" >&2
+  echo "  NOTE: Agent/copilot/dependabot/CodeRabbit は自動除外済み" >&2
+  echo "" >&2
   exit 1
 fi
 if [[ "$CI_PENDING" -gt 0 ]]; then
-  echo "⏳ PR #${PR}: CI に実行中ジョブあり ($CI_PENDING 件)。完了を待ってください。" >&2
+  echo "" >&2
+  echo "⏳ [BLOCKED] PR #${PR}: CI に実行中ジョブあり ($CI_PENDING 件)" >&2
+  echo "  WHY: マージ前にCI全ジョブの完了を確認する必要があります (Epic #130)" >&2
+  echo "  FIX: gh pr checks ${PR} --watch で完了を待ってください" >&2
+  echo "  NOTE: Agent/copilot/dependabot/CodeRabbit は自動除外済み" >&2
+  echo "" >&2
   exit 1
 fi
 

--- a/tests/test-issue-187.sh
+++ b/tests/test-issue-187.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# test-issue-187.sh — Verify non-CI check runs are excluded from merge gate (#187)
+# =========================================================================
+# Tests that jq_ci_failures_filter and jq_ci_pending_filter correctly
+# exclude non-CI check runs (Agent, copilot, dependabot, CodeRabbit)
+# while still counting actual CI check runs.
+# =========================================================================
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; ((PASS++)); }
+fail() { echo "  FAIL: $1"; ((FAIL++)); }
+
+# Source common.sh to get the filter functions
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${SCRIPT_DIR}/hooks/gate-modes/common.sh"
+
+echo "=== Issue #187: Non-CI check run exclusion filter tests ==="
+echo ""
+
+# =========================================================================
+# Test 1: jq_ci_pending_filter excludes "Agent" check run
+# =========================================================================
+echo "--- Test 1: Agent check run (in_progress) is excluded from pending count ---"
+MOCK_RESPONSE='{
+  "check_runs": [
+    {"name": "Agent", "status": "in_progress", "conclusion": null},
+    {"name": "hook-tests", "status": "completed", "conclusion": "success"},
+    {"name": "shellcheck", "status": "completed", "conclusion": "success"}
+  ]
+}'
+RESULT=$(echo "$MOCK_RESPONSE" | jq "$(jq_ci_pending_filter)")
+if [[ "$RESULT" -eq 0 ]]; then
+  pass "Agent in_progress excluded, pending=0"
+else
+  fail "Expected pending=0, got $RESULT"
+fi
+
+# =========================================================================
+# Test 2: Actual CI pending job is still counted
+# =========================================================================
+echo "--- Test 2: Actual CI pending job is counted ---"
+MOCK_RESPONSE='{
+  "check_runs": [
+    {"name": "Agent", "status": "in_progress", "conclusion": null},
+    {"name": "hook-tests", "status": "in_progress", "conclusion": null},
+    {"name": "shellcheck", "status": "completed", "conclusion": "success"}
+  ]
+}'
+RESULT=$(echo "$MOCK_RESPONSE" | jq "$(jq_ci_pending_filter)")
+if [[ "$RESULT" -eq 1 ]]; then
+  pass "hook-tests in_progress counted, pending=1"
+else
+  fail "Expected pending=1, got $RESULT"
+fi
+
+# =========================================================================
+# Test 3: Multiple non-CI check runs excluded simultaneously
+# =========================================================================
+echo "--- Test 3: Multiple non-CI check runs excluded ---"
+MOCK_RESPONSE='{
+  "check_runs": [
+    {"name": "Agent", "status": "in_progress", "conclusion": null},
+    {"name": "copilot", "status": "in_progress", "conclusion": null},
+    {"name": "dependabot", "status": "in_progress", "conclusion": null},
+    {"name": "CodeRabbit", "status": "in_progress", "conclusion": null},
+    {"name": "hook-tests", "status": "completed", "conclusion": "success"},
+    {"name": "shellcheck", "status": "completed", "conclusion": "success"}
+  ]
+}'
+RESULT=$(echo "$MOCK_RESPONSE" | jq "$(jq_ci_pending_filter)")
+if [[ "$RESULT" -eq 0 ]]; then
+  pass "All 4 non-CI runs excluded, pending=0"
+else
+  fail "Expected pending=0, got $RESULT"
+fi
+
+# =========================================================================
+# Test 4: Case-insensitive matching
+# =========================================================================
+echo "--- Test 4: Case-insensitive matching ---"
+MOCK_RESPONSE='{
+  "check_runs": [
+    {"name": "agent", "status": "in_progress", "conclusion": null},
+    {"name": "COPILOT", "status": "in_progress", "conclusion": null},
+    {"name": "Dependabot", "status": "in_progress", "conclusion": null},
+    {"name": "coderabbit", "status": "in_progress", "conclusion": null},
+    {"name": "quality-gate", "status": "completed", "conclusion": "success"}
+  ]
+}'
+RESULT=$(echo "$MOCK_RESPONSE" | jq "$(jq_ci_pending_filter)")
+if [[ "$RESULT" -eq 0 ]]; then
+  pass "Case-insensitive exclusion works, pending=0"
+else
+  fail "Expected pending=0, got $RESULT"
+fi
+
+# =========================================================================
+# Test 5: jq_ci_failures_filter excludes non-CI failed runs
+# =========================================================================
+echo "--- Test 5: Non-CI failure check runs excluded from failure count ---"
+MOCK_RESPONSE='{
+  "check_runs": [
+    {"name": "Agent", "status": "completed", "conclusion": "failure"},
+    {"name": "hook-tests", "status": "completed", "conclusion": "success"},
+    {"name": "shellcheck", "status": "completed", "conclusion": "success"}
+  ]
+}'
+RESULT=$(echo "$MOCK_RESPONSE" | jq "$(jq_ci_failures_filter)")
+if [[ "$RESULT" -eq 0 ]]; then
+  pass "Agent failure excluded, failures=0"
+else
+  fail "Expected failures=0, got $RESULT"
+fi
+
+# =========================================================================
+# Test 6: Actual CI failure is still counted
+# =========================================================================
+echo "--- Test 6: Actual CI failure is counted ---"
+MOCK_RESPONSE='{
+  "check_runs": [
+    {"name": "Agent", "status": "completed", "conclusion": "failure"},
+    {"name": "hook-tests", "status": "completed", "conclusion": "failure"},
+    {"name": "shellcheck", "status": "completed", "conclusion": "success"}
+  ]
+}'
+RESULT=$(echo "$MOCK_RESPONSE" | jq "$(jq_ci_failures_filter)")
+if [[ "$RESULT" -eq 1 ]]; then
+  pass "hook-tests failure counted, failures=1"
+else
+  fail "Expected failures=1, got $RESULT"
+fi
+
+# =========================================================================
+# Test 7: All CI jobs completed successfully — no false positives
+# =========================================================================
+echo "--- Test 7: All CI green, no non-CI runs — clean pass ---"
+MOCK_RESPONSE='{
+  "check_runs": [
+    {"name": "hook-tests", "status": "completed", "conclusion": "success"},
+    {"name": "shellcheck", "status": "completed", "conclusion": "success"},
+    {"name": "json-validate", "status": "completed", "conclusion": "success"},
+    {"name": "syntax-check", "status": "completed", "conclusion": "success"}
+  ]
+}'
+RESULT_F=$(echo "$MOCK_RESPONSE" | jq "$(jq_ci_failures_filter)")
+RESULT_P=$(echo "$MOCK_RESPONSE" | jq "$(jq_ci_pending_filter)")
+if [[ "$RESULT_F" -eq 0 ]] && [[ "$RESULT_P" -eq 0 ]]; then
+  pass "All green: failures=0, pending=0"
+else
+  fail "Expected failures=0 pending=0, got failures=$RESULT_F pending=$RESULT_P"
+fi
+
+# =========================================================================
+# Test 8: Prefix match — names starting with excluded pattern
+# =========================================================================
+echo "--- Test 8: Prefix match — names starting with excluded pattern ---"
+MOCK_RESPONSE='{
+  "check_runs": [
+    {"name": "Agent - session abc123", "status": "in_progress", "conclusion": null},
+    {"name": "copilot-review", "status": "in_progress", "conclusion": null},
+    {"name": "hook-tests", "status": "completed", "conclusion": "success"}
+  ]
+}'
+RESULT=$(echo "$MOCK_RESPONSE" | jq "$(jq_ci_pending_filter)")
+if [[ "$RESULT" -eq 0 ]]; then
+  pass "Prefix-extended names excluded, pending=0"
+else
+  fail "Expected pending=0, got $RESULT"
+fi
+
+# =========================================================================
+# Summary
+# =========================================================================
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/tests/test-issue-187.sh
+++ b/tests/test-issue-187.sh
@@ -5,13 +5,13 @@
 # exclude non-CI check runs (Agent, copilot, dependabot, CodeRabbit)
 # while still counting actual CI check runs.
 # =========================================================================
-set -euo pipefail
+set -uo pipefail
 
 PASS=0
 FAIL=0
 
-pass() { echo "  PASS: $1"; ((PASS++)); }
-fail() { echo "  FAIL: $1"; ((FAIL++)); }
+pass() { echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL+1)); }
 
 # Source common.sh to get the filter functions
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"


### PR DESCRIPTION
## Summary

- pre-merge.sh / verify.sh の CI_PENDING jq フィルタが Agent/copilot/dependabot/CodeRabbit を非CIとして除外
- WHY+FIX形式のエラーメッセージ追加 (Harness Best Practices準拠)
- common.sh に共通フィルタ関数を追加

## Test plan

- [ ] テスト通過: Agent in_progress が除外されること確認
- [ ] 実CI job (hook-tests, shellcheck等) は引き続き検出されること
- [ ] デプロイ済み: MD5一致確認

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)