### PR TITLE
fix: codex-review skill uses CLI exec instead of MCP (#197)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -82,6 +82,7 @@ Reflect (gstack)
 | スキル | 機能 | トリガー |
 |-------|------|---------|
 | `code-reviewer` | OWASP セキュリティチェック付き PR レビュー | "review this PR", "code review" |
+| `codex-review` | Codex CLI セカンドオピニオンレビュー（`codex exec` 並列エキスパート） | "Codex レビュー", "セカンドオピニオン" |
 | `classify-review` | AI による PR レビュー severity 再分類（偽陽性フィルター） | /classify-review [PR番号] |
 | `review-loop` | CI グリーン + レビュー LGTM まで自動ループ | /review-loop |
 | `bugfix` | 根本原因分析 + 全インスタンス修正 | /bugfix [説明] |
@@ -151,7 +152,7 @@ Codex CLI (40%) — 直列実装、運用、品質監査
 
 | 経路 | 用途 | コマンド |
 |------|------|---------|
-| **A: レビュー** | コードレビュー、セカンドオピニオン | `codex exec review --base <branch>` |
+| **A: レビュー** | コードレビュー、セカンドオピニオン（並列エキスパート） | `codex exec --sandbox read-only` / `codex-review` スキル |
 | **B: ハンドオーバー** | 大規模実装（ユーザー判断が必要） | ハンドオーバードキュメント作成 → ユーザーが Codex に渡す |
 | **C: 並列実行** | 独立タスクを分離 worktree で実行 | `codex-parallel.sh` または `codex-orchestrate.sh` |
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Reflect (gstack)
 | Skill | Purpose | Trigger |
 |-------|---------|---------|
 | `code-reviewer` | PR review with OWASP security checks | "review this PR", "code review" |
+| `codex-review` | Codex CLI second opinion review (parallel experts via `codex exec`) | "Codex レビュー", "セカンドオピニオン" |
 | `classify-review` | AI-based PR review severity re-classification (false positive filter) | /classify-review [PR#] |
 | `review-loop` | CI green + review LGTM auto-loop | /review-loop |
 | `bugfix` | Root cause analysis + fix all instances | /bugfix [description] |
@@ -152,7 +153,7 @@ The `agent-orchestrator` skill manages team composition, wave-based execution, a
 
 | Route | Purpose | Command |
 |-------|---------|---------|
-| **A: Review** | Code review, second opinion | `codex exec review --base <branch>` |
+| **A: Review** | Code review, second opinion (parallel experts) | `codex exec --sandbox read-only` / `codex-review` skill |
 | **B: Handover** | Large implementation (requires user judgment) | Create handover doc → user passes to Codex |
 | **C: Parallel** | Independent tasks in isolated worktrees | `codex-parallel.sh` or `codex-orchestrate.sh` |
 

--- a/skills/codex-review/SKILL.md
+++ b/skills/codex-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: codex-review
 description: "Codexにセカンドオピニオンを求める。AI同士の忖度なしガチレビュー。Use when user mentions 'Codex レビュー', 'セカンドオピニオン', 'Codex の意見', 'Codex でレビュー'. Do NOT load for: 'Codex に実装させて', 'Codex Worker', 'Codex に作らせて', '実装を依頼'."
-allowed-tools: ["Bash", "Read", "Write", "Edit"]
+allowed-tools: ["Bash", "Read"]
 argument-hint: "[code|plan|scope]"
 ---
 

--- a/skills/codex-review/SKILL.md
+++ b/skills/codex-review/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: codex-review
+description: "Codexにセカンドオピニオンを求める。AI同士の忖度なしガチレビュー。Use when user mentions 'Codex レビュー', 'セカンドオピニオン', 'Codex の意見', 'Codex でレビュー', or 'Codex セットアップ'. Do NOT load for: 'Codex に実装させて', 'Codex Worker', 'Codex に作らせて', '実装を依頼'."
+allowed-tools: ["Bash", "Read", "Write", "Edit"]
+argument-hint: "[code|plan|scope]"
+---
+
+# Codex Review Integration Skill
+
+OpenAI Codex CLI を使用してコードレビュー時にセカンドオピニオンを提供するスキル。
+
+> **重要**: Codex MCP (`mcp__codex__*`) は使用禁止です（delegation.md / Issue #72）。
+> 全ての Codex 呼び出しは CLI (`codex exec`) 経由で行います。
+> Ref: ADR-004, `hooks/block-codex-mcp.sh`
+
+## Do NOT Load For (誤発動防止)
+
+以下のキーワードは `codex-worker` スキルが担当します:
+
+| トリガーワード | 正しいスキル | 理由 |
+|---------------|-------------|------|
+| "Codex に実装させて" | `codex-worker` | 実装 ≠ レビュー |
+| "Codex Worker" | `codex-worker` | Worker = 実装役 |
+| "Codex に作らせて" | `codex-worker` | 作成 = 実装 |
+| "実装を依頼" | `codex-worker` | 実装目的 |
+
+## 使用場面
+
+### レビュー
+- **セカンドオピニオン**: Claude のレビュー結果に Codex の視点を追加
+- **コード品質チェック**: 複数 AI モデルの得意分野を活用
+- **設計レビュー**: アーキテクチャや実装パターンの多角的検証
+
+## 機能詳細
+
+| 機能 | 詳細 |
+|------|------|
+| **レビュー統合** | See [references/codex-review-integration.md](references/codex-review-integration.md) |
+| **並列レビュー** | See [references/codex-parallel-review.md](references/codex-parallel-review.md) |
+
+## 実行手順
+
+1. ユーザーのリクエストを分類
+2. 上記の「機能詳細」から適切な参照ファイルを読む
+3. その内容に従って CLI でレビューを実行
+
+### 並列レビュー時の必須ルール
+
+**Codex モード（`review.mode: codex`）でのレビュー実行時**:
+
+1. **呼び出すエキスパートを判定**（全部ではなく必要なもののみ）:
+   - 設定で `enabled: false` → 除外
+   - CLI/バックエンド → Accessibility, SEO 除外
+   - ドキュメントのみ変更 → Quality, Architect を優先
+2. 有効なエキスパートの `references/experts/*.md` から **プロンプトを個別に読み込む**
+3. 有効なエキスパートのみ **Bash で codex exec を並列実行**
+4. 絶対に1回の呼び出しで複数観点をまとめない
+
+```
+正しい（CLI 並列実行）:
+  Bash(codex exec --sandbox read-only "$(cat experts/security-expert.md)" &)
+  Bash(codex exec --sandbox read-only "$(cat experts/performance-expert.md)" &)
+  Bash(codex exec --sandbox read-only "$(cat experts/quality-expert.md)" &)
+  wait
+
+間違い:
+  mcp__codex__codex({prompt: "..."})  ← hookでBLOCKED
+```
+
+**詳細**: [references/codex-parallel-review.md](references/codex-parallel-review.md)
+
+---
+
+## 実行方法
+
+### 単発レビュー（経路A）
+
+```bash
+# codex-parallel.sh --review を使用
+bash ~/.claude/scripts/codex-parallel.sh --review "$(pwd)" --base develop
+```
+
+### 直接 CLI 呼び出し
+
+```bash
+# codex exec で直接レビュー
+codex exec --sandbox read-only "以下のコードをレビューしてください: ..."
+```
+
+### 並列エキスパートレビュー
+
+```bash
+# 各エキスパートを個別に並列実行
+codex exec --sandbox read-only -o /tmp/review-security.md "$SECURITY_PROMPT" &
+codex exec --sandbox read-only -o /tmp/review-performance.md "$PERF_PROMPT" &
+codex exec --sandbox read-only -o /tmp/review-quality.md "$QUALITY_PROMPT" &
+wait
+# 結果を統合
+```
+
+---
+
+## レビューワークフロー
+
+### Solo モード
+
+```
+/codex-review 実行
+    │
+    ├── Claude レビュー（従来通り）
+    │
+    └── codex exec CLI 呼び出し
+            │
+            └── 結果統合
+```
+
+### 2-Agent モード
+
+```
+PM（Cursor / Codex）
+    │
+    └── タスク依頼
+            │
+            ├── Claude Code 実装
+            │
+            └── /harness-review
+                    │
+                    ├── Claude レビュー
+                    └── Codex CLI セカンドオピニオン
+```
+
+---
+
+## 設定
+
+`.claude-code-harness.config.yaml` で Codex 統合を設定:
+
+```yaml
+review:
+  codex:
+    enabled: true
+    auto: false
+    prompt: "Review the code and output issues and improvement suggestions"
+    execution_mode: exec   # CLI直接実行（唯一のサポートモード）
+```
+
+| 設定項目 | デフォルト | 説明 |
+|---------|-----------|------|
+| `enabled` | `false` | Codex 統合の有効/無効 |
+| `auto` | `false` | 自動レビュー実行 |
+| `prompt` | (上記) | Codex へのレビュープロンプト |
+| `execution_mode` | `exec` | CLI 直接実行（MCP は廃止） |
+
+> **Note**: `execution_mode: mcp` はレガシーであり `block-codex-mcp.sh` によりブロックされます。
+> 単発・並列ともに `codex exec` CLI を使用してください。
+
+---
+
+## 注意事項
+
+### MCP 廃止について
+
+- Codex MCP (`mcp__codex__*`) は `block-codex-mcp.sh` hook により PreToolUse でブロックされます
+- delegation.md: "Codex MCP使用禁止 — CLI経由のみ"
+- ADR-004: 3-Phase Model で Codex は CLI 経由の大規模委任に使用
+- **全ての呼び出しは `codex exec` CLI で行うこと**
+
+### 並列実行と ADR-004 の整合
+
+ADR-004 の「Max 1 concurrent Codex request」は **Route C（実装・workspace-write）** に対するルール。
+並列エキスパートレビューは `--sandbox read-only` で worktree を使用しないため安全:
+
+| | Route C（実装） | 並列レビュー |
+|--|----------------|-------------|
+| sandbox | workspace-write | read-only |
+| worktree | 使用（コンフリクトリスク） | 不使用 |
+| ADR-004 制限 | 1並列 | 制限なし |
+
+API レート制限を考慮し、同時実行は最大4プロセスを推奨。
+
+### パフォーマンス
+
+- `codex exec --sandbox read-only` は独立APIクエリとして動作
+- 並列実行は Bash のバックグラウンドジョブ (`&` + `wait`) で実現
+- 各プロセスは worktree を作らず、ファイル書き込みも行わない
+
+### コスト
+
+- Codex API 利用には OpenAI のクレジットが必要です
+- レビュー頻度に応じたコスト見積もりを推奨
+
+---
+
+## 参考資料
+
+- ADR-004: Codex大規模委任モデル (`docs/adr/004-codex-delegation-model.md`)
+- delegation.md: Codex CLI 3経路 (`rules/delegation.md`)
+- scripts/README.md: CLI routes (`scripts/README.md`)
+- block-codex-mcp.sh: MCP ブロック hook (`hooks/block-codex-mcp.sh`)

--- a/skills/codex-review/SKILL.md
+++ b/skills/codex-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codex-review
-description: "Codexにセカンドオピニオンを求める。AI同士の忖度なしガチレビュー。Use when user mentions 'Codex レビュー', 'セカンドオピニオン', 'Codex の意見', 'Codex でレビュー', or 'Codex セットアップ'. Do NOT load for: 'Codex に実装させて', 'Codex Worker', 'Codex に作らせて', '実装を依頼'."
+description: "Codexにセカンドオピニオンを求める。AI同士の忖度なしガチレビュー。Use when user mentions 'Codex レビュー', 'セカンドオピニオン', 'Codex の意見', 'Codex でレビュー'. Do NOT load for: 'Codex に実装させて', 'Codex Worker', 'Codex に作らせて', '実装を依頼'."
 allowed-tools: ["Bash", "Read", "Write", "Edit"]
 argument-hint: "[code|plan|scope]"
 ---
@@ -9,131 +9,62 @@ argument-hint: "[code|plan|scope]"
 
 OpenAI Codex CLI を使用してコードレビュー時にセカンドオピニオンを提供するスキル。
 
-> **重要**: Codex MCP (`mcp__codex__*`) は使用禁止です（delegation.md / Issue #72）。
-> 全ての Codex 呼び出しは CLI (`codex exec`) 経由で行います。
+> **重要**: Codex MCP (`mcp__codex__*`) は使用禁止（delegation.md / Issue #72）。
+> 全ての Codex 呼び出しは `codex exec --sandbox read-only` で行う。
 > Ref: ADR-004, `hooks/block-codex-mcp.sh`
 
-## Do NOT Load For (誤発動防止)
+## Do NOT Load For
 
-以下のキーワードは `codex-worker` スキルが担当します:
+以下は `codex-worker` スキル（ハーネスプラグイン提供）が担当:
 
-| トリガーワード | 正しいスキル | 理由 |
-|---------------|-------------|------|
-| "Codex に実装させて" | `codex-worker` | 実装 ≠ レビュー |
-| "Codex Worker" | `codex-worker` | Worker = 実装役 |
-| "Codex に作らせて" | `codex-worker` | 作成 = 実装 |
-| "実装を依頼" | `codex-worker` | 実装目的 |
+- "Codex に実装させて" / "Codex Worker" / "Codex に作らせて" / "実装を依頼"
 
-## 使用場面
+## 実行方法（統一: `codex exec --sandbox read-only`）
 
-### レビュー
-- **セカンドオピニオン**: Claude のレビュー結果に Codex の視点を追加
-- **コード品質チェック**: 複数 AI モデルの得意分野を活用
-- **設計レビュー**: アーキテクチャや実装パターンの多角的検証
+全てのレビューは `codex exec --sandbox read-only` で実行する。
+`codex-parallel.sh --review`（Route A）も内部的に同じ CLI を呼ぶため、
+直接 `codex exec` を使用することでシンプルに統一。
 
-## 機能詳細
+### 単発レビュー
 
-| 機能 | 詳細 |
-|------|------|
-| **レビュー統合** | See [references/codex-review-integration.md](references/codex-review-integration.md) |
-| **並列レビュー** | See [references/codex-parallel-review.md](references/codex-parallel-review.md) |
-
-## 実行手順
-
-1. ユーザーのリクエストを分類
-2. 上記の「機能詳細」から適切な参照ファイルを読む
-3. その内容に従って CLI でレビューを実行
-
-### 並列レビュー時の必須ルール
-
-**Codex モード（`review.mode: codex`）でのレビュー実行時**:
-
-1. **呼び出すエキスパートを判定**（全部ではなく必要なもののみ）:
-   - 設定で `enabled: false` → 除外
-   - CLI/バックエンド → Accessibility, SEO 除外
-   - ドキュメントのみ変更 → Quality, Architect を優先
-2. 有効なエキスパートの `references/experts/*.md` から **プロンプトを個別に読み込む**
-3. 有効なエキスパートのみ **Bash で codex exec を並列実行**
-4. 絶対に1回の呼び出しで複数観点をまとめない
-
+```bash
+codex exec -C "$(pwd)" --sandbox read-only \
+  "以下の変更をレビューしてください: $(git diff HEAD~1)"
 ```
-正しい（CLI 並列実行）:
-  Bash(codex exec --sandbox read-only "$(cat experts/security-expert.md)" &)
-  Bash(codex exec --sandbox read-only "$(cat experts/performance-expert.md)" &)
-  Bash(codex exec --sandbox read-only "$(cat experts/quality-expert.md)" &)
-  wait
 
-間違い:
-  mcp__codex__codex({prompt: "..."})  ← hookでBLOCKED
+> **Note**: 出力をファイルに保存する場合は stdout をキャプチャする。
+> `-o` (`--output-last-message`) はエージェントの最後のメッセージのみ出力するため、
+> 完全な出力には `| tee /tmp/review.md` を推奨。
+
+### 並列エキスパートレビュー
+
+```bash
+# 各エキスパートを個別に並列実行（read-only = worktree不使用 = 安全）
+codex exec -C "$(pwd)" --sandbox read-only \
+  "$(cat experts/security-expert.md)" > /tmp/review-security.md 2>/dev/null &
+codex exec -C "$(pwd)" --sandbox read-only \
+  "$(cat experts/performance-expert.md)" > /tmp/review-perf.md 2>/dev/null &
+codex exec -C "$(pwd)" --sandbox read-only \
+  "$(cat experts/quality-expert.md)" > /tmp/review-quality.md 2>/dev/null &
+wait
 ```
+
+> `experts/*.md` はハーネスプラグインが提供。未設定時はプロジェクト固有のプロンプトを作成すること。
 
 **詳細**: [references/codex-parallel-review.md](references/codex-parallel-review.md)
 
 ---
 
-## 実行方法
+## 機能詳細
 
-### 単発レビュー（経路A）
-
-```bash
-# codex-parallel.sh --review を使用
-bash ~/.claude/scripts/codex-parallel.sh --review "$(pwd)" --base develop
-```
-
-### 直接 CLI 呼び出し
-
-```bash
-# codex exec で直接レビュー
-codex exec --sandbox read-only "以下のコードをレビューしてください: ..."
-```
-
-### 並列エキスパートレビュー
-
-```bash
-# 各エキスパートを個別に並列実行
-codex exec --sandbox read-only -o /tmp/review-security.md "$SECURITY_PROMPT" &
-codex exec --sandbox read-only -o /tmp/review-performance.md "$PERF_PROMPT" &
-codex exec --sandbox read-only -o /tmp/review-quality.md "$QUALITY_PROMPT" &
-wait
-# 結果を統合
-```
-
----
-
-## レビューワークフロー
-
-### Solo モード
-
-```
-/codex-review 実行
-    │
-    ├── Claude レビュー（従来通り）
-    │
-    └── codex exec CLI 呼び出し
-            │
-            └── 結果統合
-```
-
-### 2-Agent モード
-
-```
-PM（Cursor / Codex）
-    │
-    └── タスク依頼
-            │
-            ├── Claude Code 実装
-            │
-            └── /harness-review
-                    │
-                    ├── Claude レビュー
-                    └── Codex CLI セカンドオピニオン
-```
-
----
+| 機能 | 詳細 |
+|------|------|
+| **並列レビュー** | See [references/codex-parallel-review.md](references/codex-parallel-review.md) |
+| **レビュー統合** | See [references/codex-review-integration.md](references/codex-review-integration.md) |
 
 ## 設定
 
-`.claude-code-harness.config.yaml` で Codex 統合を設定:
+`.claude-code-harness.config.yaml` で設定（ハーネスプラグインの設定ファイル）:
 
 ```yaml
 review:
@@ -141,59 +72,35 @@ review:
     enabled: true
     auto: false
     prompt: "Review the code and output issues and improvement suggestions"
-    execution_mode: exec   # CLI直接実行（唯一のサポートモード）
 ```
 
-| 設定項目 | デフォルト | 説明 |
-|---------|-----------|------|
-| `enabled` | `false` | Codex 統合の有効/無効 |
-| `auto` | `false` | 自動レビュー実行 |
-| `prompt` | (上記) | Codex へのレビュープロンプト |
-| `execution_mode` | `exec` | CLI 直接実行（MCP は廃止） |
-
-> **Note**: `execution_mode: mcp` はレガシーであり `block-codex-mcp.sh` によりブロックされます。
-> 単発・並列ともに `codex exec` CLI を使用してください。
-
----
+> `execution_mode: mcp` はレガシー。`block-codex-mcp.sh` によりブロックされるため使用不可。
 
 ## 注意事項
 
-### MCP 廃止について
-
-- Codex MCP (`mcp__codex__*`) は `block-codex-mcp.sh` hook により PreToolUse でブロックされます
-- delegation.md: "Codex MCP使用禁止 — CLI経由のみ"
-- ADR-004: 3-Phase Model で Codex は CLI 経由の大規模委任に使用
-- **全ての呼び出しは `codex exec` CLI で行うこと**
-
 ### 並列実行と ADR-004 の整合
 
-ADR-004 の「Max 1 concurrent Codex request」は **Route C（実装・workspace-write）** に対するルール。
-並列エキスパートレビューは `--sandbox read-only` で worktree を使用しないため安全:
+ADR-004「Max 1 concurrent Codex request」は Route C（実装・workspace-write）に対するルール。
+`--sandbox read-only` レビューは worktree 不使用・ファイル書き込みなしのため並列安全。
+詳細は [references/codex-parallel-review.md](references/codex-parallel-review.md) を参照。
 
-| | Route C（実装） | 並列レビュー |
-|--|----------------|-------------|
-| sandbox | workspace-write | read-only |
-| worktree | 使用（コンフリクトリスク） | 不使用 |
-| ADR-004 制限 | 1並列 | 制限なし |
+> **TODO**: この解釈は ADR-004 の amendment で正式に明文化すべき。
 
-API レート制限を考慮し、同時実行は最大4プロセスを推奨。
+### 発火検証結果（2026-03-29）
 
-### パフォーマンス
-
-- `codex exec --sandbox read-only` は独立APIクエリとして動作
-- 並列実行は Bash のバックグラウンドジョブ (`&` + `wait`) で実現
-- 各プロセスは worktree を作らず、ファイル書き込みも行わない
-
-### コスト
-
-- Codex API 利用には OpenAI のクレジットが必要です
-- レビュー頻度に応じたコスト見積もりを推奨
+| 検証項目 | 結果 |
+|---------|------|
+| `block-codex-mcp.sh` exit code | 2 (ブロック成功) |
+| stderr メッセージ | "[BLOCKED] Codex MCP..." 出力確認 |
+| MD5 (`~/.claude/hooks/` vs `hooks/`) | 一致 |
+| `settings.json` matcher | `mcp__codex__.*` 登録済み |
+| `codex` CLI | v0.117.0 (`/opt/homebrew/bin/codex`) |
+| `--sandbox read-only` フラグ | 利用可能 |
 
 ---
 
 ## 参考資料
 
 - ADR-004: Codex大規模委任モデル (`docs/adr/004-codex-delegation-model.md`)
-- delegation.md: Codex CLI 3経路 (`rules/delegation.md`)
-- scripts/README.md: CLI routes (`scripts/README.md`)
+- delegation.md: Codex CLI 経路 (`rules/delegation.md`)
 - block-codex-mcp.sh: MCP ブロック hook (`hooks/block-codex-mcp.sh`)

--- a/skills/codex-review/references/codex-parallel-review.md
+++ b/skills/codex-review/references/codex-parallel-review.md
@@ -127,7 +127,7 @@ git diff --name-only HEAD~1
 差分コンテキストを注入:
 
 ```bash
-for file in $(git diff --name-only HEAD~1); do
+git diff -z --name-only HEAD~1 | while IFS= read -r -d '' file; do
   echo "=== $file ==="
   git diff HEAD~1 -- "$file" | head -200
 done

--- a/skills/codex-review/references/codex-parallel-review.md
+++ b/skills/codex-review/references/codex-parallel-review.md
@@ -1,0 +1,244 @@
+# Codex 並列レビュー実行ガイド（CLI版）
+
+Codex モード時に複数のエキスパートを CLI (`codex exec`) 経由で並列呼び出しするオーケストレーション手順。
+
+> **重要**: Codex MCP (`mcp__codex__*`) は `block-codex-mcp.sh` によりブロックされます。
+> 並列実行は Bash バックグラウンドジョブ (`&` + `wait`) で実現します。
+> Ref: delegation.md, ADR-004, Issue #72, Issue #197
+
+## 並列実行の安全性（ADR-004 との整合）
+
+ADR-004 は「Max 1 concurrent Codex request from Claude Code」と規定しているが、
+これは **Route C（実装委任・workspace-write sandbox・worktree 使用）** に対するルール。
+
+並列エキスパートレビューは以下の理由で安全:
+
+| 項目 | Route C（実装） | 並列レビュー |
+|------|----------------|-------------|
+| sandbox | workspace-write | **read-only** |
+| worktree | 作成する（コンフリクトリスク） | **使用しない** |
+| ファイル書き込み | あり | **なし** |
+| ADR-004 制限 | 1並列 | **制限なし**（read-only） |
+
+**結論**: `codex exec --sandbox read-only` は独立したAPIクエリとして動作し、
+worktree もファイル書き込みも行わないため、複数プロセスの同時実行は安全。
+ただし OpenAI API のレート制限に注意し、同時実行は最大4プロセスを推奨。
+
+## 概要
+
+Codex モードでは、Claude がオーケストレーターとして **4 つのエキスパート** を CLI 経由で並列呼び出しします。レビュータイプに応じて異なるエキスパートが使用されます。
+
+## レビュータイプと4つのエキスパート
+
+| Review Type | 4 Experts | Expert Files |
+|-------------|-----------|--------------|
+| **Code** | Security, Performance, Quality, Accessibility | `security-expert.md`, `performance-expert.md`, `quality-expert.md`, `accessibility-expert.md` |
+| **Plan** | Clarity, Feasibility, Dependencies, Acceptance | `clarity-expert.md`, `feasibility-expert.md`, `dependencies-expert.md`, `acceptance-expert.md` |
+| **Scope** | Scope-creep, Priority, Feasibility, Impact | `scope-creep-expert.md`, `priority-expert.md`, `scope-feasibility-expert.md`, `impact-expert.md` |
+
+```
+Claude (オーケストレーター)
+    ↓
+レビュータイプ判定
+    ↓
+Bash 並列 CLI 実行 (codex exec × N experts)
+    ├── Expert 1 (background)
+    ├── Expert 2 (background)
+    ├── Expert 3 (background)
+    └── Expert 4 (background)
+    ↓ wait
+結果統合 → 判定
+```
+
+---
+
+## 並列呼び出し必須ルール（MANDATORY）
+
+### 禁止事項
+
+| 禁止 | 理由 |
+|------|------|
+| ❌ `mcp__codex__codex` を使用する | `block-codex-mcp.sh` でブロックされる |
+| ❌ 1回の CLI 呼び出しで複数エキスパートをまとめる | 各エキスパートの専門性が薄まる |
+| ❌ experts/*.md を読まずに汎用プロンプトを送る | 専門家プロンプトの知見が活かされない |
+
+### 必須事項
+
+| 必須 | 方法 |
+|------|------|
+| ✅ `codex exec` CLI を使用する | MCP ではなく CLI 経由 |
+| ✅ 各エキスパートを **個別の CLI 呼び出し** で実行 | `codex exec` をレビュータイプに応じて4回呼び出し |
+| ✅ experts/*.md から **個別にプロンプトを読み込む** | ファイルごとに別プロセスで実行 |
+| ✅ **Bash バックグラウンドジョブで並列実行** | `&` + `wait` で並列化 |
+
+### 正しい実行パターン
+
+```bash
+# 各エキスパートを個別に並列実行
+codex exec --sandbox read-only -o /tmp/review-security.md \
+  "$(cat experts/security-expert.md)" &
+PID1=$!
+
+codex exec --sandbox read-only -o /tmp/review-performance.md \
+  "$(cat experts/performance-expert.md)" &
+PID2=$!
+
+codex exec --sandbox read-only -o /tmp/review-quality.md \
+  "$(cat experts/quality-expert.md)" &
+PID3=$!
+
+codex exec --sandbox read-only -o /tmp/review-accessibility.md \
+  "$(cat experts/accessibility-expert.md)" &
+PID4=$!
+
+# 全エキスパートの完了を待機
+wait $PID1 $PID2 $PID3 $PID4
+```
+
+### なぜ分けるのか
+
+| 1回でまとめた場合 | 4回に分けた場合 |
+|------------------|-----------------|
+| 各観点が2-3行で浅い | 各観点が詳細に分析される |
+| 重要な問題を見落とす | 専門家視点で漏れなく検出 |
+| 「問題なし」で終わりやすい | 具体的な改善提案が出る |
+
+---
+
+## 実行フロー
+
+### Step 1: 設定確認
+
+```yaml
+# .claude-code-harness.config.yaml
+review:
+  mode: codex
+  codex:
+    enabled: true
+    execution_mode: exec   # CLI固定（MCP廃止）
+    code_experts:
+      security: true
+      accessibility: true
+      performance: true
+      quality: true
+```
+
+### Step 2: 変更ファイルの収集
+
+```bash
+git diff --name-only HEAD~1
+```
+
+### Step 3: エキスパート判定（フィルタリング）
+
+設定で `false` のエキスパートは除外。プロジェクト種別により自動除外:
+
+| プロジェクト種別 | 自動除外 |
+|-----------------|---------|
+| CLI / バックエンドAPI | Accessibility, SEO |
+| Webフロントエンド | （全て有効） |
+| ドキュメントのみ | Security, Performance, Accessibility |
+
+### Step 4: プロンプト準備
+
+`experts/*.md` から読み込み、変数を展開:
+
+| 変数 | 取得方法 |
+|------|----------|
+| `{files}` | `git diff --name-only HEAD~1` |
+| `{tech_stack}` | package.json から検出 |
+
+差分コンテキストも注入:
+
+```bash
+for file in $(git diff --name-only HEAD~1); do
+  echo "=== $file ==="
+  git diff HEAD~1 -- "$file" | head -200
+done
+```
+
+### Step 5: CLI 並列実行
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_PATH="$(pwd)"
+OUTPUT_DIR="/tmp/codex-review-$(date +%s)"
+mkdir -p "$OUTPUT_DIR"
+
+run_expert() {
+    local name="$1"
+    local prompt_file="$2"
+    local output_file="${OUTPUT_DIR}/${name}.md"
+    codex exec \
+        -C "$REPO_PATH" \
+        --sandbox read-only \
+        -o "$output_file" \
+        "$(cat "$prompt_file")" 2>/dev/null
+    echo "[${name}] Done → ${output_file}"
+}
+
+run_expert "security" "experts/security-expert.md" &
+run_expert "performance" "experts/performance-expert.md" &
+run_expert "quality" "experts/quality-expert.md" &
+run_expert "accessibility" "experts/accessibility-expert.md" &
+
+wait
+echo "All experts completed. Results in: ${OUTPUT_DIR}/"
+```
+
+### Step 5.1: 出力制限ルール
+
+| 制約 | 内容 |
+|------|------|
+| 言語 | English only（統合時に日本語化） |
+| 最大文字数 | 2500 文字 |
+| スコア | A-F |
+| 件数 | Critical/High: 全件、Medium: 5件、Low: 3件 |
+
+### Step 6: 結果統合
+
+```markdown
+## Codex 並列レビュー結果
+
+| Expert | Score | Critical | High | Medium | Low |
+|--------|-------|----------|------|--------|-----|
+| Security | B | 0 | 1 | 2 | 3 |
+| Performance | C | 0 | 2 | 3 | 1 |
+| Quality | B | 0 | 0 | 4 | 5 |
+| Accessibility | A | 0 | 0 | 1 | 2 |
+```
+
+### Step 7: コミット判定
+
+| 集計 | 判定 | アクション |
+|------|------|-----------|
+| Critical >= 1 | REJECT | 手動介入必須 |
+| High >= 1 | REQUEST CHANGES | 自動修正ループ（最大3回） |
+| Critical = 0, High = 0 | APPROVE | コミット可能 |
+
+> Low/Medium のみは APPROVE（重箱の隅つつき防止）。
+
+---
+
+## エラーハンドリング
+
+一部エキスパート失敗時は成功分で判定続行。全失敗時は Claude 単体レビューにフォールバック。
+
+## MCP からの移行
+
+| 旧（MCP・廃止） | 新（CLI） |
+|-----------------|-----------|
+| `mcp__codex__codex({prompt: ...})` | `codex exec --sandbox read-only "..."` |
+| Claude 並列ツール呼び出し | Bash `&` + `wait` |
+| MCP サーバー登録必要 | CLI のみ、登録不要 |
+
+## 並列実行上の注意
+
+- **API レート制限**: OpenAI API のレート制限により、同時4プロセスを超える並列は推奨しない
+- **Route C との区別**: 実装委任（Route C）は ADR-004 により1並列。レビュー（read-only）は並列可
+- **codex-parallel.sh --review（Route A）**: 単一プロセスで実行。並列エキスパートレビューとは別経路
+- **コスト**: 4並列 = 4倍のAPIコール。必要なエキスパートのみ有効化してコスト最適化
+
+> Ref: Issue #197, delegation.md, ADR-004

--- a/skills/codex-review/references/codex-parallel-review.md
+++ b/skills/codex-review/references/codex-parallel-review.md
@@ -1,107 +1,92 @@
 # Codex 並列レビュー実行ガイド（CLI版）
 
-Codex モード時に複数のエキスパートを CLI (`codex exec`) 経由で並列呼び出しするオーケストレーション手順。
+複数のエキスパートを `codex exec --sandbox read-only` で並列呼び出しするオーケストレーション手順。
 
-> **重要**: Codex MCP (`mcp__codex__*`) は `block-codex-mcp.sh` によりブロックされます。
-> 並列実行は Bash バックグラウンドジョブ (`&` + `wait`) で実現します。
+> **重要**: Codex MCP (`mcp__codex__*`) は `block-codex-mcp.sh` によりブロック。
 > Ref: delegation.md, ADR-004, Issue #72, Issue #197
 
 ## 並列実行の安全性（ADR-004 との整合）
 
-ADR-004 は「Max 1 concurrent Codex request from Claude Code」と規定しているが、
-これは **Route C（実装委任・workspace-write sandbox・worktree 使用）** に対するルール。
-
-並列エキスパートレビューは以下の理由で安全:
+ADR-004「Max 1 concurrent Codex request」は **Route C（実装・workspace-write・worktree 使用）** に対するルール。
 
 | 項目 | Route C（実装） | 並列レビュー |
 |------|----------------|-------------|
 | sandbox | workspace-write | **read-only** |
-| worktree | 作成する（コンフリクトリスク） | **使用しない** |
+| worktree | 作成（コンフリクトリスク） | **不使用** |
 | ファイル書き込み | あり | **なし** |
-| ADR-004 制限 | 1並列 | **制限なし**（read-only） |
+| ADR-004 制限 | 1並列 | **制限なし** |
 
-**結論**: `codex exec --sandbox read-only` は独立したAPIクエリとして動作し、
-worktree もファイル書き込みも行わないため、複数プロセスの同時実行は安全。
-ただし OpenAI API のレート制限に注意し、同時実行は最大4プロセスを推奨。
+`codex exec --sandbox read-only` は独立 API クエリとして動作し、
+worktree もファイル書き込みも行わないため並列安全。
+API レート制限を考慮し同時最大4プロセスを推奨。
+
+> **TODO**: この解釈は ADR-004 amendment で正式に明文化すべき。
 
 ## 概要
 
-Codex モードでは、Claude がオーケストレーターとして **4 つのエキスパート** を CLI 経由で並列呼び出しします。レビュータイプに応じて異なるエキスパートが使用されます。
-
-## レビュータイプと4つのエキスパート
-
-| Review Type | 4 Experts | Expert Files |
-|-------------|-----------|--------------|
-| **Code** | Security, Performance, Quality, Accessibility | `security-expert.md`, `performance-expert.md`, `quality-expert.md`, `accessibility-expert.md` |
-| **Plan** | Clarity, Feasibility, Dependencies, Acceptance | `clarity-expert.md`, `feasibility-expert.md`, `dependencies-expert.md`, `acceptance-expert.md` |
-| **Scope** | Scope-creep, Priority, Feasibility, Impact | `scope-creep-expert.md`, `priority-expert.md`, `scope-feasibility-expert.md`, `impact-expert.md` |
+Claude がオーケストレーターとして **4 つのエキスパート** を CLI 並列呼び出し。
 
 ```
 Claude (オーケストレーター)
-    ↓
-レビュータイプ判定
-    ↓
-Bash 並列 CLI 実行 (codex exec × N experts)
-    ├── Expert 1 (background)
-    ├── Expert 2 (background)
-    ├── Expert 3 (background)
-    └── Expert 4 (background)
+    ↓ レビュータイプ判定
+    ↓ Bash 並列 (codex exec × N)
+    ├── Expert 1 &
+    ├── Expert 2 &
+    ├── Expert 3 &
+    └── Expert 4 &
     ↓ wait
 結果統合 → 判定
 ```
 
+## レビュータイプとエキスパート
+
+| Type | 4 Experts |
+|------|-----------|
+| **Code** | Security, Performance, Quality, Accessibility |
+| **Plan** | Clarity, Feasibility, Dependencies, Acceptance |
+| **Scope** | Scope-creep, Priority, Feasibility, Impact |
+
+> `experts/*.md` プロンプトファイルはハーネスプラグインが提供。
+> 未設定時はプロジェクト固有のプロンプトを `skills/codex-review/experts/` に作成すること。
+
 ---
 
-## 並列呼び出し必須ルール（MANDATORY）
+## 必須ルール
 
-### 禁止事項
+### 禁止
 
 | 禁止 | 理由 |
 |------|------|
-| ❌ `mcp__codex__codex` を使用する | `block-codex-mcp.sh` でブロックされる |
-| ❌ 1回の CLI 呼び出しで複数エキスパートをまとめる | 各エキスパートの専門性が薄まる |
-| ❌ experts/*.md を読まずに汎用プロンプトを送る | 専門家プロンプトの知見が活かされない |
-
-### 必須事項
-
-| 必須 | 方法 |
-|------|------|
-| ✅ `codex exec` CLI を使用する | MCP ではなく CLI 経由 |
-| ✅ 各エキスパートを **個別の CLI 呼び出し** で実行 | `codex exec` をレビュータイプに応じて4回呼び出し |
-| ✅ experts/*.md から **個別にプロンプトを読み込む** | ファイルごとに別プロセスで実行 |
-| ✅ **Bash バックグラウンドジョブで並列実行** | `&` + `wait` で並列化 |
+| `mcp__codex__codex` を使用 | `block-codex-mcp.sh` でブロック |
+| 1回で複数エキスパートをまとめる | 専門性が薄まる |
+| experts/*.md を読まずに汎用プロンプト | 専門知見が活かされない |
 
 ### 正しい実行パターン
 
 ```bash
-# 各エキスパートを個別に並列実行
-codex exec --sandbox read-only -o /tmp/review-security.md \
-  "$(cat experts/security-expert.md)" &
+REPO="$(pwd)"
+
+# stdout キャプチャで完全な出力を取得
+# Note: -o (--output-last-message) は最後のメッセージのみ。
+#       完全な出力には stdout リダイレクトを使用。
+codex exec -C "$REPO" --sandbox read-only \
+  "$(cat experts/security-expert.md)" > /tmp/review-security.md 2>/dev/null &
 PID1=$!
 
-codex exec --sandbox read-only -o /tmp/review-performance.md \
-  "$(cat experts/performance-expert.md)" &
+codex exec -C "$REPO" --sandbox read-only \
+  "$(cat experts/performance-expert.md)" > /tmp/review-perf.md 2>/dev/null &
 PID2=$!
 
-codex exec --sandbox read-only -o /tmp/review-quality.md \
-  "$(cat experts/quality-expert.md)" &
+codex exec -C "$REPO" --sandbox read-only \
+  "$(cat experts/quality-expert.md)" > /tmp/review-quality.md 2>/dev/null &
 PID3=$!
 
-codex exec --sandbox read-only -o /tmp/review-accessibility.md \
-  "$(cat experts/accessibility-expert.md)" &
+codex exec -C "$REPO" --sandbox read-only \
+  "$(cat experts/accessibility-expert.md)" > /tmp/review-a11y.md 2>/dev/null &
 PID4=$!
 
-# 全エキスパートの完了を待機
 wait $PID1 $PID2 $PID3 $PID4
 ```
-
-### なぜ分けるのか
-
-| 1回でまとめた場合 | 4回に分けた場合 |
-|------------------|-----------------|
-| 各観点が2-3行で浅い | 各観点が詳細に分析される |
-| 重要な問題を見落とす | 専門家視点で漏れなく検出 |
-| 「問題なし」で終わりやすい | 具体的な改善提案が出る |
 
 ---
 
@@ -110,12 +95,10 @@ wait $PID1 $PID2 $PID3 $PID4
 ### Step 1: 設定確認
 
 ```yaml
-# .claude-code-harness.config.yaml
+# .claude-code-harness.config.yaml（ハーネスプラグインの設定ファイル）
 review:
-  mode: codex
   codex:
     enabled: true
-    execution_mode: exec   # CLI固定（MCP廃止）
     code_experts:
       security: true
       accessibility: true
@@ -123,32 +106,25 @@ review:
       quality: true
 ```
 
-### Step 2: 変更ファイルの収集
+### Step 2: 変更ファイル収集
 
 ```bash
 git diff --name-only HEAD~1
 ```
 
-### Step 3: エキスパート判定（フィルタリング）
+### Step 3: エキスパート判定
 
-設定で `false` のエキスパートは除外。プロジェクト種別により自動除外:
+設定で `false` は除外。プロジェクト種別で自動除外:
 
-| プロジェクト種別 | 自動除外 |
-|-----------------|---------|
-| CLI / バックエンドAPI | Accessibility, SEO |
-| Webフロントエンド | （全て有効） |
+| 種別 | 除外 |
+|------|------|
+| CLI / バックエンド | Accessibility, SEO |
+| Webフロントエンド | なし |
 | ドキュメントのみ | Security, Performance, Accessibility |
 
 ### Step 4: プロンプト準備
 
-`experts/*.md` から読み込み、変数を展開:
-
-| 変数 | 取得方法 |
-|------|----------|
-| `{files}` | `git diff --name-only HEAD~1` |
-| `{tech_stack}` | package.json から検出 |
-
-差分コンテキストも注入:
+差分コンテキストを注入:
 
 ```bash
 for file in $(git diff --name-only HEAD~1); do
@@ -170,13 +146,11 @@ mkdir -p "$OUTPUT_DIR"
 run_expert() {
     local name="$1"
     local prompt_file="$2"
-    local output_file="${OUTPUT_DIR}/${name}.md"
     codex exec \
         -C "$REPO_PATH" \
         --sandbox read-only \
-        -o "$output_file" \
-        "$(cat "$prompt_file")" 2>/dev/null
-    echo "[${name}] Done → ${output_file}"
+        "$(cat "$prompt_file")" > "${OUTPUT_DIR}/${name}.md" 2>/dev/null
+    echo "[${name}] Done"
 }
 
 run_expert "security" "experts/security-expert.md" &
@@ -185,17 +159,8 @@ run_expert "quality" "experts/quality-expert.md" &
 run_expert "accessibility" "experts/accessibility-expert.md" &
 
 wait
-echo "All experts completed. Results in: ${OUTPUT_DIR}/"
+echo "Results in: ${OUTPUT_DIR}/"
 ```
-
-### Step 5.1: 出力制限ルール
-
-| 制約 | 内容 |
-|------|------|
-| 言語 | English only（統合時に日本語化） |
-| 最大文字数 | 2500 文字 |
-| スコア | A-F |
-| 件数 | Critical/High: 全件、Medium: 5件、Low: 3件 |
 
 ### Step 6: 結果統合
 
@@ -226,19 +191,21 @@ echo "All experts completed. Results in: ${OUTPUT_DIR}/"
 
 一部エキスパート失敗時は成功分で判定続行。全失敗時は Claude 単体レビューにフォールバック。
 
+## 出力制限ルール
+
+| 制約 | 内容 |
+|------|------|
+| 言語 | English only（統合時に日本語化） |
+| 最大文字数 | 2500 文字 |
+| スコア | A-F |
+| 件数 | Critical/High: 全件、Medium: 5件、Low: 3件 |
+
 ## MCP からの移行
 
 | 旧（MCP・廃止） | 新（CLI） |
 |-----------------|-----------|
 | `mcp__codex__codex({prompt: ...})` | `codex exec --sandbox read-only "..."` |
 | Claude 並列ツール呼び出し | Bash `&` + `wait` |
-| MCP サーバー登録必要 | CLI のみ、登録不要 |
-
-## 並列実行上の注意
-
-- **API レート制限**: OpenAI API のレート制限により、同時4プロセスを超える並列は推奨しない
-- **Route C との区別**: 実装委任（Route C）は ADR-004 により1並列。レビュー（read-only）は並列可
-- **codex-parallel.sh --review（Route A）**: 単一プロセスで実行。並列エキスパートレビューとは別経路
-- **コスト**: 4並列 = 4倍のAPIコール。必要なエキスパートのみ有効化してコスト最適化
+| MCP サーバー登録 | 不要 |
 
 > Ref: Issue #197, delegation.md, ADR-004

--- a/skills/codex-review/references/codex-review-integration.md
+++ b/skills/codex-review/references/codex-review-integration.md
@@ -1,123 +1,71 @@
----
-name: codex-review-integration
-description: "Codex CLI を使用したレビュー実行手順"
-allowed-tools: ["Read", "Bash"]
----
-
 # Codex レビュー実行（CLI版）
 
-Codex CLI (`codex exec`) を使用してコードレビューを実行する手順。
+`codex exec --sandbox read-only` を使用したレビュー実行手順。
 
-> **重要**: Codex MCP (`mcp__codex__*`) は使用禁止です（`block-codex-mcp.sh`）。
-> 全ての呼び出しは `codex exec` CLI 経由で行います。
+> **重要**: Codex MCP (`mcp__codex__*`) は使用禁止（`block-codex-mcp.sh`）。
 > Ref: delegation.md, ADR-004, Issue #72, Issue #197
-
----
-
-## 概要
-
-Codex CLI が設定済みの場合、以下の方法でレビューを実行できます:
-
-1. **`/harness-review` 経由**: 自動的に Codex CLI 統合
-2. **直接 CLI 呼び出し**: `codex exec` を直接使用
-3. **経路A**: `codex-parallel.sh --review` を使用
 
 ---
 
 ## 実行方法
 
-### 方法1: /harness-review 経由（推奨）
+全てのレビューは `codex exec --sandbox read-only` で統一。
 
-```
-ユーザー: /harness-review
-    ↓
-harness-review スキル起動
-    ↓
-codex.enabled 確認 → true
-    ↓
-Claude + Codex CLI 並列レビュー
-    ↓
-結果統合
-```
-
-### 方法2: codex-parallel.sh 経由（経路A）
+### 単発レビュー
 
 ```bash
-# レビューモードで実行
-bash ~/.claude/scripts/codex-parallel.sh --review "$(pwd)" --base develop
-```
-
-### 方法3: codex exec 直接呼び出し
-
-```bash
-# 単発レビュー
-codex exec --sandbox read-only \
-  "以下のコードをレビューしてください: $(git diff --name-only HEAD~1)"
-
-# 出力ファイル指定
-codex exec --sandbox read-only \
-  -o /tmp/codex-review-result.md \
+# 基本形
+codex exec -C "$(pwd)" --sandbox read-only \
   "以下の変更をレビューしてください: $(git diff HEAD~1)"
+
+# 出力をファイルに保存（stdout キャプチャ推奨）
+codex exec -C "$(pwd)" --sandbox read-only \
+  "以下の変更をレビューしてください: $(git diff HEAD~1)" | tee /tmp/review.md
+```
+
+> **Note**: `-o` (`--output-last-message`) はエージェントの最後のメッセージのみ出力。
+> 完全な出力には `| tee` または `> file.md` を使用。
+
+### 並列エキスパートレビュー
+
+複数のエキスパートプロンプトを並列実行:
+
+```bash
+codex exec -C "$(pwd)" --sandbox read-only \
+  "$(cat experts/security-expert.md)" > /tmp/review-security.md 2>/dev/null &
+codex exec -C "$(pwd)" --sandbox read-only \
+  "$(cat experts/quality-expert.md)" > /tmp/review-quality.md 2>/dev/null &
+wait
+```
+
+**詳細**: [codex-parallel-review.md](./codex-parallel-review.md)
+
+### /harness-review 経由
+
+```
+/harness-review → codex.enabled=true → codex exec 自動実行 → 結果統合
 ```
 
 ---
 
-## レビュープロンプト
-
-### デフォルトプロンプト
-
-```
-日本語でコードレビューを行い、問題点と改善提案を出力してください
-```
-
-### カスタマイズ例
+## レビュープロンプト例
 
 **セキュリティ重視**:
-```yaml
-review:
-  codex:
-    prompt: |
-      以下の観点でセキュリティレビューを行ってください:
-      1. 入力検証の不備
-      2. 認証・認可の問題
-      3. インジェクション脆弱性
-      4. 機密情報の露出
+```
+以下の観点でセキュリティレビューを行ってください:
+1. 入力検証の不備
+2. 認証・認可の問題
+3. インジェクション脆弱性
+4. 機密情報の露出
 ```
 
 **パフォーマンス重視**:
-```yaml
-review:
-  codex:
-    prompt: |
-      以下の観点でパフォーマンスレビューを行ってください:
-      1. N+1クエリ
-      2. 不要な再レンダリング
-      3. メモリリーク
-      4. 非効率なアルゴリズム
 ```
-
----
-
-## レビュー結果の形式
-
-### 統合フォーマット
-
-```markdown
-## Codex レビュー結果
-
-**サマリ**: 3件の改善提案
-
-### 問題点
-
-| ファイル | 行 | 重要度 | 内容 |
-|---------|-----|--------|------|
-| src/api/users.ts | 45 | 高 | SQL インジェクションの可能性 |
-| src/components/Form.tsx | 12 | 中 | useEffect の依存配列が不完全 |
-
-### 改善提案
-
-1. 関数を分割して可読性を向上
-2. 型定義を厳密化
+以下の観点でパフォーマンスレビューを行ってください:
+1. N+1クエリ
+2. 不要な再レンダリング
+3. メモリリーク
+4. 非効率なアルゴリズム
 ```
 
 ---
@@ -126,48 +74,33 @@ review:
 
 ### タイムアウト
 
+macOS では `gtimeout`（coreutils）を使用:
+
 ```bash
-# タイムアウト付きで実行（120秒）
-timeout 120 codex exec --sandbox read-only "..." || echo "Codex review timed out"
+gtimeout 120 codex exec --sandbox read-only "..." || echo "Codex review timed out"
 ```
 
 ### API エラー
 
-Codex CLI がエラーを返した場合:
 1. `codex login status` で認証確認
 2. OpenAI ダッシュボードでクレジット確認
-3. レート制限の場合は時間を置いて再試行
+3. レート制限時は時間を置いて再試行
 
 ---
 
-## ベストプラクティス
-
-### 効果的なレビューのために
-
-1. **対象を絞る**: 重要なファイルに集中
-2. **観点を明確に**: プロンプトでレビュー観点を指定
-3. **結果を比較**: Claude と Codex の指摘を比較して優先度判断
-
-### MCP ではなく CLI を使う理由
+## CLI を使う理由（MCP 廃止）
 
 | 観点 | MCP (廃止) | CLI (推奨) |
 |------|-----------|------------|
 | sandbox | なし | read-only/workspace-write |
 | worktree | 非対応 | 対応 |
 | hook 互換 | block-codex-mcp.sh でブロック | 正常動作 |
-| 進捗表示 | なし | あり |
-
-### 並列実行の安全性
-
-ADR-004 の「Max 1 concurrent Codex request」は Route C（実装・workspace-write）に対するルール。
-`codex exec --sandbox read-only` によるレビューは worktree を使用せず、ファイル書き込みも行わないため
-並列実行しても安全。API レート制限を考慮し同時最大4プロセスを推奨。
+| 並列安全性 | N/A | read-only で並列安全 |
 
 ---
 
 ## 関連ドキュメント
 
-- `scripts/codex-parallel.sh` — 経路A/C CLI スクリプト
+- [codex-parallel-review.md](./codex-parallel-review.md) — 並列実行ガイド
 - `hooks/block-codex-mcp.sh` — MCP ブロック hook
 - `docs/adr/004-codex-delegation-model.md` — Codex 委任モデル
-- `rules/delegation.md` — 委任ルール

--- a/skills/codex-review/references/codex-review-integration.md
+++ b/skills/codex-review/references/codex-review-integration.md
@@ -1,0 +1,173 @@
+---
+name: codex-review-integration
+description: "Codex CLI を使用したレビュー実行手順"
+allowed-tools: ["Read", "Bash"]
+---
+
+# Codex レビュー実行（CLI版）
+
+Codex CLI (`codex exec`) を使用してコードレビューを実行する手順。
+
+> **重要**: Codex MCP (`mcp__codex__*`) は使用禁止です（`block-codex-mcp.sh`）。
+> 全ての呼び出しは `codex exec` CLI 経由で行います。
+> Ref: delegation.md, ADR-004, Issue #72, Issue #197
+
+---
+
+## 概要
+
+Codex CLI が設定済みの場合、以下の方法でレビューを実行できます:
+
+1. **`/harness-review` 経由**: 自動的に Codex CLI 統合
+2. **直接 CLI 呼び出し**: `codex exec` を直接使用
+3. **経路A**: `codex-parallel.sh --review` を使用
+
+---
+
+## 実行方法
+
+### 方法1: /harness-review 経由（推奨）
+
+```
+ユーザー: /harness-review
+    ↓
+harness-review スキル起動
+    ↓
+codex.enabled 確認 → true
+    ↓
+Claude + Codex CLI 並列レビュー
+    ↓
+結果統合
+```
+
+### 方法2: codex-parallel.sh 経由（経路A）
+
+```bash
+# レビューモードで実行
+bash ~/.claude/scripts/codex-parallel.sh --review "$(pwd)" --base develop
+```
+
+### 方法3: codex exec 直接呼び出し
+
+```bash
+# 単発レビュー
+codex exec --sandbox read-only \
+  "以下のコードをレビューしてください: $(git diff --name-only HEAD~1)"
+
+# 出力ファイル指定
+codex exec --sandbox read-only \
+  -o /tmp/codex-review-result.md \
+  "以下の変更をレビューしてください: $(git diff HEAD~1)"
+```
+
+---
+
+## レビュープロンプト
+
+### デフォルトプロンプト
+
+```
+日本語でコードレビューを行い、問題点と改善提案を出力してください
+```
+
+### カスタマイズ例
+
+**セキュリティ重視**:
+```yaml
+review:
+  codex:
+    prompt: |
+      以下の観点でセキュリティレビューを行ってください:
+      1. 入力検証の不備
+      2. 認証・認可の問題
+      3. インジェクション脆弱性
+      4. 機密情報の露出
+```
+
+**パフォーマンス重視**:
+```yaml
+review:
+  codex:
+    prompt: |
+      以下の観点でパフォーマンスレビューを行ってください:
+      1. N+1クエリ
+      2. 不要な再レンダリング
+      3. メモリリーク
+      4. 非効率なアルゴリズム
+```
+
+---
+
+## レビュー結果の形式
+
+### 統合フォーマット
+
+```markdown
+## Codex レビュー結果
+
+**サマリ**: 3件の改善提案
+
+### 問題点
+
+| ファイル | 行 | 重要度 | 内容 |
+|---------|-----|--------|------|
+| src/api/users.ts | 45 | 高 | SQL インジェクションの可能性 |
+| src/components/Form.tsx | 12 | 中 | useEffect の依存配列が不完全 |
+
+### 改善提案
+
+1. 関数を分割して可読性を向上
+2. 型定義を厳密化
+```
+
+---
+
+## エラーハンドリング
+
+### タイムアウト
+
+```bash
+# タイムアウト付きで実行（120秒）
+timeout 120 codex exec --sandbox read-only "..." || echo "Codex review timed out"
+```
+
+### API エラー
+
+Codex CLI がエラーを返した場合:
+1. `codex login status` で認証確認
+2. OpenAI ダッシュボードでクレジット確認
+3. レート制限の場合は時間を置いて再試行
+
+---
+
+## ベストプラクティス
+
+### 効果的なレビューのために
+
+1. **対象を絞る**: 重要なファイルに集中
+2. **観点を明確に**: プロンプトでレビュー観点を指定
+3. **結果を比較**: Claude と Codex の指摘を比較して優先度判断
+
+### MCP ではなく CLI を使う理由
+
+| 観点 | MCP (廃止) | CLI (推奨) |
+|------|-----------|------------|
+| sandbox | なし | read-only/workspace-write |
+| worktree | 非対応 | 対応 |
+| hook 互換 | block-codex-mcp.sh でブロック | 正常動作 |
+| 進捗表示 | なし | あり |
+
+### 並列実行の安全性
+
+ADR-004 の「Max 1 concurrent Codex request」は Route C（実装・workspace-write）に対するルール。
+`codex exec --sandbox read-only` によるレビューは worktree を使用せず、ファイル書き込みも行わないため
+並列実行しても安全。API レート制限を考慮し同時最大4プロセスを推奨。
+
+---
+
+## 関連ドキュメント
+
+- `scripts/codex-parallel.sh` — 経路A/C CLI スクリプト
+- `hooks/block-codex-mcp.sh` — MCP ブロック hook
+- `docs/adr/004-codex-delegation-model.md` — Codex 委任モデル
+- `rules/delegation.md` — 委任ルール


### PR DESCRIPTION
## Summary
- Created `skills/codex-review/` with CLI-based skill replacing MCP (`mcp__codex__codex`) with `codex exec --sandbox read-only`
- Parallel expert review now uses Bash background jobs (`&` + `wait`) instead of MCP parallel tool calls
- Documented ADR-004 compatibility: read-only review is safe to parallelize (no worktree, no file writes) unlike Route C implementation

## Changes
| File | Description |
|------|-------------|
| `skills/codex-review/SKILL.md` | Main skill file, all MCP refs replaced with CLI |
| `skills/codex-review/references/codex-parallel-review.md` | Parallel execution guide (CLI version) |
| `skills/codex-review/references/codex-review-integration.md` | Integration guide (CLI version) |

## ADR-004 Parallel Safety
ADR-004's "Max 1 concurrent Codex request" applies to Route C (implementation, workspace-write sandbox, worktree). Parallel expert review uses `--sandbox read-only` with no worktree, making concurrent execution safe.

## Test plan
- [ ] `grep -r "mcp__codex__" skills/codex-review/` returns only doc/migration references (no executable calls)
- [ ] `block-codex-mcp.sh` hook remains deployed (MD5 match verified)
- [ ] `settings.json` has `mcp__codex__.*` matcher registered
- [ ] New skill files reference only `codex exec` CLI for execution

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * Codex CLIを用いるセカンドオピニオン向け「codex-review」スキルの操作ガイドを追加
  * 単一実行と最大数並列実行の手順例、出力キャプチャと同期方法を記載
  * 安全制約（読み取り専用サンドボックス／特定経路の禁止）と構成例を明示
  * エラー処理、検証手順、評価フロー（スコア基準による判定）を追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->