### PR TITLE
fix: isolate context budget Write gate per session

### DIFF
--- a/hooks/context-budget-reset.sh
+++ b/hooks/context-budget-reset.sh
@@ -19,6 +19,8 @@ NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 cat > "$STATE_FILE" << EOF
 {
   "session_id": "$(uuidgen 2>/dev/null || python3 -c 'import uuid; print(uuid.uuid4())')",
+  "mode": "auto",
+  "contexts": {},
   "read_files": [],
   "read_count": 0,
   "write_test_doc_count": 0,

--- a/hooks/context-budget-set-mode.sh
+++ b/hooks/context-budget-set-mode.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# context-budget-set-mode.sh
+# ========================================================================
+# Manual helper: set context budget gate mode.
+#
+# Usage:
+#   bash ~/.claude/hooks/context-budget-set-mode.sh planning
+#   bash ~/.claude/hooks/context-budget-set-mode.sh research
+#   bash ~/.claude/hooks/context-budget-set-mode.sh auto
+#
+# This is intentionally a hook-side helper because context-budget gate
+# messages point users at ~/.claude/hooks/ and the state file is protected
+# from direct edits.
+# ========================================================================
+
+set -euo pipefail
+
+MODE="${1:-}"
+case "$MODE" in
+  auto|planning|research) ;;
+  *)
+    echo "Usage: $0 <auto|planning|research>" >&2
+    exit 2
+    ;;
+esac
+
+STATE_DIR="$HOME/.claude/state"
+STATE_FILE="$STATE_DIR/context-budget.json"
+mkdir -p "$STATE_DIR"
+
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+_STATE_FILE="$STATE_FILE" _MODE="$MODE" _NOW="$NOW" python3 << 'PY'
+import json
+import os
+import fcntl
+
+path = os.environ["_STATE_FILE"]
+mode = os.environ["_MODE"]
+now = os.environ["_NOW"]
+
+with open(path, "a+", encoding="utf-8") as f:
+    fcntl.flock(f, fcntl.LOCK_EX)
+    f.seek(0)
+    try:
+        state = json.load(f)
+    except json.JSONDecodeError:
+        state = {}
+
+    state["mode"] = mode
+    state["mode_set_at"] = now
+    state["mode_set_by"] = "context-budget-set-mode.sh"
+    state.setdefault("contexts", {})
+    state.setdefault("read_files", [])
+    state.setdefault("warnings_issued", [])
+
+    f.seek(0)
+    f.truncate()
+    json.dump(state, f, indent=2)
+    f.write("\n")
+    fcntl.flock(f, fcntl.LOCK_UN)
+PY
+
+echo "[Context Budget] mode=$MODE"

--- a/hooks/context-budget-write-gate.sh
+++ b/hooks/context-budget-write-gate.sh
@@ -10,6 +10,7 @@
 #
 # Trigger: Before Write tool use
 # State file: ~/.claude/state/context-budget.json
+# Primary count source: current transcript_path (session-local)
 # Rule ref: delegation.md > テスト作成は原則Codex委任
 # ========================================================================
 
@@ -30,6 +31,7 @@ if [[ ! -f "$STATE_FILE" ]]; then
 {
   "session_id": "",
   "mode": "auto",
+  "contexts": {},
   "read_files": [],
   "read_count": 0,
   "write_test_doc_count": 0,
@@ -38,6 +40,37 @@ if [[ ! -f "$STATE_FILE" ]]; then
   "started_at": ""
 }
 EOF
