### PR TITLE
fix: codex exec review (経路A) のバジェットカウント除外で循環デッドロック解消

### DIFF
--- a/hooks/codex-task-gate.sh
+++ b/hooks/codex-task-gate.sh
@@ -80,7 +80,11 @@ is_codex_exec=false
 if echo "$first_line" | grep -qE '^\s*(\S+=\S+\s+)*bash\s+\S*codex-(parallel|orchestrate)'; then
     is_codex_exec=true
 elif echo "$first_line" | grep -qE '^\s*(\S+=\S+\s+)*codex\s+exec\b'; then
-    is_codex_exec=true
+    # 経路A (codex exec review) はレビュー専用 — バジェットカウント対象外
+    # 経路C (codex exec <implementation>) のみカウントする
+    if ! echo "$first_line" | grep -qE 'codex\s+exec\s+review\b'; then
+        is_codex_exec=true
+    fi
 fi
 
 if [[ "$tool_name" == "Bash" ]] && [[ "$is_codex_exec" == "true" ]]; then

--- a/hooks/codex-task-release.sh
+++ b/hooks/codex-task-release.sh
@@ -33,7 +33,10 @@ is_codex_exec=false
 if echo "$first_line" | grep -qE '^\s*(\S+=\S+\s+)*bash\s+\S*codex-(parallel|orchestrate)'; then
     is_codex_exec=true
 elif echo "$first_line" | grep -qE '^\s*(\S+=\S+\s+)*codex\s+exec\b'; then
-    is_codex_exec=true
+    # 経路A (codex exec review) はバジェットカウント対象外 (codex-task-gate.sh と対称)
+    if ! echo "$first_line" | grep -qE 'codex\s+exec\s+review\b'; then
+        is_codex_exec=true
+    fi
 fi
 
 [[ "$is_codex_exec" != "true" ]] && exit 0


### PR DESCRIPTION
## Summary
- `codex-task-gate.sh` が `codex exec review`（経路A: レビュー）を実装用 Codex 呼び出しと同一視してブロックしていた循環依存を解消
- `codex-task-release.sh` (PostToolUse) にも同じ除外を追加し、カウンタの対称性を確保
- `\b` ワードバウンダリで `review` サブコマンドのみ除外し、`reviewAll` 等のバイパスを防止

## Changes
- `hooks/codex-task-gate.sh:82-88`: `codex exec review` 検出時にバジェットカウント対象外とする条件分岐を追加
- `hooks/codex-task-release.sh:35-40`: 同じ除外ロジックを追加しカウンタ対称性を確保（Codex P1レビュー指摘対応）

## Test plan
- [x] `codex exec review` → exit 0 (許可)
- [x] `codex exec <impl>` 1回目 → exit 0 (許可)
- [x] `codex exec <impl>` 2回目 → exit 2 (ブロック)
- [x] ブロック後の `codex exec review` → exit 0 (常に許可)
- [x] `codex exec reviewAll` → exit 2 (バイパス防止、\b境界)
- [x] `ENV=val codex exec review` → exit 0 (env prefix対応)
- [x] MD5一致デプロイ検証 (gate + release 両方)
- [x] JSON入力による発火検証 (gate + release 両方)
- [x] code-reviewer APPROVE
- [x] Codex CLI レビュー実行完了（P1指摘→release.sh修正で対応済み）

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Codexコマンド検出ロジックを更新。レビューコマンドと実装コマンドの処理を区別するよう改善し、予算管理メカニズムの精度が向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->