### PR TITLE
fix: record code reviews for worktree branch context

### DIFF
--- a/hooks/record-code-review.sh
+++ b/hooks/record-code-review.sh
@@ -45,39 +45,148 @@ if [[ "$IS_REVIEW" != "true" ]]; then
   exit 0
 fi
 
+if ! command -v python3 &>/dev/null; then
+  echo "[WARN] python3 が見つかりません。レビュー記録をスキップできないため fail-closed します。" >&2
+  echo "  python3 をインストールしてください。" >&2
+  exit 2
+fi
+
+resolve_review_context() {
+  _HOOK_INPUT="$input" python3 - <<'PY'
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def load_tool_input(raw):
+    try:
+        payload = json.loads(raw or "{}")
+    except (json.JSONDecodeError, TypeError):
+        payload = {}
+    tool_input = payload.get("tool_input", {})
+    if isinstance(tool_input, str):
+        try:
+            tool_input = json.loads(tool_input)
+        except (json.JSONDecodeError, TypeError):
+            tool_input = {}
+    return tool_input if isinstance(tool_input, dict) else {}
+
+
+def git_root(path_text):
+    if not path_text:
+        return ""
+    path = Path(os.path.expanduser(os.path.expandvars(path_text))).resolve()
+    candidates = [path] if path.is_dir() else [path.parent]
+    candidates.extend(candidates[0].parents)
+    for candidate in candidates:
+        try:
+            out = subprocess.check_output(
+                ["git", "-C", str(candidate), "rev-parse", "--show-toplevel"],
+                stderr=subprocess.DEVNULL,
+                text=True,
+            ).strip()
+        except Exception:
+            continue
+        if out:
+            return out
+    return ""
+
+
+def git_branch(repo):
+    if not repo:
+        return ""
+    try:
+        return subprocess.check_output(
+            ["git", "-C", repo, "branch", "--show-current"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except Exception:
+        return ""
+
+
+tool_input = load_tool_input(os.environ.get("_HOOK_INPUT", ""))
+text_fields = []
+for key in ("prompt", "description", "message", "task", "instructions"):
+    value = tool_input.get(key)
+    if isinstance(value, str):
+        text_fields.append(value)
+text = "\n".join(text_fields)
+
+branch = ""
+for key in ("branch", "head_branch", "head", "target_branch", "review_branch"):
+    value = tool_input.get(key)
+    if isinstance(value, str) and value.strip():
+        branch = value.strip().split(":", 1)[-1]
+        break
+
+if not branch:
+    patterns = [
+        r"(?:^|[\s,;])--head(?:=|\s+)([A-Za-z0-9._/-]+)",
+        r"(?:^|[\s,;])(?:branch|head|review_branch|target_branch)\s*[:=]\s*`?([A-Za-z0-9._/-]+)`?",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, text)
+        if match:
+            branch = match.group(1).split(":", 1)[-1]
+            break
+
+repo = ""
+for key in ("cwd", "worktree", "worktree_path", "repo_path", "repository_path", "project_path", "working_directory"):
+    value = tool_input.get(key)
+    if isinstance(value, str):
+        repo = git_root(value)
+        if repo:
+            break
+
+if not repo:
+    for raw_path in re.findall(r"/[^\s'\"`<>),]+", text):
+        repo = git_root(raw_path.rstrip(".,:;]})"))
+        if repo:
+            break
+
+if not repo:
+    repo = git_root(os.getcwd())
+
+if not branch:
+    branch = git_branch(repo)
+
+print(json.dumps({"repo": repo, "branch": branch}))
+PY
+}
+
+CONTEXT_JSON=$(resolve_review_context)
+REPO_PATH=$(echo "$CONTEXT_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin).get('repo',''))" 2>/dev/null || echo "")
+BRANCH=$(echo "$CONTEXT_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin).get('branch',''))" 2>/dev/null || echo "")
+
 # Determine state directories — write to BOTH global and project-scoped
 # to prevent CWD-dependent state mismatch (Issue #7)
 GLOBAL_STATE_DIR="$HOME/.claude/state"
 mkdir -p "$GLOBAL_STATE_DIR"
 [ ! -f "$GLOBAL_STATE_DIR/review-status.json" ] && echo '{}' > "$GLOBAL_STATE_DIR/review-status.json"
 
-PROJECT_STATE_DIR=""
+PROJECT_STATE_DIRS=()
 if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
-  PROJECT_STATE_DIR="${CLAUDE_PROJECT_DIR}/.claude/state"
-elif git rev-parse --show-toplevel &>/dev/null; then
-  PROJECT_STATE_DIR="$(git rev-parse --show-toplevel)/.claude/state"
+  PROJECT_STATE_DIRS+=("${CLAUDE_PROJECT_DIR}/.claude/state")
 fi
-if [[ -n "$PROJECT_STATE_DIR" ]] && [[ "$PROJECT_STATE_DIR" != "$GLOBAL_STATE_DIR" ]]; then
-  mkdir -p "$PROJECT_STATE_DIR"
-  [ ! -f "$PROJECT_STATE_DIR/review-status.json" ] && echo '{}' > "$PROJECT_STATE_DIR/review-status.json"
+if [[ -n "$REPO_PATH" ]]; then
+  PROJECT_STATE_DIRS+=("$REPO_PATH/.claude/state")
+elif git rev-parse --show-toplevel &>/dev/null; then
+  PROJECT_STATE_DIRS+=("$(git rev-parse --show-toplevel)/.claude/state")
 fi
 
 # Primary state file (global — always consistent regardless of CWD)
 REVIEW_STATE="$GLOBAL_STATE_DIR/review-status.json"
 
-# Get current branch
-BRANCH=$(git branch --show-current 2>/dev/null || echo "")
 if [[ -z "$BRANCH" ]]; then
   exit 0
 fi
 
 # Update review-status.json: mark code_review as true for this branch
 NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-if ! command -v python3 &>/dev/null; then
-  echo "[WARN] python3 が見つかりません。レビュー記録をスキップできないため fail-closed します。" >&2
-  echo "  python3 をインストールしてください。" >&2
-  exit 2
-fi
 if command -v python3 &>/dev/null; then
   # Primary: python3 + fcntl for atomic flock write
   _STATE="$REVIEW_STATE" _BR="$BRANCH" _NOW="$NOW" python3 -c "
@@ -104,8 +213,12 @@ elif command -v jq &>/dev/null; then
 fi
 
 # Also write to project-scoped state if it exists (dual-write for CWD consistency)
-if [[ -n "$PROJECT_STATE_DIR" ]] && [[ "$PROJECT_STATE_DIR" != "$GLOBAL_STATE_DIR" ]]; then
+for PROJECT_STATE_DIR in "${PROJECT_STATE_DIRS[@]}"; do
+  [[ -z "$PROJECT_STATE_DIR" ]] && continue
+  [[ "$PROJECT_STATE_DIR" == "$GLOBAL_STATE_DIR" ]] && continue
   PROJECT_REVIEW="$PROJECT_STATE_DIR/review-status.json"
+  mkdir -p "$PROJECT_STATE_DIR"
+  [ ! -f "$PROJECT_REVIEW" ] && echo '{}' > "$PROJECT_REVIEW"
   if command -v python3 &>/dev/null; then
     # Primary: python3 + fcntl for atomic flock write
     _STATE="$PROJECT_REVIEW" _BR="$BRANCH" _NOW="$NOW" python3 -c "
@@ -130,7 +243,7 @@ with open(f_path, 'r+') as f:
       '.[$b] = ((.[$b] // {}) + {"code_review": true, "code_review_at": $t})' \
       "$PROJECT_REVIEW" > "$tmp" 2>/dev/null && mv "$tmp" "$PROJECT_REVIEW"
   fi
-fi
+done
 
-echo "✅ [review-gate] code-reviewer 完了を記録: branch=$BRANCH" >&2
+echo "✅ [review-gate] code-reviewer 完了を記録: branch=$BRANCH repo=${REPO_PATH:-unknown}" >&2
 exit 0

--- a/tests/test-record-code-review-worktree-context.sh
+++ b/tests/test-record-code-review-worktree-context.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# test-record-code-review-worktree-context.sh -- code-review records use Agent worktree context
+set -euo pipefail
+
+PASS=0
+FAIL=0
+TOTAL=0
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { PASS=$((PASS+1)); TOTAL=$((TOTAL+1)); echo -e "${GREEN}  PASS${NC} $1"; }
+fail() { FAIL=$((FAIL+1)); TOTAL=$((TOTAL+1)); echo -e "${RED}  FAIL${NC} $1"; }
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$ROOT/hooks/record-code-review.sh"
+TMP_DIR=""
+
+cleanup() {
+  if [[ -n "$TMP_DIR" ]]; then
+    git -C "$TMP_DIR/repo" worktree remove --force "$TMP_DIR/worktree" >/dev/null 2>&1 || true
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+json_payload() {
+  PROMPT="$1" python3 - <<'PY'
+import json, os
+print(json.dumps({
+    "tool_name": "Agent",
+    "tool_input": {
+        "subagent_type": "code-reviewer",
+        "prompt": os.environ["PROMPT"],
+    },
+}))
+PY
+}
+
+state_has_branch() {
+  local state_file="$1"
+  local branch="$2"
+  python3 - "$state_file" "$branch" <<'PY'
+import json, sys
+path, branch = sys.argv[1:]
+with open(path) as f:
+    data = json.load(f)
+assert data.get(branch, {}).get("code_review") is True
+PY
+}
+
+echo "=== record-code-review worktree context tests ==="
+
+if bash -n "$HOOK" 2>/dev/null; then
+  pass "T1: syntax check"
+else
+  fail "T1: syntax check failed"
+fi
+
+TMP_DIR="$(mktemp -d)"
+REPO="$TMP_DIR/repo"
+WT="$TMP_DIR/worktree"
+HOME_DIR="$TMP_DIR/home"
+PROJECT_DIR="$TMP_DIR/project"
+mkdir -p "$HOME_DIR/.claude/state" "$PROJECT_DIR/.claude/state"
+
+git init "$REPO" >/dev/null
+git -C "$REPO" config user.email "test@example.com"
+git -C "$REPO" config user.name "Test User"
+git -C "$REPO" checkout -b develop >/dev/null
+printf 'base\n' > "$REPO/base.txt"
+git -C "$REPO" add base.txt
+git -C "$REPO" commit -m "base" >/dev/null
+
+git -C "$REPO" checkout -b opencode/investigation-spikes >/dev/null
+printf 'wrong branch\n' > "$REPO/wrong.txt"
+git -C "$REPO" add wrong.txt
+git -C "$REPO" commit -m "wrong branch" >/dev/null
+
+git -C "$REPO" worktree add -b feat/governance-policy-gate "$WT" develop >/dev/null
+
+payload=$(json_payload "Review branch: feat/governance-policy-gate in worktree: $WT")
+out=""
+ec=0
+out=$(cd "$REPO" && HOME="$HOME_DIR" CLAUDE_PROJECT_DIR="$PROJECT_DIR" bash "$HOOK" <<<"$payload" 2>&1) || ec=$?
+if [[ "$ec" -eq 0 ]]; then
+  pass "T2: hook exits 0 from wrong parent branch"
+else
+  fail "T2: hook failed (exit $ec: $out)"
+fi
+
+if state_has_branch "$HOME_DIR/.claude/state/review-status.json" "feat/governance-policy-gate"; then
+  pass "T3: global state uses reviewed worktree branch"
+else
+  fail "T3: global state missing feat/governance-policy-gate"
+fi
+
+if state_has_branch "$PROJECT_DIR/.claude/state/review-status.json" "feat/governance-policy-gate"; then
+  pass "T4: CLAUDE_PROJECT_DIR state uses reviewed worktree branch"
+else
+  fail "T4: project state missing feat/governance-policy-gate"
+fi
+
+if state_has_branch "$WT/.claude/state/review-status.json" "feat/governance-policy-gate"; then
+  pass "T5: worktree-local state uses reviewed branch"
+else
+  fail "T5: worktree-local state missing feat/governance-policy-gate"
+fi
+
+if python3 - "$HOME_DIR/.claude/state/review-status.json" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+assert not data.get("opencode/investigation-spikes", {}).get("code_review")
+PY
+then
+  pass "T6: parent CWD branch was not marked reviewed"
+else
+  fail "T6: parent CWD branch was incorrectly marked reviewed"
+fi
+
+payload=$(python3 - <<PY
+import json
+print(json.dumps({
+    "tool_name": "Agent",
+    "tool_input": {
+        "subagent_type": "code-reviewer",
+        "cwd": "$WT",
+        "prompt": "Review this branch",
+    },
+}))
+PY
+)
+rm -f "$HOME_DIR/.claude/state/review-status.json"
+out=$(cd "$REPO" && HOME="$HOME_DIR" bash "$HOOK" <<<"$payload" 2>&1) || ec=$?
+if state_has_branch "$HOME_DIR/.claude/state/review-status.json" "feat/governance-policy-gate"; then
+  pass "T7: tool_input.cwd resolves branch without prompt branch"
+else
+  fail "T7: cwd branch resolution failed"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed (total $TOTAL)"
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Closes #225

- Resolve `record-code-review.sh` branch/repo context from Agent payload metadata (`branch`, `head`, `cwd`, `worktree`, `repo_path`, etc.).
- Parse prompt/description fallback text for `branch:` / `--head` and absolute worktree paths.
- Write review records to global state, `CLAUDE_PROJECT_DIR` state, and resolved worktree repo state where applicable.
- Add regression coverage proving a review launched from a parent `opencode/investigation-spikes` CWD records `feat/governance-policy-gate`, not the parent branch.

## Validation

- `bash -n hooks/*.sh hooks/gate-modes/*.sh scripts/*.sh setup.sh`
- `python3 -m json.tool settings.json`
- `python3 -m json.tool .claude/settings.local.json`
- `git diff --check`
- `bash tests/test-record-code-review-worktree-context.sh`
- `for t in tests/test-*.sh; do bash "$t"; done`
- Deployed `record-code-review.sh` to `~/.claude/hooks/` and verified the installed hook records `feat/governance-policy-gate` from a wrong parent CWD.

## Note

`shellcheck` and `gh` are not installed in this local environment, so shellcheck and GitHub CLI validation were not runnable here.