### PR TITLE
fix: detect monorepo root test guards in stop-test-gate.sh (#217)

### DIFF
--- a/hooks/stop-test-gate.sh
+++ b/hooks/stop-test-gate.sh
@@ -168,6 +168,70 @@ elif [ -f "$PROJECT_DIR/Makefile" ] && grep -q '^test:' "$PROJECT_DIR/Makefile";
   TEST_CMD="cd \"$PROJECT_DIR\" && make test"
 fi
 
+# =========================================================================
+# Issue #217: Monorepo root test guard detection
+# Monorepos may intentionally block root-level test execution with a guard
+# script (e.g., "echo 'do not run tests from root' && exit 1").
+# Detect this pattern and use monorepo-aware test runners instead.
+# =========================================================================
+if [[ -n "$TEST_CMD" ]] && [[ -f "$PROJECT_DIR/package.json" ]] && command -v jq &>/dev/null; then
+  _is_monorepo=false
+  if [[ -f "$PROJECT_DIR/turbo.json" ]] || \
+     [[ -f "$PROJECT_DIR/pnpm-workspace.yaml" ]] || \
+     [[ -f "$PROJECT_DIR/lerna.json" ]] || \
+     [[ -f "$PROJECT_DIR/nx.json" ]] || \
+     jq -e '.workspaces' "$PROJECT_DIR/package.json" &>/dev/null 2>&1; then
+    _is_monorepo=true
+  fi
+
+  if [[ "$_is_monorepo" == "true" ]]; then
+    _test_script=$(jq -r '.scripts.test // ""' "$PROJECT_DIR/package.json" 2>/dev/null)
+    _root_guard=false
+
+    # Guard pattern: explicit exit 1/2 without a known test runner invocation
+    if [[ -n "$_test_script" ]]; then
+      if echo "$_test_script" | grep -qE 'exit[[:space:]]+[12]'; then
+        if ! echo "$_test_script" | grep -qiE '(jest|vitest|mocha|ava|tap|nyc|c8|playwright|cypress|bun[[:space:]]+test)'; then
+          _root_guard=true
+        fi
+      fi
+    fi
+
+    # Also check bunfig.toml for explicit test root guard
+    if [[ -f "$PROJECT_DIR/bunfig.toml" ]] && grep -q 'do-not-run-tests-from-root' "$PROJECT_DIR/bunfig.toml" 2>/dev/null; then
+      _root_guard=true
+    fi
+
+    if [[ "$_root_guard" == "true" ]]; then
+      echo "[stop-test-gate] monorepo root test guard 検出: 代替テストランナー検索。" >&2
+      TEST_CMD=""
+
+      # Priority 1: Turbo (runs test in workspace packages, skips root)
+      if [[ -f "$PROJECT_DIR/turbo.json" ]] && command -v turbo &>/dev/null; then
+        TEST_CMD="cd \"$PROJECT_DIR\" && turbo test"
+        echo "[stop-test-gate] turbo test を使用。" >&2
+      # Priority 2: Nx
+      elif [[ -f "$PROJECT_DIR/nx.json" ]] && command -v nx &>/dev/null; then
+        TEST_CMD="cd \"$PROJECT_DIR\" && nx run-many --target=test"
+        echo "[stop-test-gate] nx run-many --target=test を使用。" >&2
+      # Priority 3: pnpm recursive
+      elif [[ -f "$PROJECT_DIR/pnpm-workspace.yaml" ]] && command -v pnpm &>/dev/null; then
+        TEST_CMD="cd \"$PROJECT_DIR\" && pnpm -r test"
+        echo "[stop-test-gate] pnpm -r test を使用。" >&2
+      # Priority 4: lerna
+      elif [[ -f "$PROJECT_DIR/lerna.json" ]] && command -v lerna &>/dev/null; then
+        TEST_CMD="cd \"$PROJECT_DIR\" && lerna run test"
+        echo "[stop-test-gate] lerna run test を使用。" >&2
+      fi
+
+      if [[ -z "$TEST_CMD" ]]; then
+        echo "[stop-test-gate] monorepo test runner 未検出: テストスキップ。" >&2
+        exit 0
+      fi
+    fi
+  fi
+fi
+
 # No test framework detected — allow stop
 if [ -z "$TEST_CMD" ]; then
   exit 0

--- a/hooks/stop-test-gate.sh
+++ b/hooks/stop-test-gate.sh
@@ -206,22 +206,38 @@ if [[ -n "$TEST_CMD" ]] && [[ -f "$PROJECT_DIR/package.json" ]] && command -v jq
       echo "[stop-test-gate] monorepo root test guard 検出: 代替テストランナー検索。" >&2
       TEST_CMD=""
 
-      # Priority 1: Turbo (runs test in workspace packages, skips root)
-      if [[ -f "$PROJECT_DIR/turbo.json" ]] && command -v turbo &>/dev/null; then
-        TEST_CMD="cd \"$PROJECT_DIR\" && turbo test"
+      # Priority 1: Turbo (local devDep or global)
+      _turbo_bin=$(resolve_runner_bin turbo)
+      if [[ -f "$PROJECT_DIR/turbo.json" ]] && [[ -n "$_turbo_bin" ]]; then
+        TEST_CMD="cd \"$PROJECT_DIR\" && \"$_turbo_bin\" test"
         echo "[stop-test-gate] turbo test を使用。" >&2
-      # Priority 2: Nx
-      elif [[ -f "$PROJECT_DIR/nx.json" ]] && command -v nx &>/dev/null; then
-        TEST_CMD="cd \"$PROJECT_DIR\" && nx run-many --target=test"
-        echo "[stop-test-gate] nx run-many --target=test を使用。" >&2
-      # Priority 3: pnpm recursive
-      elif [[ -f "$PROJECT_DIR/pnpm-workspace.yaml" ]] && command -v pnpm &>/dev/null; then
-        TEST_CMD="cd \"$PROJECT_DIR\" && pnpm -r test"
-        echo "[stop-test-gate] pnpm -r test を使用。" >&2
-      # Priority 4: lerna
-      elif [[ -f "$PROJECT_DIR/lerna.json" ]] && command -v lerna &>/dev/null; then
-        TEST_CMD="cd \"$PROJECT_DIR\" && lerna run test"
-        echo "[stop-test-gate] lerna run test を使用。" >&2
+      # Priority 2: Nx (local devDep or global)
+      else
+        _nx_bin=$(resolve_runner_bin nx)
+        if [[ -f "$PROJECT_DIR/nx.json" ]] && [[ -n "$_nx_bin" ]]; then
+          TEST_CMD="cd \"$PROJECT_DIR\" && \"$_nx_bin\" run-many --target=test"
+          echo "[stop-test-gate] nx run-many --target=test を使用。" >&2
+        # Priority 3: pnpm recursive
+        elif [[ -f "$PROJECT_DIR/pnpm-workspace.yaml" ]] && command -v pnpm &>/dev/null; then
+          TEST_CMD="cd \"$PROJECT_DIR\" && pnpm -r test"
+          echo "[stop-test-gate] pnpm -r test を使用。" >&2
+        # Priority 4: lerna (local devDep or global)
+        else
+          _lerna_bin=$(resolve_runner_bin lerna)
+          if [[ -f "$PROJECT_DIR/lerna.json" ]] && [[ -n "$_lerna_bin" ]]; then
+            TEST_CMD="cd \"$PROJECT_DIR\" && \"$_lerna_bin\" run test"
+            echo "[stop-test-gate] lerna run test を使用。" >&2
+          # Priority 5: npm/yarn workspaces fallback (no dedicated runner)
+          elif jq -e '.workspaces' "$PROJECT_DIR/package.json" &>/dev/null 2>&1; then
+            if [[ -f "$PROJECT_DIR/yarn.lock" ]]; then
+              TEST_CMD="cd \"$PROJECT_DIR\" && yarn workspaces run test"
+              echo "[stop-test-gate] yarn workspaces run test を使用。" >&2
+            else
+              TEST_CMD="cd \"$PROJECT_DIR\" && npm test --workspaces --if-present"
+              echo "[stop-test-gate] npm test --workspaces を使用。" >&2
+            fi
+          fi
+        fi
       fi
 
       if [[ -z "$TEST_CMD" ]]; then

--- a/hooks/stop-test-gate.sh
+++ b/hooks/stop-test-gate.sh
@@ -180,7 +180,7 @@ if [[ -n "$TEST_CMD" ]] && [[ -f "$PROJECT_DIR/package.json" ]] && command -v jq
      [[ -f "$PROJECT_DIR/pnpm-workspace.yaml" ]] || \
      [[ -f "$PROJECT_DIR/lerna.json" ]] || \
      [[ -f "$PROJECT_DIR/nx.json" ]] || \
-     jq -e '.workspaces' "$PROJECT_DIR/package.json" &>/dev/null 2>&1; then
+     jq -e '.workspaces' "$PROJECT_DIR/package.json" &>/dev/null; then
     _is_monorepo=true
   fi
 
@@ -188,10 +188,10 @@ if [[ -n "$TEST_CMD" ]] && [[ -f "$PROJECT_DIR/package.json" ]] && command -v jq
     _test_script=$(jq -r '.scripts.test // ""' "$PROJECT_DIR/package.json" 2>/dev/null)
     _root_guard=false
 
-    # Guard pattern: explicit exit 1/2 without a known test runner invocation
+    # Guard pattern: explicit exit 1/2 or && false, without a known test runner
     if [[ -n "$_test_script" ]]; then
-      if echo "$_test_script" | grep -qE 'exit[[:space:]]+[12]'; then
-        if ! echo "$_test_script" | grep -qiE '(jest|vitest|mocha|ava|tap|nyc|c8|playwright|cypress|bun[[:space:]]+test)'; then
+      if printf '%s\n' "$_test_script" | grep -qE '(exit[[:space:]]+[12]|&&[[:space:]]*false([[:space:]]|$))'; then
+        if ! printf '%s\n' "$_test_script" | grep -qiE '(jest|vitest|mocha|ava|tap|nyc|c8|playwright|cypress|bun[[:space:]]+test)'; then
           _root_guard=true
         fi
       fi
@@ -204,6 +204,7 @@ if [[ -n "$TEST_CMD" ]] && [[ -f "$PROJECT_DIR/package.json" ]] && command -v jq
 
     if [[ "$_root_guard" == "true" ]]; then
       echo "[stop-test-gate] monorepo root test guard 検出: 代替テストランナー検索。" >&2
+      _MONOREPO_GUARD_ACTIVE=true
       TEST_CMD=""
 
       # Priority 1: Turbo (local devDep or global)
@@ -228,7 +229,7 @@ if [[ -n "$TEST_CMD" ]] && [[ -f "$PROJECT_DIR/package.json" ]] && command -v jq
             TEST_CMD="cd \"$PROJECT_DIR\" && \"$_lerna_bin\" run test"
             echo "[stop-test-gate] lerna run test を使用。" >&2
           # Priority 5: npm/yarn workspaces fallback (no dedicated runner)
-          elif jq -e '.workspaces' "$PROJECT_DIR/package.json" &>/dev/null 2>&1; then
+          elif jq -e '.workspaces' "$PROJECT_DIR/package.json" &>/dev/null; then
             if [[ -f "$PROJECT_DIR/yarn.lock" ]]; then
               TEST_CMD="cd \"$PROJECT_DIR\" && yarn workspaces run test"
               echo "[stop-test-gate] yarn workspaces run test を使用。" >&2
@@ -292,11 +293,14 @@ fi
 
 # =========================================================================
 # Phase 2: runner-specific targeted test command
+# Skip when monorepo guard is active — the monorepo runner (turbo/nx/etc.)
+# already handles per-package test routing; root-level vitest/jest binaries
+# would override it incorrectly.
 # =========================================================================
 TARGETED_CMD=""
 FULL_SUITE_CMD="$TEST_CMD"
 
-if [[ "$_detect_exit" -eq 0 ]] && [[ "${#SOURCE_FILES[@]}" -gt 0 || "${#TEST_FILES[@]}" -gt 0 ]]; then
+if [[ "${_MONOREPO_GUARD_ACTIVE:-false}" != "true" ]] && [[ "$_detect_exit" -eq 0 ]] && [[ "${#SOURCE_FILES[@]}" -gt 0 || "${#TEST_FILES[@]}" -gt 0 ]]; then
   SOURCE_FILES_STR="$(shell_join_args "${SOURCE_FILES[@]}")"
   TEST_FILES_STR="$(shell_join_args "${TEST_FILES[@]}")"
 


### PR DESCRIPTION
## Summary

- Monorepo workspace detection (turbo.json, pnpm-workspace.yaml, lerna.json, nx.json, package.json workspaces)
- Root test guard pattern detection (`exit 1/2` or `&& false` without known test runner) + bunfig.toml guard
- Monorepo-aware test runner fallback with local binary resolution (turbo > nx > pnpm -r > lerna > npm/yarn workspaces)
- Phase 2 targeted test skip when monorepo guard active (prevents vitest/jest override)
- Graceful skip if no runner available

## Root Cause

`stop-test-gate.sh` selected root `npm test` in monorepos where the root test script intentionally blocks execution (e.g., `"echo 'do not run tests from root' && exit 1"`). This caused false failures blocking session termination in every session.

## Review Findings Addressed

| Source | Priority | Finding | Fix |
|--------|----------|---------|-----|
| Codex CLI | P1 | npm/yarn workspaces fallback missing | Added Priority 5 fallback |
| Codex CLI | P1 | Local node_modules/.bin not checked | Use resolve_runner_bin() |
| code-reviewer | HIGH | Phase 2 overrides monorepo runner | _MONOREPO_GUARD_ACTIVE flag |
| code-reviewer | WARN | echo vs printf for pipes | Switched to printf |
| code-reviewer | WARN | Narrow guard regex | Added `&& false` pattern |
| code-reviewer | WARN | Redundant 2>&1 | Removed |

## Verification

- shellcheck: clean (all 3 commits)
- MD5 match: source == deployed (`c50b911f8d22a8dcce99d20f79b91314`)
- 8/8 test cases passed:
  1. Turbo monorepo + local turbo binary
  2. pnpm workspace + root guard
  3. bunfig.toml guard
  4. Normal project (no false positive)
  5. Monorepo with jest (no false positive)
  6. Lerna monorepo + root guard
  7. npm workspaces fallback
  8. yarn workspaces fallback

## Test plan

- [x] shellcheck passes
- [x] Hook deployed to ~/.claude/hooks/ with MD5 match
- [x] 8/8 test scenarios pass (5 guard + 2 false positive + 1 local binary)
- [x] code-reviewer: CRITICAL=0 HIGH=0 (after fix)
- [x] Codex CLI review: P1 issues resolved
- [ ] CI passes

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * モノレポプロジェクトのテスト実行を自動検出および最適化しました。複数のパッケージマネージャー（Turbo、Nx、pnpm、Lerna、Yarn）に対応し、各ワークスペースで正しくテストが実行されるようになります。ルートレベルのテストスキップ設定も認識するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->