### PR TITLE
fix: enforce-issue-close-verification --reason未検出 + body内誤検出を修正

### DIFF
--- a/hooks/enforce-issue-close-verification.sh
+++ b/hooks/enforce-issue-close-verification.sh
@@ -5,28 +5,46 @@
 # 根本原因 (2026-03-07):
 #   「関連コードが存在する ≠ 受入基準を満たしている」
 #   7件中6件を誤クローズした事故の再発防止
+#
+# Bug fix (#199, 2026-03-29):
+#   Bug 1: --reason "not planned" (重複/統合クローズ) を検出してスキップ
+#   Bug 2: 引用文字列を除去してから issue close パターンをマッチし誤検出を防止
 
 set -euo pipefail
 
 # Extract command from stdin JSON
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
-ISSUE_NUM=$(echo "$COMMAND" | grep -oE 'issue close [0-9]+' | grep -oE '[0-9]+' || true)
+
+# Bug 2 fix: 引用文字列を除去してからコマンド部分のみでissue番号を抽出
+# --body "..." や --comment "..." 内の誤マッチを防ぐ
+CMD_FLAT=$(echo "$COMMAND" | tr '\n' ' ')
+CMD_NO_QUOTES=$(echo "$CMD_FLAT" | sed 's/"[^"]*"//g' | sed "s/'[^']*'//g")
+ISSUE_NUM=$(echo "$CMD_NO_QUOTES" | grep -oE 'issue close [0-9]+' | grep -oE '[0-9]+' || true)
 
 if [ -z "$ISSUE_NUM" ]; then
   exit 0
 fi
 
+# Bug 1 fix: --reason "not planned" は証拠不要（重複/統合クローズ）
+CLOSE_REASON=$(echo "$CMD_FLAT" | sed -En 's/.*--reason[= ]"([^"]*)".*/\1/p')
+if [ -z "$CLOSE_REASON" ]; then
+  CLOSE_REASON=$(echo "$CMD_FLAT" | sed -En "s/.*--reason[= ]'([^']*)'.*/\1/p")
+fi
+if [ "$CLOSE_REASON" = "not planned" ]; then
+  exit 0
+fi
+
 # Check if the close comment contains verification evidence
 # Extract comment from -c "..." or --comment "..." (BSD compatible, no grep -P)
-COMMENT=$(echo "$COMMAND" | sed -En 's/.*(--comment|-c) "([^"]*)".*/\2/p')
+COMMENT=$(echo "$CMD_FLAT" | sed -En 's/.*(--comment|-c) "([^"]*)".*/\2/p')
 if [ -z "$COMMENT" ]; then
   # Try single-quoted variant: -c '...'
-  COMMENT=$(echo "$COMMAND" | sed -En "s/.*(--comment|-c) '([^']*)'.*/\2/p")
+  COMMENT=$(echo "$CMD_FLAT" | sed -En "s/.*(--comment|-c) '([^']*)'.*/\2/p")
 fi
 if [ -z "$COMMENT" ]; then
   # No explicit comment flag found — use entire command for pattern matching
-  COMMENT="$COMMAND"
+  COMMENT="$CMD_FLAT"
 fi
 
 # Required patterns in the close comment

--- a/hooks/enforce-issue-close-verification.sh
+++ b/hooks/enforce-issue-close-verification.sh
@@ -16,30 +16,29 @@ set -euo pipefail
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
 
-# Bug 2 fix: 引用文字列を除去してからコマンド部分のみでissue番号を抽出
-# --body "..." や --comment "..." 内の誤マッチを防ぐ
+# Bug 2 fix: flag引数の値のみを除去してissue番号を抽出
+# --body/--comment/-c の引数を除去し、positional引数（issue番号）は保持
 CMD_FLAT=$(echo "$COMMAND" | tr '\n' ' ')
-CMD_NO_QUOTES=$(echo "$CMD_FLAT" | sed 's/"[^"]*"//g' | sed "s/'[^']*'//g")
-ISSUE_NUM=$(echo "$CMD_NO_QUOTES" | grep -oE 'issue close [0-9]+' | grep -oE '[0-9]+' || true)
+CMD_STRIPPED=$(echo "$CMD_FLAT" | sed 's/--body "[^"]*"//g; s/--comment "[^"]*"//g; s/-c "[^"]*"//g; s/--body-file [^ ]*//g' | sed "s/--body '[^']*'//g; s/--comment '[^']*'//g; s/-c '[^']*'//g")
+# Issue番号を抽出（引用符付き "123" も対応）
+ISSUE_NUM=$(echo "$CMD_STRIPPED" | sed "s/[\"']//g" | grep -oE 'issue close [0-9]+' | grep -oE '[0-9]+' || true)
 
 if [ -z "$ISSUE_NUM" ]; then
   exit 0
 fi
 
 # Bug 1 fix: --reason/-r "not planned" は証拠不要（重複/統合クローズ）
-# P1: --comment内の偽--reasonパターンを除外するため、--comment/-c引数を先に除去
-# P2: -r (短縮形) もサポート
-CMD_FOR_REASON=$(echo "$CMD_FLAT" | sed 's/--comment "[^"]*"//g; s/-c "[^"]*"//g' | sed "s/--comment '[^']*'//g; s/-c '[^']*'//g")
-CLOSE_REASON=$(echo "$CMD_FOR_REASON" | sed -En 's/.*(--reason|-r)[= ]"([^"]*)".*/\2/p')
+# CMD_STRIPPEDから--comment/-c/--bodyは除去済みなので--reason誤検出なし
+CLOSE_REASON=$(echo "$CMD_STRIPPED" | sed -En 's/.*(--reason|-r)[= ]"([^"]*)".*/\2/p')
 if [ -z "$CLOSE_REASON" ]; then
