### PR TITLE
fix: add deploy verification gate for PR creation (#209)

### DIFF
--- a/hooks/enforce-deploy-verify-on-pr.sh
+++ b/hooks/enforce-deploy-verify-on-pr.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# enforce-deploy-verify-on-pr.sh — Block PR creation if changed hooks/scripts not deployed
+# PreToolUse hook on Bash matcher
+# Exit 0 = allow, Exit 2 = block
+# Triggers on: gh pr create
+# Checks: MD5 of changed hooks/*.sh and scripts/*.sh vs deployed copies
+set -euo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_name',''))" 2>/dev/null || echo "")
+[[ "$TOOL_NAME" == "Bash" ]] || exit 0
+
+COMMAND=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null || echo "")
+echo "$COMMAND" | grep -qE '\bgh\s+pr\s+create\b' || exit 0
+
+PROJECT_DIR=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+[[ -n "$PROJECT_DIR" ]] || exit 0
+
+BASE_BRANCH="develop"
+CHANGED_FILES=$(git diff --name-only "$BASE_BRANCH"...HEAD 2>/dev/null || git diff --name-only "$BASE_BRANCH" HEAD 2>/dev/null || echo "")
+[[ -n "$CHANGED_FILES" ]] || exit 0
+
+HOOK_CHANGES=$(echo "$CHANGED_FILES" | grep -E '^hooks/[^/]+\.sh$' || true)
+SCRIPT_CHANGES=$(echo "$CHANGED_FILES" | grep -E '^scripts/[^/]+\.sh$' || true)
+[[ -n "$HOOK_CHANGES" || -n "$SCRIPT_CHANGES" ]] || exit 0
+
+ERRORS=""
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  SOURCE="$PROJECT_DIR/$file"
+  DEPLOYED="$HOME/.claude/hooks/$(basename "$file")"
+  if [[ ! -f "$DEPLOYED" ]]; then
+    ERRORS="${ERRORS}\n  ❌ $file → $DEPLOYED (未デプロイ)"
+  else
+    SRC_MD5=$(md5 -q "$SOURCE" 2>/dev/null || md5sum "$SOURCE" 2>/dev/null | awk '{print $1}')
+    DEP_MD5=$(md5 -q "$DEPLOYED" 2>/dev/null || md5sum "$DEPLOYED" 2>/dev/null | awk '{print $1}')
+    if [[ "$SRC_MD5" != "$DEP_MD5" ]]; then
+      ERRORS="${ERRORS}\n  ❌ $file — MD5不一致 (src:${SRC_MD5:0:8} != dep:${DEP_MD5:0:8})"
+    fi
+  fi
+done <<< "$HOOK_CHANGES"
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  SOURCE="$PROJECT_DIR/$file"
+  DEPLOYED="$HOME/.claude/scripts/$(basename "$file")"
+  if [[ ! -f "$DEPLOYED" ]]; then
+    ERRORS="${ERRORS}\n  ❌ $file → $DEPLOYED (未デプロイ)"
+  else
+    SRC_MD5=$(md5 -q "$SOURCE" 2>/dev/null || md5sum "$SOURCE" 2>/dev/null | awk '{print $1}')
+    DEP_MD5=$(md5 -q "$DEPLOYED" 2>/dev/null || md5sum "$DEPLOYED" 2>/dev/null | awk '{print $1}')
+    if [[ "$SRC_MD5" != "$DEP_MD5" ]]; then
+      ERRORS="${ERRORS}\n  ❌ $file — MD5不一致 (src:${SRC_MD5:0:8} != dep:${DEP_MD5:0:8})"
+    fi
+  fi
+done <<< "$SCRIPT_CHANGES"
+
+[[ -n "$ERRORS" ]] || exit 0
+
+echo "" >&2
+echo "🚫 [BLOCKED] PR作成を拒否。変更されたhook/scriptが未デプロイです。" >&2
+echo "" >&2
+echo "  デプロイ検証結果:" >&2
+echo -e "$ERRORS" >&2
+echo "" >&2
+echo "  解決方法:" >&2
+echo "  1. bash setup.sh  # 全hook/scriptをデプロイ" >&2
+echo "  2. MD5一致を確認してから再試行" >&2
+echo "" >&2
+echo "  Epic #130: 「コードがある」≠「動作する」" >&2
+exit 2

--- a/tests/test-issue-209.sh
+++ b/tests/test-issue-209.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# test-issue-209.sh -- Test enforce-deploy-verify-on-pr.sh (#209)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+HOOK="$PROJECT_DIR/hooks/enforce-deploy-verify-on-pr.sh"
+PASS=0
+FAIL=0
+
+pass() { echo -e "\033[0;32mPASS\033[0m: $1"; PASS=$(( PASS + 1 )); }
+fail() { echo -e "\033[0;31mFAIL\033[0m: $1"; FAIL=$(( FAIL + 1 )); }
+
+# T1: Non-Bash tool → pass
+ec=0; echo '{"tool_name":"Edit","tool_input":{"file_path":"x"}}' | bash "$HOOK" 2>/dev/null || ec=$?
+[[ $ec -eq 0 ]] && pass "T1: non-Bash passes" || fail "T1: exit $ec"
+
+# T2: Bash without gh pr create → pass
+ec=0; echo '{"tool_name":"Bash","tool_input":{"command":"git status"}}' | bash "$HOOK" 2>/dev/null || ec=$?
+[[ $ec -eq 0 ]] && pass "T2: non-PR bash passes" || fail "T2: exit $ec"
+
+# T3: Syntax check
+bash -n "$HOOK" && pass "T3: syntax OK" || fail "T3: syntax error"
+
+# T4: gh pr create triggers (may block or pass depending on branch state, but must not crash)
+ec=0; echo '{"tool_name":"Bash","tool_input":{"command":"gh pr create --title test"}}' | bash "$HOOK" 2>/dev/null || ec=$?
+[[ $ec -eq 0 || $ec -eq 2 ]] && pass "T4: gh pr create handled (exit $ec)" || fail "T4: unexpected exit $ec"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- New PreToolUse hook: enforce-deploy-verify-on-pr.sh
- Blocks PR creation when changed hooks/scripts not deployed via setup.sh
- MD5 comparison of source vs deployed files
- Root cause fix for Epic #130 philosophy violation

## 4-stage verification
- [x] Code: hooks/enforce-deploy-verify-on-pr.sh
- [x] Deploy: setup.sh → ~/.claude/hooks/ (MD5 match)
- [x] Register: settings.json PreToolUse Bash matcher
- [x] Fire: BLOCK (exit 2) + PASS (exit 0) paths confirmed

## Test plan
- [x] 4 test cases in tests/test-issue-209.sh (all pass)

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア**
  * PR作成フロー向けの新しい検証メカニズムを導入しました。

* **テスト**
  * 新しい検証メカニズムの動作を確認するテストスイートを実装しました。複数のシナリオに対応した検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->