### PR TITLE
fix: resolve PR gate branch from worktree context

### DIFF
--- a/hooks/enforce-deploy-verify-on-pr.sh
+++ b/hooks/enforce-deploy-verify-on-pr.sh
@@ -6,6 +6,61 @@
 # Checks: MD5 of changed hooks/*.sh and scripts/*.sh vs deployed copies
 set -euo pipefail
 
+GIT_CONTEXT_DIR="${GIT_CONTEXT_DIR:-}"
+
+git_ctx() {
+  if [[ -n "${GIT_CONTEXT_DIR:-}" ]]; then
+    git -C "$GIT_CONTEXT_DIR" "$@"
+  else
+    git "$@"
+  fi
+}
+
+command_git_context_dir() {
+  local cmd="${1:-}"
+  [[ -z "$cmd" ]] && return 0
+  _CMD="$cmd" python3 - <<'PY'
+import os, shlex, subprocess, sys
+
+cmd = os.environ.get("_CMD", "")
+try:
+    lexer = shlex.shlex(cmd, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    tokens = list(lexer)
+except Exception:
+    sys.exit(0)
+
+gh_index = -1
+for i in range(len(tokens) - 2):
+    if tokens[i:i+3] == ["gh", "pr", "create"]:
+        gh_index = i
+        break
+if gh_index < 0:
+    sys.exit(0)
+
+candidate = ""
+for i in range(gh_index):
+    if tokens[i] == "cd" and i + 1 < gh_index:
+        candidate = tokens[i + 1]
+
+if not candidate or candidate == "-":
+    sys.exit(0)
+
+path = os.path.abspath(os.path.expanduser(candidate))
+try:
+    top = subprocess.check_output(
+        ["git", "-C", path, "rev-parse", "--show-toplevel"],
+        stderr=subprocess.DEVNULL,
+        text=True,
+    ).strip()
+except Exception:
+    sys.exit(0)
+
+if top:
+    print(top)
+PY
+}
+
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_name',''))" 2>/dev/null || echo "")
 [[ "$TOOL_NAME" == "Bash" ]] || exit 0
@@ -13,14 +68,19 @@ TOOL_NAME=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.std
 COMMAND=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null || echo "")
 echo "$COMMAND" | grep -qE '\bgh\s+pr\s+create\b' || exit 0
 
-PROJECT_DIR=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+_cmd_context=$(command_git_context_dir "$COMMAND")
+if [[ -n "$_cmd_context" ]]; then
+  export GIT_CONTEXT_DIR="$_cmd_context"
+fi
+
+PROJECT_DIR=$(git_ctx rev-parse --show-toplevel 2>/dev/null || echo "")
 [[ -n "$PROJECT_DIR" ]] || exit 0
 
-BASE_BRANCH="${DEPLOY_VERIFY_BASE_BRANCH:-$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || echo "develop")}"
-CHANGED_FILES=$(git diff --name-only "$BASE_BRANCH"...HEAD 2>/dev/null || git diff --name-only "$BASE_BRANCH" HEAD 2>/dev/null || echo "")
+BASE_BRANCH="${DEPLOY_VERIFY_BASE_BRANCH:-$(git_ctx symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || echo "develop")}"
+CHANGED_FILES=$(git_ctx diff --name-only "$BASE_BRANCH"...HEAD 2>/dev/null || git_ctx diff --name-only "$BASE_BRANCH" HEAD 2>/dev/null || echo "")
 [[ -n "$CHANGED_FILES" ]] || exit 0
 
-HOOK_CHANGES=$(echo "$CHANGED_FILES" | grep -E '^hooks/[^/]+\.sh$' || true)
+HOOK_CHANGES=$(echo "$CHANGED_FILES" | grep -E '^hooks/.*\.sh$' | grep -vE '^hooks/_unused/' || true)
 SCRIPT_CHANGES=$(echo "$CHANGED_FILES" | grep -E '^scripts/[^/]+\.sh$' || true)
 [[ -n "$HOOK_CHANGES" || -n "$SCRIPT_CHANGES" ]] || exit 0
 