-  CLOSE_REASON=$(echo "$CMD_FOR_REASON" | sed -En "s/.*(--reason|-r)[= ]'([^']*)'.*/\2/p")
+  CLOSE_REASON=$(echo "$CMD_STRIPPED" | sed -En "s/.*(--reason|-r)[= ]'([^']*)'.*/\2/p")
 fi
 if [ "$CLOSE_REASON" = "not planned" ] || [ "$CLOSE_REASON" = "duplicate" ]; then
   exit 0
 fi
 
 # --duplicate-of フラグは重複クローズを意味する（証拠不要）
-if echo "$CMD_NO_QUOTES" | grep -qE '\-\-duplicate-of'; then
+if echo "$CMD_STRIPPED" | grep -qE '\-\-duplicate-of'; then
   exit 0
 fi
 

--- a/hooks/enforce-issue-close-verification.sh
+++ b/hooks/enforce-issue-close-verification.sh
@@ -34,7 +34,12 @@ CLOSE_REASON=$(echo "$CMD_FOR_REASON" | sed -En 's/.*(--reason|-r)[= ]"([^"]*)".
 if [ -z "$CLOSE_REASON" ]; then
   CLOSE_REASON=$(echo "$CMD_FOR_REASON" | sed -En "s/.*(--reason|-r)[= ]'([^']*)'.*/\2/p")
 fi
-if [ "$CLOSE_REASON" = "not planned" ]; then
+if [ "$CLOSE_REASON" = "not planned" ] || [ "$CLOSE_REASON" = "duplicate" ]; then
+  exit 0
+fi
+
+# --duplicate-of フラグは重複クローズを意味する（証拠不要）
+if echo "$CMD_NO_QUOTES" | grep -qE '\-\-duplicate-of'; then
   exit 0
 fi
 

--- a/hooks/enforce-issue-close-verification.sh
+++ b/hooks/enforce-issue-close-verification.sh
@@ -26,10 +26,13 @@ if [ -z "$ISSUE_NUM" ]; then
   exit 0
 fi
 
-# Bug 1 fix: --reason "not planned" は証拠不要（重複/統合クローズ）
-CLOSE_REASON=$(echo "$CMD_FLAT" | sed -En 's/.*--reason[= ]"([^"]*)".*/\1/p')
+# Bug 1 fix: --reason/-r "not planned" は証拠不要（重複/統合クローズ）
+# P1: --comment内の偽--reasonパターンを除外するため、--comment/-c引数を先に除去
+# P2: -r (短縮形) もサポート
+CMD_FOR_REASON=$(echo "$CMD_FLAT" | sed 's/--comment "[^"]*"//g; s/-c "[^"]*"//g' | sed "s/--comment '[^']*'//g; s/-c '[^']*'//g")
+CLOSE_REASON=$(echo "$CMD_FOR_REASON" | sed -En 's/.*(--reason|-r)[= ]"([^"]*)".*/\2/p')
 if [ -z "$CLOSE_REASON" ]; then
-  CLOSE_REASON=$(echo "$CMD_FLAT" | sed -En "s/.*--reason[= ]'([^']*)'.*/\1/p")
+  CLOSE_REASON=$(echo "$CMD_FOR_REASON" | sed -En "s/.*(--reason|-r)[= ]'([^']*)'.*/\2/p")
 fi
 if [ "$CLOSE_REASON" = "not planned" ]; then
   exit 0


### PR DESCRIPTION
## Summary

Closes #199

- **Bug 1**: `--reason "not planned"` / `-r "not planned"` / `--reason "duplicate"` / `--duplicate-of` の非完了クローズを検出して証拠チェックをスキップ
- **Bug 2**: flag引数の値のみを除去して `issue close` パターンの誤検出を防止（positional引数は保持）

### レビュー指摘対応（4ラウンド）
- **Codex R1 P1**: `--comment`内の偽`--reason`パターンによるバイパス防止
- **Codex R1 P2**: `-r` 短縮形サポート
- **code-reviewer HIGH**: `--duplicate-of` フラグ + `--reason "duplicate"` 対応
- **Codex R2 P1**: 全引用文字列除去→flag引数値のみ除去に変更（引用符付きissue番号バイパス修正）

## Test plan (9/9 PASS)

- [x] 証拠なしclose → ブロック (exit 2)
- [x] `--reason "not planned"` → パス (exit 0)
- [x] `-r "not planned"` → パス (exit 0)
- [x] `--reason "duplicate"` → パス (exit 0)
- [x] `--duplicate-of 456` → パス (exit 0)
- [x] `--reason "completed"` → ブロック (exit 2)
- [x] `--body` 内に "issue close 456" → パス (exit 0)
- [x] 引用符付きissue番号 `"123"` → ブロック (exit 2)
- [x] 証拠ありclose → パス (exit 0)
- [x] MD5一致（プロジェクト内 ↔ デプロイ先）
- [x] code-reviewer + Codex CLI x2 レビュー完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Issue番号の検出がより堅牢になり、引用符を含む形式に対応しました
  * コマンド処理の安定性が向上しました
  * Duplicate および not planned の終了理由が自動的に処理されるようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->