+fi
+
+INPUT_JSON=""
+if [[ ! -t 0 ]]; then
+  INPUT_JSON=$(cat)
+fi
+
+FILE_PATH=""
+TRANSCRIPT_PATH=""
+SESSION_ID=""
+HOOK_CWD=""
+if [[ -n "$INPUT_JSON" ]]; then
+  PARSED=$(echo "$INPUT_JSON" | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    fp = data.get('tool_input', {}).get('file_path', '')
+    print(fp)
+    print(data.get('transcript_path', ''))
+    print(data.get('session_id', ''))
+    print(data.get('cwd', ''))
+except Exception:
+    print('')
+    print('')
+    print('')
+    print('')
+" 2>/dev/null || echo "")
+  FILE_PATH=$(printf '%s\n' "$PARSED" | sed -n '1p')
+  TRANSCRIPT_PATH=$(printf '%s\n' "$PARSED" | sed -n '2p')
+  SESSION_ID=$(printf '%s\n' "$PARSED" | sed -n '3p')
+  HOOK_CWD=$(printf '%s\n' "$PARSED" | sed -n '4p')
 fi
 
 # --- Planning mode exemption ---
@@ -51,24 +84,6 @@ if [[ "$MODE" == "planning" ]] || [[ "$MODE" == "research" ]]; then
   exit 0
 fi
 
-INPUT_JSON=""
-if [[ ! -t 0 ]]; then
-  INPUT_JSON=$(cat)
-fi
-
-FILE_PATH=""
-if [[ -n "$INPUT_JSON" ]]; then
-  FILE_PATH=$(echo "$INPUT_JSON" | python3 -c "
-import json, os, sys
-try:
-    data = json.load(sys.stdin)
-    fp = data.get('tool_input', {}).get('file_path', '')
-    print(fp)
-except:
-    print('')
-" 2>/dev/null || echo "")
-fi
-
 # Skip non-project files (hooks, memory, settings, state, tmp)
 if [[ "$FILE_PATH" == *"/.claude/"* ]] || [[ "$FILE_PATH" == *"/memory/"* ]] || [[ "$FILE_PATH" == /tmp/* ]]; then
   exit 0
@@ -77,40 +92,123 @@ fi
 NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 [[ ! -f "$STATE_FILE" ]] && echo '{}' > "$STATE_FILE"
-_STATE_FILE="$STATE_FILE" _FILE_PATH="$FILE_PATH" _NOW="$NOW" python3 << PYEOF
-import json, sys, os, re, fcntl
+_STATE_FILE="$STATE_FILE" _FILE_PATH="$FILE_PATH" _NOW="$NOW" _TRANSCRIPT_PATH="$TRANSCRIPT_PATH" _SESSION_ID="$SESSION_ID" _HOOK_CWD="$HOOK_CWD" python3 << 'PYEOF'
+import hashlib
+import json
+import os
+import re
+import sys
+import fcntl
 
 state_file = os.environ['_STATE_FILE']
 file_path = os.environ['_FILE_PATH']
 now = os.environ['_NOW']
 basename = os.path.basename(file_path)
+transcript_path = os.environ.get('_TRANSCRIPT_PATH', '')
+session_id = os.environ.get('_SESSION_ID', '')
+hook_cwd = os.environ.get('_HOOK_CWD', '')
 
-# Detect test file patterns
-is_test = bool(re.search(r'(test_|\.test\.|\.spec\.|__tests__|_test\.)', file_path, re.IGNORECASE))
+def classify(path):
+    if not path:
+        return False, False
+    is_test_file = bool(re.search(r'(test_|\.test\.|\.spec\.|__tests__|_test\.)', path, re.IGNORECASE))
+    is_doc_file = bool(re.search(r'(\.md$|/docs/|README|CHANGELOG|\.rst$)', path, re.IGNORECASE))
+    if re.search(r'(CLAUDE\.md|Plans\.md|MEMORY\.md|AGENTS\.md)', path):
+        is_doc_file = False
+    return is_test_file, is_doc_file
 
-# Detect documentation file patterns
-is_doc = bool(re.search(r'(\.md$|/docs/|README|CHANGELOG|\.rst$)', file_path, re.IGNORECASE))
-# Exclude project config docs that are typically small edits
-if re.search(r'(CLAUDE\.md|Plans\.md|MEMORY\.md|AGENTS\.md)', file_path):
-    is_doc = False
-
+is_test, is_doc = classify(file_path)
 if not is_test and not is_doc:
     sys.exit(0)
 
-with open(state_file, "r+") as f:
-    fcntl.flock(f, fcntl.LOCK_EX)
-    state = json.load(f)
+def iter_tool_uses(record):
+    message = record.get("message", {})
+    content = message.get("content", [])
+    if isinstance(content, dict):
+        content = [content]
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                yield block.get("name", ""), block.get("input", {}) or {}
 
-    if not state.get("started_at"):
-        state["started_at"] = now
+    # Lightweight fallback for synthetic transcripts and future format changes.
+    tool_name = record.get("tool_name", "")
+    tool_input = record.get("tool_input", {})
+    if tool_name:
+        yield tool_name, tool_input if isinstance(tool_input, dict) else {}
 
-    state["write_test_doc_count"] = state.get("write_test_doc_count", 0) + 1
-    count = state["write_test_doc_count"]
+def count_from_transcript(transcript_path):
+    if not transcript_path or not os.path.isfile(transcript_path):
+        return None
 
-    f.seek(0)
-    f.truncate()
-    json.dump(state, f, indent=2)
-    fcntl.flock(f, fcntl.LOCK_UN)
+    files = []
+    try:
+        with open(transcript_path, encoding="utf-8") as transcript:
+            for line in transcript:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                for name, tool_input in iter_tool_uses(record):
+                    if name != "Write":
+                        continue
+                    prior_path = tool_input.get("file_path", "")
+                    prior_is_test, prior_is_doc = classify(prior_path)
+                    if prior_is_test or prior_is_doc:
+                        files.append(prior_path)
+    except OSError:
+        return None
+
+    unique = []
+    seen = set()
+    for prior_path in files:
+        if prior_path and prior_path not in seen:
+            unique.append(prior_path)
+            seen.add(prior_path)
+    if file_path and file_path not in seen:
+        unique.append(file_path)
+    return len(unique)
+
+def fallback_context_key():
+    raw = (
+        session_id
+        or transcript_path
+        or hook_cwd
+        or os.environ.get("CLAUDE_PROJECT_DIR", "")
+        or os.getcwd()
+    )
+    return hashlib.sha256(raw.encode("utf-8", "ignore")).hexdigest()[:16]
+
+def count_from_context_state():
+    key = fallback_context_key()
+    with open(state_file, "r+") as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        try:
+            state = json.load(f)
+        except json.JSONDecodeError:
+            state = {}
+
+        if not state.get("started_at"):
+            state["started_at"] = now
+        contexts = state.setdefault("contexts", {})
+        context = contexts.setdefault(key, {})
+        files = context.setdefault("write_test_doc_files", [])
+        if file_path and file_path not in files:
+            files.append(file_path)
+        context["write_test_doc_count"] = len(files)
+        context["updated_at"] = now
+
+        f.seek(0)
+        f.truncate()
+        json.dump(state, f, indent=2)
+        fcntl.flock(f, fcntl.LOCK_UN)
+    return len(files)
+
+transcript_count = count_from_transcript(transcript_path)
+count = transcript_count if transcript_count is not None else count_from_context_state()
 
 file_type = "テスト" if is_test else "ドキュメント"
 

--- a/hooks/enforce-hook-deploy-integrity.sh
+++ b/hooks/enforce-hook-deploy-integrity.sh
@@ -18,6 +18,7 @@ set -uo pipefail
 
 # --- Known exclusions (not directly registered in settings.json) ---
 EXCLUDED_FROM_REGISTRATION=(
+  "context-budget-set-mode.sh"
   "inject-claude-review-helper.py"
   "record-codex-review.sh"
   "validate-hook-deployment.sh"

--- a/hooks/validate-hook-deployment.sh
+++ b/hooks/validate-hook-deployment.sh
@@ -15,6 +15,7 @@ set -uo pipefail
 
 # --- Known exclusions (not directly registered in settings.json) ---
 EXCLUDED_FROM_REGISTRATION=(
+  "context-budget-set-mode.sh"
   "inject-claude-review-helper.py"
   "record-codex-review.sh"
   "README.md"

--- a/scripts/delivery_score.py
+++ b/scripts/delivery_score.py
@@ -60,12 +60,21 @@ def score_hook_coverage(project_root: Path) -> dict:
                     if script_name.endswith(".sh"):
                         registered_hooks.add(script_name)
 
-    # Expected hooks: all .sh files in hooks/ directory
+    # Expected hooks: event hooks in hooks/ directory. Hook-side helpers are
+    # deployed with hooks but are intentionally invoked manually/by other hooks.
+    excluded_from_registration = {
+        "context-budget-set-mode.sh",
+        "inject-claude-review-helper.py",
+        "record-codex-review.sh",
+        "validate-hook-deployment.sh",
+    }
+
+    # Expected hooks: all .sh files in hooks/ directory minus helpers.
     hooks_dir = project_root / "hooks"
     expected_hooks = set()
     if hooks_dir.exists():
         for f in hooks_dir.iterdir():
-            if f.suffix == ".sh" and not f.name.startswith("_"):
+            if f.suffix == ".sh" and not f.name.startswith("_") and f.name not in excluded_from_registration:
                 expected_hooks.add(f.name)
 
     # Exclude _unused directory

--- a/tests/test-context-budget-write-session-isolation.sh
+++ b/tests/test-context-budget-write-session-isolation.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# test-context-budget-write-session-isolation.sh
+# Verifies doc/test Write gating is scoped to the current transcript, not
+# stale counters left by another agent/session.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$ROOT/hooks/context-budget-write-gate.sh"
+SET_MODE="$ROOT/hooks/context-budget-set-mode.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo -e "\033[0;32mPASS\033[0m: $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "\033[0;31mFAIL\033[0m: $1"; FAIL=$((FAIL + 1)); }
+
+TMP_HOME="$(mktemp -d)"
+trap 'rm -rf "$TMP_HOME"' EXIT
+export HOME="$TMP_HOME"
+mkdir -p "$HOME/.claude/state"
+
+make_input() {
+  local transcript="$1"
+  local file_path="$2"
+  python3 - "$transcript" "$file_path" <<'PY'
+import json
+import sys
+
+print(json.dumps({
+    "tool_name": "Write",
+    "transcript_path": sys.argv[1],
+    "tool_input": {"file_path": sys.argv[2], "content": "x"},
+}))
+PY
+}
+
+run_hook() {
+  local input="$1"
+  set +e
+  output=$(printf '%s' "$input" | bash "$HOOK" 2>&1)
+  status=$?
+  set -e
+}
+
+# Stale global counter should not affect a fresh transcript.
+cat > "$HOME/.claude/state/context-budget.json" <<'JSON'
+{
+  "mode": "auto",
+  "write_test_doc_count": 9,
+  "contexts": {}
+}
+JSON
+fresh_transcript="$TMP_HOME/fresh.jsonl"
+: > "$fresh_transcript"
+run_hook "$(make_input "$fresh_transcript" "/repo/docs/reviews/claude-code-review-20260520.md")"
+if [[ "$status" -eq 0 && "$output" == *"ドキュメントファイル作成を検出"* ]]; then
+  pass "T1: fresh transcript ignores stale global doc counter"
+else
+  fail "T1: expected allow despite stale counter (status=$status output=$output)"
+fi
+
+# A second doc Write in the same transcript is still blocked.
+blocked_transcript="$TMP_HOME/blocked.jsonl"
+cat > "$blocked_transcript" <<'JSONL'
+{"message":{"content":[{"type":"tool_use","name":"Write","input":{"file_path":"/repo/docs/reviews/first.md","content":"x"}}]}}
+JSONL
+run_hook "$(make_input "$blocked_transcript" "/repo/docs/reviews/second.md")"
+if [[ "$status" -eq 2 && "$output" == *"2件目"* ]]; then
+  pass "T2: same transcript still blocks second doc Write"
+else
+  fail "T2: expected second doc Write block (status=$status output=$output)"
+fi
+
+# The advertised planning helper must exist and exempt the gate.
+bash "$SET_MODE" planning >/dev/null
+run_hook "$(make_input "$blocked_transcript" "/repo/docs/reviews/third.md")"
+if [[ "$status" -eq 0 ]]; then
+  pass "T3: planning mode helper exempts doc Write gate"
+else
+  fail "T3: expected planning mode allow (status=$status output=$output)"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Closes #227.

- Scope `context-budget-write-gate.sh` doc/test counting to the current `transcript_path` when available, with a per-context fallback instead of trusting stale global `write_test_doc_count`.
- Add the advertised `context-budget-set-mode.sh` helper so `planning` / `research` mode can actually be set without editing protected state files.
- Mark the helper as intentionally unregistered in deployment checks and delivery scoring.
- Add regression coverage for stale global counters, same-transcript second doc blocking, and planning-mode exemption.

## Validation

- `bash -n hooks/*.sh scripts/*.sh setup.sh`
- `python3 -m json.tool settings.json`
- `python3 -m json.tool .claude/settings.local.json`
- `python3 -m py_compile scripts/delivery_score.py`
- `git diff --check`
- `bash tests/test-context-budget-write-session-isolation.sh`
- `bash tests/test-codex-task-doc-gate.sh`
- `for t in tests/test-*.sh; do bash "$t" || exit 1; done`
- `python3 scripts/delivery_score.py --json`
- Local deployment: copied changed hooks/scripts into `~/.claude`, MD5 verified, and deployed `context-budget-write-gate.sh` allowed a fresh transcript despite stale global `write_test_doc_count=9`.

Note: `shellcheck` is not installed in this local environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * コンテキスト予算ゲートのモード設定機能を追加

* **Improvements**
  * Write ツール使用時のテスト/ドキュメント作成検出をセッション別に分離・管理するよう拡張
  * コンテキスト単位でのカウント方式に変更し、トランスクリプト履歴から重複排除

* **Tests**
  * セッション分離の検証テストを新規追加

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terisuke/claude-code-skills/pull/228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->