@@ -31,8 +91,13 @@ check_deploy() {
   local file="$1" deploy_dir="$2"
   [[ -z "$file" ]] && return
   local source="$PROJECT_DIR/$file"
-  local deployed
-  deployed="$deploy_dir/$(basename "$file")"
+  local rel_path deployed
+  case "$file" in
+    hooks/*) rel_path="${file#hooks/}" ;;
+    scripts/*) rel_path="${file#scripts/}" ;;
+    *) rel_path="$(basename "$file")" ;;
+  esac
+  deployed="$deploy_dir/$rel_path"
   if [[ ! -f "$deployed" ]]; then
     ERRORS="${ERRORS}\n  ❌ $file → $deployed (未デプロイ)"
   else

--- a/hooks/enforce-hook-deploy-integrity.sh
+++ b/hooks/enforce-hook-deploy-integrity.sh
@@ -20,6 +20,7 @@ set -uo pipefail
 EXCLUDED_FROM_REGISTRATION=(
   "inject-claude-review-helper.py"
   "record-codex-review.sh"
+  "validate-hook-deployment.sh"
   "README.md"
 )
 
@@ -49,6 +50,9 @@ SETTINGS_FILE="$HOME/.claude/settings.json"
 # --- Helper: check if a filename is in the exclusion list ---
 is_excluded() {
   local filename="$1"
+  case "$filename" in
+    gate-modes/*) return 0 ;;
+  esac
   for excluded in "${EXCLUDED_FROM_REGISTRATION[@]}"; do
     if [[ "$filename" == "$excluded" ]]; then
       return 0
@@ -160,7 +164,7 @@ if [[ -f "$SETTINGS_FILE" ]]; then
     esac
 
     # Skip known exclusions
-    if is_excluded "$filename"; then
+    if is_excluded "$rel_path" || is_excluded "$filename"; then
       continue
     fi
 

--- a/hooks/gate-modes/common.sh
+++ b/hooks/gate-modes/common.sh
@@ -101,22 +101,128 @@ resolve_repo() {
   fi
 
   # Priority 3: upstream remote (fork workflow)
-  if git remote get-url upstream &>/dev/null; then
-    git remote get-url upstream 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||'
+  if git_ctx remote get-url upstream &>/dev/null; then
+    git_ctx remote get-url upstream 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||'
     return
   fi
 
   # Priority 4: origin (default)
-  git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||' || echo ""
+  git_ctx remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||' || echo ""
 }
 
+
+# =========================================================================
+# Helper: run git in the command's repository context when known
+# =========================================================================
+GIT_CONTEXT_DIR="${GIT_CONTEXT_DIR:-}"
+
+git_ctx() {
+  if [[ -n "${GIT_CONTEXT_DIR:-}" ]]; then
+    git -C "$GIT_CONTEXT_DIR" "$@"
+  else
+    git "$@"
+  fi
+}
+
+# Extract --head from a gh pr create command. Supports:
+#   gh pr create --head branch
+#   gh pr create --head=branch
+#   gh pr create --head owner:branch
+extract_pr_head_branch() {
+  local cmd="${1:-}"
+  [[ -z "$cmd" ]] && return 0
+  _CMD="$cmd" python3 - <<'PY'
+import os, shlex, sys
+
+cmd = os.environ.get("_CMD", "")
+try:
+    lexer = shlex.shlex(cmd, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    tokens = list(lexer)
+except Exception:
+    sys.exit(0)
+
+for i in range(len(tokens) - 2):
+    if tokens[i:i+3] != ["gh", "pr", "create"]:
+        continue
+    j = i + 3
+    while j < len(tokens):
+        token = tokens[j]
+        if token in {"&&", "||", ";", "|"}:
+            break
+        if token == "--head" and j + 1 < len(tokens):
+            value = tokens[j + 1]
+            print(value.split(":", 1)[-1])
+            sys.exit(0)
+        if token.startswith("--head="):
+            value = token.split("=", 1)[1]
+            print(value.split(":", 1)[-1])
+            sys.exit(0)
+        j += 1
+PY
+}
+
+# Resolve a leading `cd <path> && gh pr create ...` context from the raw
+# Bash command without executing it. Claude hooks run before Bash, so the
+# hook process cannot observe subshell cd effects directly.
+command_git_context_dir() {
+  local cmd="${1:-}"
+  [[ -z "$cmd" ]] && return 0
+  _CMD="$cmd" python3 - <<'PY'
+import os, shlex, subprocess, sys
+
+cmd = os.environ.get("_CMD", "")
+try:
+    lexer = shlex.shlex(cmd, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    tokens = list(lexer)
+except Exception:
+    sys.exit(0)
+
+gh_index = -1
+for i in range(len(tokens) - 2):
+    if tokens[i:i+3] == ["gh", "pr", "create"]:
+        gh_index = i
+        break
+if gh_index < 0:
+    sys.exit(0)
+
+candidate = ""
+for i in range(gh_index):
+    if tokens[i] == "cd" and i + 1 < gh_index:
+        candidate = tokens[i + 1]
+
+if not candidate or candidate == "-":
+    sys.exit(0)
+
+path = os.path.abspath(os.path.expanduser(candidate))
+try:
+    top = subprocess.check_output(
+        ["git", "-C", path, "rev-parse", "--show-toplevel"],
+        stderr=subprocess.DEVNULL,
+        text=True,
+    ).strip()
+except Exception:
+    sys.exit(0)
+
+if top:
+    print(top)
+PY
+}
 
 # =========================================================================
 # Helper: get current branch
 # =========================================================================
 current_branch() {
+  local cmd="${1:-}"
   local b
-  b=$(git branch --show-current 2>/dev/null || echo "")
+  b=$(extract_pr_head_branch "$cmd")
+  if [[ -n "$b" ]]; then
+    echo "$b"
+    return
+  fi
+
+  b=$(git_ctx branch --show-current 2>/dev/null || echo "")
   # GitHub Actions PR builds checkout a detached HEAD; GITHUB_HEAD_REF
   # carries the actual source branch name in that context.
   if [[ -z "$b" ]]; then
@@ -155,14 +261,19 @@ classify_review_tier() {
   # Fallback to local git diff if API failed
   if [[ -z "$changed_files" ]]; then
     local base_branch="main"
-    if git rev-parse --verify develop &>/dev/null; then
+    if git_ctx rev-parse --verify develop &>/dev/null; then
       base_branch="develop"
-    elif git rev-parse --verify main &>/dev/null; then
+    elif git_ctx rev-parse --verify main &>/dev/null; then
       base_branch="main"
-    elif git rev-parse --verify master &>/dev/null; then
+    elif git_ctx rev-parse --verify master &>/dev/null; then
       base_branch="master"
     fi
-    changed_files=$(git diff --name-only "${base_branch}...HEAD" 2>/dev/null || git diff --name-only "${base_branch}" 2>/dev/null || echo "")
+
+    local head_ref="HEAD"
+    if [[ -n "$branch" ]] && git_ctx rev-parse --verify "$branch" &>/dev/null; then
+      head_ref="$branch"
+    fi
+    changed_files=$(git_ctx diff --name-only "${base_branch}...${head_ref}" 2>/dev/null || git_ctx diff --name-only "$base_branch" "$head_ref" 2>/dev/null || echo "")
   fi
 
   if [[ -z "$changed_files" ]]; then

--- a/hooks/gate-modes/pre-create.sh
+++ b/hooks/gate-modes/pre-create.sh
@@ -17,13 +17,18 @@ echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) PRE_CREATE invoked. CWD=$(pwd) STATE=$REVIE
 cmd=$(extract_cmd)
 
 # Verify this is a gh pr create command
-if [[ -n "$cmd" ]] && ! echo "$(echo "$cmd" | head -1)" | grep -qE 'gh\s+pr\s+create'; then
+if [[ -n "$cmd" ]] && ! printf '%s\n' "$cmd" | grep -qE 'gh[[:space:]]+pr[[:space:]]+create'; then
   echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) SKIP: cmd='$cmd' not gh pr create" >> "$LOG_FILE" 2>/dev/null
   exit 0
 fi
 
-BRANCH=$(current_branch)
-echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) BRANCH=$BRANCH" >> "$LOG_FILE" 2>/dev/null
+_cmd_context=$(command_git_context_dir "$cmd")
+if [[ -n "$_cmd_context" ]]; then
+  export GIT_CONTEXT_DIR="$_cmd_context"
+fi
+
+BRANCH=$(current_branch "$cmd")
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) BRANCH=$BRANCH GIT_CONTEXT=${GIT_CONTEXT_DIR:-}" >> "$LOG_FILE" 2>/dev/null
 [[ -z "$BRANCH" ]] && { echo "[WARN] Cannot determine branch. Blocking PR creation." >&2; exit 2; }
 
 # Classify review tier based on branch name + changed files

--- a/settings.json
+++ b/settings.json
@@ -351,6 +351,12 @@
           },
           {
             "type": "command",
+            "command": "bash ~/.claude/hooks/enforce-deploy-verify-on-pr.sh",
+            "timeout": 15,
+            "statusMessage": "Verifying changed hooks/scripts are deployed..."
+          },
+          {
+            "type": "command",
             "command": "bash ~/.claude/hooks/enforce-follow-up-limit.sh",
             "timeout": 15,
             "statusMessage": "Checking follow-up fix limit..."

--- a/setup.sh
+++ b/setup.sh
@@ -49,9 +49,15 @@ mkdir -p "$HOOKS_DIR"
 cp "$REPO_DIR"/hooks/*.sh "$HOOKS_DIR/"
 cp "$REPO_DIR"/hooks/*.py "$HOOKS_DIR/" 2>/dev/null || true
 chmod +x "$HOOKS_DIR"/*.sh
+if [ -d "$REPO_DIR/hooks/gate-modes" ]; then
+  mkdir -p "$HOOKS_DIR/gate-modes"
+  cp "$REPO_DIR"/hooks/gate-modes/*.sh "$HOOKS_DIR/gate-modes/"
+  chmod +x "$HOOKS_DIR"/gate-modes/*.sh
+fi
 SH_COUNT=$(ls "$REPO_DIR"/hooks/*.sh 2>/dev/null | wc -l | tr -d ' ')
 PY_COUNT=$(ls "$REPO_DIR"/hooks/*.py 2>/dev/null | wc -l | tr -d ' ')
-echo "  Copied ${SH_COUNT} shell + ${PY_COUNT} python hook scripts"
+GATE_COUNT=$(ls "$REPO_DIR"/hooks/gate-modes/*.sh 2>/dev/null | wc -l | tr -d ' ')
+echo "  Copied ${SH_COUNT} shell + ${PY_COUNT} python hook scripts + ${GATE_COUNT} gate-mode modules"
 
 # 6. Copy scripts
 echo "[6/8] Installing scripts..."

--- a/tests/test-issue-183.sh
+++ b/tests/test-issue-183.sh
@@ -113,6 +113,20 @@ else
   echo "  FAIL (orphan not reported)"
 fi
 
+# --- T7b: gate-mode modules are dispatcher-sourced, not directly registered ---
+mkdir -p "${FAKE_PROJECT_HOOKS}/gate-modes" "${FAKE_INSTALLED_HOOKS}/gate-modes"
+echo '#!/bin/bash' > "${FAKE_PROJECT_HOOKS}/gate-modes/module.sh"
+cp "${FAKE_PROJECT_HOOKS}/gate-modes/module.sh" "${FAKE_INSTALLED_HOOKS}/gate-modes/module.sh"
+
+STDERR_OUT=$(CLAUDE_PROJECT_DIR="${TMPDIR_BASE}/project" bash "$PATCHED_H1" 2>&1 >/dev/null)
+if ! echo "$STDERR_OUT" | grep -q "NOT REGISTERED: gate-modes/module.sh"; then
+  PASS=$((PASS+1)); echo "--- T7b: gate-mode module registration check skipped ---"
+  echo "  PASS"
+else
+  FAIL=$((FAIL+1)); echo "--- T7b: gate-mode module registration check skipped ---"
+  echo "  FAIL (gate-mode module reported as unregistered)"
+fi
+
 echo ""
 echo "==================================="
 echo "Hook 2: enforce-hook-deploy-after-merge.sh"

--- a/tests/test-issue-214.sh
+++ b/tests/test-issue-214.sh
@@ -67,6 +67,13 @@ else
   fail "T7: BASE_BRANCH=main override unexpected exit $ec"
 fi
 
+# T8: Hook is registered in settings.json for PR creation preflight
+if grep -q 'enforce-deploy-verify-on-pr.sh' "$(cd "$(dirname "$0")/.." && pwd)/settings.json"; then
+  pass "T8: settings.json registers deploy verification hook"
+else
+  fail "T8: settings.json does not register deploy verification hook"
+fi
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed (total $TOTAL)"
 [[ "$FAIL" -eq 0 ]] && exit 0 || exit 1

--- a/tests/test-local-permissions-guard.sh
+++ b/tests/test-local-permissions-guard.sh
@@ -19,9 +19,11 @@ echo "=== Local permissions guard tests ==="
 
 tmpdirs=()
 cleanup() {
+  set +u
   for dir in "${tmpdirs[@]}"; do
     rm -rf "$dir"
   done
+  set -u
 }
 trap cleanup EXIT
 

--- a/tests/test-opencode-background-permissions.sh
+++ b/tests/test-opencode-background-permissions.sh
@@ -21,7 +21,11 @@ SETUP_FILE="$ROOT/setup.sh"
 
 # Temporary config directory for CI or machines without OpenCode installed.
 TMP_CONF_DIR=""
-cleanup() { [[ -n "$TMP_CONF_DIR" ]] && rm -rf "$TMP_CONF_DIR"; }
+cleanup() {
+  if [[ -n "$TMP_CONF_DIR" ]]; then
+    rm -rf "$TMP_CONF_DIR"
+  fi
+}
 trap cleanup EXIT
 
 echo "=== OpenCode background-safe permissions tests ==="

--- a/tests/test-pr-create-worktree-context.sh
+++ b/tests/test-pr-create-worktree-context.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# test-pr-create-worktree-context.sh -- PR create hooks honor Bash command worktree context
+set -euo pipefail
+
+PASS=0
+FAIL=0
+TOTAL=0
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { PASS=$((PASS+1)); TOTAL=$((TOTAL+1)); echo -e "${GREEN}  PASS${NC} $1"; }
+fail() { FAIL=$((FAIL+1)); TOTAL=$((TOTAL+1)); echo -e "${RED}  FAIL${NC} $1"; }
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PRECREATE_HOOK="$ROOT/hooks/pr-ci-review-gate.sh"
+DEPLOY_HOOK="$ROOT/hooks/enforce-deploy-verify-on-pr.sh"
+
+TMP_DIR=""
+cleanup() {
+  if [[ -n "$TMP_DIR" ]]; then
+    git -C "$TMP_DIR/repo" worktree remove --force "$TMP_DIR/worktree" >/dev/null 2>&1 || true
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+json_payload() {
+  CMD="$1" python3 - <<'PY'
+import json, os
+print(json.dumps({
+    "tool_name": "Bash",
+    "tool_input": {"command": os.environ["CMD"]},
+}))
+PY
+}
+
+setup_repo() {
+  TMP_DIR="$(mktemp -d)"
+  REPO="$TMP_DIR/repo"
+  WT="$TMP_DIR/worktree"
+  HOME_DIR="$TMP_DIR/home"
+  PROJECT_DIR="$TMP_DIR/project"
+
+  mkdir -p "$HOME_DIR/.claude/state" "$PROJECT_DIR/.claude/state"
+  git init "$REPO" >/dev/null
+  git -C "$REPO" config user.email "test@example.com"
+  git -C "$REPO" config user.name "Test User"
+  git -C "$REPO" checkout -b develop >/dev/null
+
+  mkdir -p "$REPO/hooks/gate-modes"
+  printf '# base common\n' > "$REPO/hooks/gate-modes/common.sh"
+  git -C "$REPO" add hooks/gate-modes/common.sh
+  git -C "$REPO" commit -m "base" >/dev/null
+
+  git -C "$REPO" checkout -b opencode/investigation-spikes >/dev/null
+  printf 'side branch\n' > "$REPO/side.txt"
+  git -C "$REPO" add side.txt
+  git -C "$REPO" commit -m "side" >/dev/null
+
+  git -C "$REPO" worktree add -b feat/worktree-pr "$WT" develop >/dev/null
+  printf '# feature common\n' > "$WT/hooks/gate-modes/common.sh"
+  git -C "$WT" add hooks/gate-modes/common.sh
+  git -C "$WT" commit -m "change gate mode" >/dev/null
+
+  python3 - <<PY
+import json
+state = {
+    "feat/worktree-pr": {
+        "code_review": True,
+        "codex_review": True,
+    }
+}
+for path in ["$PROJECT_DIR/.claude/state/review-status.json", "$HOME_DIR/.claude/state/review-status.json"]:
+    with open(path, "w") as f:
+        json.dump(state, f)
+PY
+}
+
+run_precreate() {
+  local cmd="$1"
+  local label="$2"
+  local payload
+  payload=$(json_payload "$cmd")
+
+  local out ec=0
+  if out=$(cd "$REPO" && HOME="$HOME_DIR" CLAUDE_PROJECT_DIR="$PROJECT_DIR" GATE_MODE=PRE_CREATE bash "$PRECREATE_HOOK" <<<"$payload" 2>&1); then
+    pass "$label"
+  else
+    ec=$?
+    fail "$label (exit $ec: $out)"
+  fi
+}
+
+run_deploy_hook_expect() {
+  local cmd="$1"
+  local expected="$2"
+  local label="$3"
+  local payload
+  payload=$(json_payload "$cmd")
+
+  local out ec=0
+  out=$(cd "$REPO" && HOME="$HOME_DIR" bash "$DEPLOY_HOOK" <<<"$payload" 2>&1) || ec=$?
+  if [[ "$ec" -eq "$expected" ]]; then
+    pass "$label"
+  else
+    fail "$label (expected exit $expected, got $ec: $out)"
+  fi
+}
+
+echo "=== PR create worktree context tests ==="
+
+setup_repo
+
+run_precreate \
+  "cd $WT && gh pr create --base develop --title 'fix: worktree context' --body 'Closes #999'" \
+  "T1: PRE_CREATE uses branch from command cd worktree"
+
+run_precreate \
+  $'cd '"$WT"$'\ngh pr create --base develop --title '"'"'fix: worktree context'"'"' --body '"'"'Closes #999'"'" \
+  "T2: PRE_CREATE detects multi-line cd then gh pr create"
+
+run_precreate \
+  "gh pr create --head feat/worktree-pr --base develop --title 'fix: worktree context' --body 'Closes #999'" \
+  "T3: PRE_CREATE uses explicit --head branch"
+
+mkdir -p "$HOME_DIR/.claude/hooks/gate-modes"
+printf '# base common\n' > "$HOME_DIR/.claude/hooks/gate-modes/common.sh"
+run_deploy_hook_expect \
+  "cd $WT && gh pr create --base develop --title 'fix: deploy context' --body 'Closes #999'" \
+  2 \
+  "T4: deploy verification checks gate-mode file in command worktree"
+
+printf '# feature common\n' > "$HOME_DIR/.claude/hooks/gate-modes/common.sh"
+run_deploy_hook_expect \
+  "cd $WT && gh pr create --base develop --title 'fix: deploy context' --body 'Closes #999'" \
+  0 \
+  "T5: deploy verification passes after gate-mode file is deployed"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed (total $TOTAL)"
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1

--- a/tests/test-publish-preflight-scenario.sh
+++ b/tests/test-publish-preflight-scenario.sh
@@ -38,6 +38,8 @@ mkdir -p "$TMP_HOME/.claude/hooks" "$TMP_HOME/.claude/scripts" "$TMP_HOME/.claud
 
 # Deploy current hooks/scripts into temp HOME to satisfy deploy verification.
 cp "$ROOT"/hooks/*.sh "$TMP_HOME/.claude/hooks/"
+mkdir -p "$TMP_HOME/.claude/hooks/gate-modes"
+cp "$ROOT"/hooks/gate-modes/*.sh "$TMP_HOME/.claude/hooks/gate-modes/"
 cp "$ROOT"/scripts/*.sh "$TMP_HOME/.claude/scripts/"
 
 BRANCH="$(git -C "$ROOT" branch --show-current 2>/dev/null || true)"
@@ -70,16 +72,23 @@ payload='{"tool_name":"Bash","tool_input":{"command":"gh pr create --base develo
 run_hook() {
   local hook="$1"
   local label="$2"
-  local extra_env=("${@:3}")
+  local -a extra_env=()
+  if [[ $# -gt 2 ]]; then
+    extra_env=("${@:3}")
+  fi
   local ec=0
-  if out=$(cd "$ROOT" && env HOME="$TMP_HOME" CLAUDE_PROJECT_DIR="$TMP_PROJECT" "${extra_env[@]}" bash "$hook" <<<"$payload" 2>&1); then
+  if [[ ${#extra_env[@]} -gt 0 ]]; then
+    out=$(cd "$ROOT" && env HOME="$TMP_HOME" CLAUDE_PROJECT_DIR="$TMP_PROJECT" "${extra_env[@]}" bash "$hook" <<<"$payload" 2>&1) || ec=$?
+  else
+    out=$(cd "$ROOT" && env HOME="$TMP_HOME" CLAUDE_PROJECT_DIR="$TMP_PROJECT" bash "$hook" <<<"$payload" 2>&1) || ec=$?
+  fi
+  if [[ "$ec" -eq 0 ]]; then
     if [[ -z "$out" || "$out" == *"[PR Guard] 確認事項:"* ]]; then
       pass "$label"
     else
       fail "$label (unexpected output: $out)"
     fi
   else
-    ec=$?
     fail "$label (exit $ec: $out)"
   fi
 }


### PR DESCRIPTION
## Summary

Closes #223

- Resolve PRE_CREATE branch context from `gh pr create --head ...` or from `cd <worktree> && gh pr create ...` without executing the Bash command.
- Run local tier/diff checks through the resolved git context instead of the hook process CWD.
- Copy `hooks/gate-modes/*.sh` during setup and include gate-mode modules in deploy verification.
- Register deploy verification in `settings.json` and stop treating dispatcher-sourced gate-mode modules as directly registered hooks.
- Harden a few test harness cleanup/env-array paths that were failing under `set -u`.

## Validation

- `bash -n hooks/*.sh hooks/gate-modes/*.sh scripts/*.sh setup.sh`
- `python3 -m json.tool settings.json`
- `python3 -m json.tool .claude/settings.local.json`
- `git diff --check`
- `for t in tests/test-*.sh; do bash "$t"; done`
- Deployed changed hooks/settings into `~/.claude` and verified deployed PRE_CREATE + deploy verification exit 0 for this branch.

## Note

`shellcheck` and `gh` are not installed in this local environment, so shellcheck and GitHub CLI validation were not runnable here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * PR作成時に別のディレクトリから実行される場合のワークツリーコンテキストに対応しました。
  * 展開されたファイルの検証機能を強化しました。

* **バグ修正**
  * フックの登録確認ロジックを修正し、更新されたディレクトリ構造に対応させました。

* **テスト**
  * ワークツリーコンテキストの動作検証とフック登録確認用のテストケースを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terisuke/claude-code-skills/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->