### PR TITLE
feat: add quantitative delegation criteria hook (#208)

### DIFF
--- a/docs/adr/004-codex-delegation-model.md
+++ b/docs/adr/004-codex-delegation-model.md
@@ -59,6 +59,18 @@ Exclude: specific split instructions (let Codex decide)
 | 2+ independent but small | Agent Team | Not worth Codex startup |
 | Quality-critical path | Claude Code + Agent Team | Quality Loop runs real-time |
 
+### Quantitative Selection Criteria (#208)
+
+| 特性 | サブエージェント (Agent) | Codex CLI 経路C | Agent Team (TeamCreate) |
+|------|------------------------|----------------|------------------------|
+| 変更ファイル数 | 1-2 | 3+ | 2+独立 |
+| 必要コンテキスト | <500行 | 1000+行 | 各タスク独立 |
+| 反復サイクル | 1-shot | impl→test→lint loop | 並行1-shot |
+| 実行時間目安 | <5分 | 5分+ | 各<5分 |
+| 例 | バグ修正, テスト追加, 調査 | リファクタ, 統合変更, 大規模実装 | 独立feature並行開発 |
+
+Enforced by: `hooks/enforce-codex-delegation.sh` (PreToolUse, Agent matcher, advisory warning)
+
 ## Alternatives
 
 | Option | Rejection Reason |

--- a/hooks/enforce-codex-delegation.sh
+++ b/hooks/enforce-codex-delegation.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# enforce-codex-delegation.sh — Warn when Agent used for Codex-appropriate tasks (#208)
+# PreToolUse hook on Agent matcher. Advisory only (exit 0 always).
+set -euo pipefail
+
+[[ "${CLAUDE_AGENT_DEPTH:-0}" -ge 1 ]] && exit 0
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_name',''))" 2>/dev/null || echo "")
+[[ "$TOOL_NAME" == "Agent" ]] || exit 0
+
+PROMPT=$(echo "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('prompt',''))" 2>/dev/null || echo "")
+SUBAGENT_TYPE=$(echo "$INPUT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('subagent_type',''))" 2>/dev/null || echo "")
+
+case "$SUBAGENT_TYPE" in
+  code-reviewer|security-reviewer|feature-dev:code-reviewer|feature-dev:code-explorer|feature-dev:code-architect|claude-code-harness:*|Explore|Plan)
+    exit 0 ;;
+esac
+
+if echo "$PROMPT" | grep -qiE '(調査|検索|search|find|explore|read|確認|check|analyze|分析)' && \
+   ! echo "$PROMPT" | grep -qiE '(implement|実装|create|作成|fix|修正|refactor|write|書)'; then
+  exit 0
+fi
+
+REASON=""
+
+REFACTOR_KW=$(echo "$PROMPT" | grep -ciE '(refactor|unif|migrat|全体|一貫|統合|横断|リファクタ|移行)' || true)
+FILE_IND=$(echo "$PROMPT" | { grep -oE '([a-zA-Z0-9_/-]+\.(sh|ts|tsx|js|jsx|py|go|rs|md)|[0-9]+\s*files?|[0-9]+\s*ファイル)' || true; } | wc -l | tr -d ' ')
+if [[ "$REFACTOR_KW" -gt 0 ]] && [[ "$FILE_IND" -ge 3 ]]; then
+  REASON="横断的リファクタリング (${FILE_IND}ファイル参照 + refactorキーワード)"
+fi
+
+if [[ -z "$REASON" ]]; then
+  if echo "$PROMPT" | grep -qiE '(全体を理解|全ファイル|full codebase|entire|1[0-9]{3,}\s*(行|lines)|all files|全コード)'; then
+    REASON="大規模コンテキスト必要 (全体理解/1000行+ 検出)"
+  fi
+fi
+
+if [[ -z "$REASON" ]]; then
+  if echo "$PROMPT" | grep -qiE '(impl.*test.*lint|テスト→修正|test.*fix.*re-?test|iterati|繰り返|ループ|反復|implement.*then.*test|実装.*テスト.*修正)'; then
+    REASON="反復サイクル (impl→test→fix ループ検出)"
+  fi
+fi
+
+[[ -z "$REASON" ]] && exit 0
+
+echo "⚠️ [delegation] このタスクは Codex CLI 経路C が適切な可能性があります。" >&2
+echo "  理由: $REASON" >&2
+echo "  基準: 変更ファイル3+/コンテキスト1000行+/反復サイクル" >&2
+echo "  → scripts/codex-parallel.sh で委任を検討してください。" >&2
+exit 0

