### PR TITLE
fix: block --all/--mirror and implicit remote force push bypass (#195)

### DIFF
--- a/hooks/protect-branches.sh
+++ b/hooks/protect-branches.sh
@@ -105,16 +105,17 @@ extract_push_branch() {
   echo "$branch"
 }
 
-# --- Check 0: Force push guard (fork-aware) (#192, #195) ---
-if echo "$cmd" | grep -qE '\bgit\s+push\b' && is_force_push "$cmd"; then
-  # Block --all/--mirror: these push ALL branches, always block (#195)
-  if echo "$cmd" | grep -qE '\s--(all|mirror)\b'; then
-    echo "[BLOCK] --all/--mirror 付き force push を検出。" >&2
-    echo "  WHY: 全ブランチ(保護ブランチ含む)の履歴が書き換えられます。" >&2
-    echo "  FIX: 個別のブランチを指定して push してください。" >&2
-    exit 2
-  fi
+# --- Check 0a: --all/--mirror guard (independent of --force flag) (#195) ---
+# --mirror and --all push ALL refs, implying forced updates even without --force
+if echo "$cmd" | grep -qE '\bgit\s+push\b' && echo "$cmd" | grep -qE '\s--(all|mirror)\b'; then
+  echo "[BLOCK] --all/--mirror 付き push を検出。" >&2
+  echo "  WHY: 全ブランチ(保護ブランチ含む)の履歴が上書き/削除されます。" >&2
+  echo "  FIX: 個別のブランチを指定して push してください。" >&2
+  exit 2
+fi
 
+# --- Check 0b: Force push guard (fork-aware) (#192, #195) ---
+if echo "$cmd" | grep -qE '\bgit\s+push\b' && is_force_push "$cmd"; then
   push_remote=$(extract_push_remote "$cmd")
   push_remote="${push_remote:-origin}"
 

--- a/hooks/protect-branches.sh
+++ b/hooks/protect-branches.sh
@@ -105,8 +105,16 @@ extract_push_branch() {
   echo "$branch"
 }
 
-# --- Check 0: Force push guard (fork-aware) (#192) ---
+# --- Check 0: Force push guard (fork-aware) (#192, #195) ---
 if echo "$cmd" | grep -qE '\bgit\s+push\b' && is_force_push "$cmd"; then
+  # Block --all/--mirror: these push ALL branches, always block (#195)
+  if echo "$cmd" | grep -qE '\s--(all|mirror)\b'; then
+    echo "[BLOCK] --all/--mirror 付き force push を検出。" >&2
+    echo "  WHY: 全ブランチ(保護ブランチ含む)の履歴が書き換えられます。" >&2
+    echo "  FIX: 個別のブランチを指定して push してください。" >&2
+    exit 2
+  fi
+
   push_remote=$(extract_push_remote "$cmd")
   push_remote="${push_remote:-origin}"
 
@@ -129,6 +137,11 @@ if echo "$cmd" | grep -qE '\bgit\s+push\b' && is_force_push "$cmd"; then
     target_branch=$(extract_push_branch "$cmd")
     if [ -z "$target_branch" ]; then
       target_branch=$(git branch --show-current 2>/dev/null || echo "")
+    fi
+    # If no explicit remote, check tracking remote (#195)
+    push_remote_explicit=$(extract_push_remote "$cmd")
+    if [ -z "$push_remote_explicit" ]; then
+      push_remote=$(git config "branch.${target_branch}.remote" 2>/dev/null || echo "origin")
     fi
     for branch in $PROTECTED_BRANCHES; do
       if [ "$target_branch" = "$branch" ]; then

--- a/tests/test-issue-195.sh
+++ b/tests/test-issue-195.sh
@@ -21,7 +21,20 @@ echo "=== protect-branches.sh tests ==="
 echo "--- Force push bypass fixes (#195) ---"
 test_case "--all force push blocked" 2 "git push --force --all origin"
 test_case "--mirror force push blocked" 2 "git push --force --mirror origin"
-test_case "implicit force push on feature" 0 "git push --force"
+test_case "--all without force blocked" 2 "git push --all origin"
+test_case "--mirror without force blocked" 2 "git push --mirror origin"
+
+# Implicit force push: expected exit depends on current branch
+current_branch=$(git branch --show-current 2>/dev/null || echo "")
+is_protected=0
+for b in develop main master; do
+  [ "$current_branch" = "$b" ] && is_protected=1
+done
+if [ "$is_protected" -eq 1 ]; then
+  test_case "implicit force push on protected ($current_branch)" 2 "git push --force"
+else
+  test_case "implicit force push on feature ($current_branch)" 0 "git push --force"
+fi
 
 echo "--- Existing force push guards (#192) ---"
 test_case "explicit force push to develop" 2 "git push --force origin develop"

--- a/tests/test-issue-195.sh
+++ b/tests/test-issue-195.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/../hooks/protect-branches.sh"
+PASS=0; FAIL=0
+
+test_case() {
+  local name="$1" expected_exit="$2" cmd="$3"
+  actual_exit=0
+  echo "{\"tool_input\":{\"command\":\"$cmd\"}}" | bash "$HOOK" >/dev/null 2>&1 || actual_exit=$?
+  if [ "$actual_exit" -eq "$expected_exit" ]; then
+    echo "  PASS: $name (exit $actual_exit)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name (expected=$expected_exit actual=$actual_exit)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== protect-branches.sh tests ==="
+echo "--- Force push bypass fixes (#195) ---"
+test_case "--all force push blocked" 2 "git push --force --all origin"
+test_case "--mirror force push blocked" 2 "git push --force --mirror origin"
+test_case "implicit force push on feature" 0 "git push --force"
+
+echo "--- Existing force push guards (#192) ---"
+test_case "explicit force push to develop" 2 "git push --force origin develop"
+test_case "force-with-lease to develop" 2 "git push --force-with-lease origin develop"
+test_case "force-with-lease=HEAD to develop" 2 "git push --force-with-lease=HEAD origin develop"
+test_case "refspec HEAD:develop" 2 "git push --force-with-lease origin HEAD:develop"
+test_case "force push to feature (allow)" 0 "git push --force origin feat/test"
+
+echo "--- Branch protection (regression) ---"
+test_case "normal push (allow)" 0 "git push origin feat/test"
+test_case "remote delete develop" 2 "git push origin --delete develop"
+test_case "colon delete develop" 2 "git push origin :develop"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/tests/test-issue-195.sh
+++ b/tests/test-issue-195.sh
@@ -18,22 +18,25 @@ test_case() {
 }
 
 echo "=== protect-branches.sh tests ==="
-echo "--- Force push bypass fixes (#195) ---"
+
+echo "--- --all/--mirror without --force (#195 P1) ---"
+test_case "--mirror without --force blocked" 2 "git push --mirror origin"
+test_case "--all without --force blocked" 2 "git push --all origin"
+
+echo "--- --all/--mirror with --force (#195) ---"
 test_case "--all force push blocked" 2 "git push --force --all origin"
 test_case "--mirror force push blocked" 2 "git push --force --mirror origin"
-test_case "--all without force blocked" 2 "git push --all origin"
-test_case "--mirror without force blocked" 2 "git push --mirror origin"
 
-# Implicit force push: expected exit depends on current branch
+echo "--- Implicit force push (branch-aware) ---"
 current_branch=$(git branch --show-current 2>/dev/null || echo "")
 is_protected=0
 for b in develop main master; do
   [ "$current_branch" = "$b" ] && is_protected=1
 done
 if [ "$is_protected" -eq 1 ]; then
-  test_case "implicit force push on protected ($current_branch)" 2 "git push --force"
+  test_case "implicit force push on protected branch" 2 "git push --force"
 else
-  test_case "implicit force push on feature ($current_branch)" 0 "git push --force"
+  test_case "implicit force push on feature branch" 0 "git push --force"
 fi
 
 echo "--- Existing force push guards (#192) ---"


### PR DESCRIPTION
## Summary
- Block --all/--mirror push unconditionally (protect-branches.sh:108-115)
- Detect implicit tracking remote via git config (protect-branches.sh:142-145)

## Verified test results (13/13 pass)
All tests in tests/test-issue-195.sh pass. 2 files changed, +71/-1 lines.

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * `git push --all` および `--mirror` コマンドの実行をブロックする保護機能を追加しました。

* **改善**
  * 保護対象ブランチの検出時に、ブランチの上流リモート設定を利用したより正確なリモート解決を実装しました。

* **テスト**
  * ブランチ保護機能の包括的なテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->