--- a/tests/test-issue-208.sh
+++ b/tests/test-issue-208.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# test-issue-208.sh -- Test enforce-codex-delegation.sh (#208)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$(dirname "$SCRIPT_DIR")/hooks/enforce-codex-delegation.sh"
+PASS=0; FAIL=0
+
+pass() { echo -e "\033[0;32mPASS\033[0m: $1"; PASS=$(( PASS + 1 )); }
+fail() { echo -e "\033[0;31mFAIL\033[0m: $1"; FAIL=$(( FAIL + 1 )); }
+
+run_hook() { unset CLAUDE_AGENT_DEPTH 2>/dev/null || true; echo "$1" | bash "$HOOK" 2>&1 >/dev/null || true; }
+
+export CLAUDE_AGENT_DEPTH=1
+out=$(echo '{"tool_name":"Agent","tool_input":{"prompt":"refactor 10 files entirely","subagent_type":"general-purpose"}}' | bash "$HOOK" 2>&1 >/dev/null) || true
+unset CLAUDE_AGENT_DEPTH
+[[ -z "$out" ]] && pass "T1: subagent skip" || fail "T1: $out"
+
+out=$(run_hook '{"tool_name":"Agent","tool_input":{"prompt":"review","subagent_type":"code-reviewer"}}')
+[[ -z "$out" ]] && pass "T2: reviewer pass" || fail "T2: $out"
+
+out=$(run_hook '{"tool_name":"Agent","tool_input":{"prompt":"find stuff","subagent_type":"Explore"}}')
+[[ -z "$out" ]] && pass "T3: Explore pass" || fail "T3: $out"
+
+out=$(run_hook '{"tool_name":"Agent","tool_input":{"prompt":"調査 how auth works","subagent_type":"general-purpose"}}')
+[[ -z "$out" ]] && pass "T4: research pass" || fail "T4: $out"
+
+out=$(run_hook '{"tool_name":"Agent","tool_input":{"prompt":"refactor auth across main.py, routes.py, middleware.py, models.py to unify tokens","subagent_type":"general-purpose"}}')
+[[ "$out" == *"[delegation]"* ]] && pass "T5: refactor warns" || fail "T5: $out"
+
+out=$(run_hook '{"tool_name":"Agent","tool_input":{"prompt":"全体を理解して1500行をリファクタリング","subagent_type":"general-purpose"}}')
+[[ "$out" == *"[delegation]"* ]] && pass "T6: large ctx warns" || fail "T6: $out"
+
+out=$(run_hook '{"tool_name":"Agent","tool_input":{"prompt":"implement then run tests fix failures and re-test iteratively","subagent_type":"general-purpose"}}')
+[[ "$out" == *"[delegation]"* ]] && pass "T7: multi-cycle warns" || fail "T7: $out"
+
+out=$(run_hook '{"tool_name":"Agent","tool_input":{"prompt":"fix null pointer in auth.ts","subagent_type":"general-purpose"}}')
+[[ -z "$out" ]] && pass "T8: simple fix pass" || fail "T8: $out"
+
+out=$(run_hook '{"tool_name":"Bash","tool_input":{"command":"ls"}}')
+[[ -z "$out" ]] && pass "T9: non-Agent pass" || fail "T9: $out"
+
+out=$(run_hook '{"tool_name":"Agent","tool_input":{"prompt":"implement 10 files","subagent_type":"claude-code-harness:impl"}}')
+[[ -z "$out" ]] && pass "T10: harness pass" || fail "T10: $out"
+
+echo ""; echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- New advisory PreToolUse hook: enforce-codex-delegation.sh
- Warns when Agent tool used for Codex CLI-appropriate tasks
- Checks: cross-file refactoring (3+ files), large context (1000+ lines), multi-cycle impl loops
- Updated ADR-004 with quantitative selection matrix

## 4-stage verification
- [x] Code: hooks/enforce-codex-delegation.sh
- [x] Deploy: setup.sh → ~/.claude/hooks/ (MD5: 0d9871461c837a3f1653775d180c3e5b)
- [x] Register: settings.json PreToolUse Agent matcher
- [x] Fire: warn + no-warn paths confirmed

## Test plan
- [x] 10 test cases in tests/test-issue-208.sh (all pass)

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)