### PR TITLE
fix: resolve Codex review records from tool worktree

### DIFF
--- a/hooks/record-codex-review.sh
+++ b/hooks/record-codex-review.sh
@@ -15,28 +15,144 @@
 
 set -euo pipefail
 
+if ! command -v python3 &>/dev/null; then
+  echo "[WARN] python3 が見つかりません。Codexレビュー記録をスキップできないため fail-closed します。" >&2
+  echo "  python3 をインストールしてください。" >&2
+  exit 2
+fi
+
+resolve_review_context() {
+  _HOOK_INPUT="$INPUT" python3 - <<'PY'
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+
+def load_tool_input(raw):
+    try:
+        payload = json.loads(raw or "{}")
+    except (json.JSONDecodeError, TypeError):
+        payload = {}
+    tool_input = payload.get("tool_input", {})
+    if isinstance(tool_input, str):
+        try:
+            tool_input = json.loads(tool_input)
+        except (json.JSONDecodeError, TypeError):
+            tool_input = {}
+    return tool_input if isinstance(tool_input, dict) else {}
+
+
+def git_root(path_text):
+    if not path_text:
+        return ""
+    path = Path(os.path.expanduser(os.path.expandvars(path_text))).resolve()
+    candidates = [path] if path.is_dir() else [path.parent]
+    candidates.extend(candidates[0].parents)
+    for candidate in candidates:
+        try:
+            out = subprocess.check_output(
+                ["git", "-C", str(candidate), "rev-parse", "--show-toplevel"],
+                stderr=subprocess.DEVNULL,
+                text=True,
+            ).strip()
+        except Exception:
+            continue
+        if out:
+            return out
+    return ""
+
+
+def git_branch(repo):
+    if not repo:
+        return ""
+    try:
+        return subprocess.check_output(
+            ["git", "-C", repo, "branch", "--show-current"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except Exception:
+        return ""
+
+
+tool_input = load_tool_input(os.environ.get("_HOOK_INPUT", ""))
+command = tool_input.get("command", "")
+if not isinstance(command, str):
+    command = ""
+
+text_fields = [command]
+for key in ("prompt", "description", "message", "task", "instructions"):
+    value = tool_input.get(key)
+    if isinstance(value, str):
+        text_fields.append(value)
+text = "\n".join(text_fields)
+
+branch = ""
+for key in ("branch", "head_branch", "head", "target_branch", "review_branch"):
+    value = tool_input.get(key)
+    if isinstance(value, str) and value.strip():
+        branch = value.strip().split(":", 1)[-1]
+        break
+
+if not branch:
+    patterns = [
+        r"(?:^|[\s,;])--head(?:=|\s+)([A-Za-z0-9._/-]+)",
+        r"(?:^|[\s,;])(?:branch|head|review_branch|target_branch)\s*[:=]\s*`?([A-Za-z0-9._/-]+)`?",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, text)
+        if match:
+            branch = match.group(1).split(":", 1)[-1]
+            break
+
+repo = ""
+for key in (
+    "cwd",
+    "worktree",
+    "worktree_path",
+    "repo_path",
+    "repository_path",
+    "project_path",
+    "working_directory",
+):
+    value = tool_input.get(key)
+    if isinstance(value, str):
+        repo = git_root(value)
+        if repo:
+            break
+
+if not repo:
+    for raw_path in re.findall(r"/[^\s'\"`<>),]+", text):
+        repo = git_root(raw_path.rstrip(".,:;]})"))
+        if repo:
+            break
+
+if not repo:
+    repo = git_root(os.getcwd())
+
+if not branch:
+    branch = git_branch(repo)
+
+print(json.dumps({"repo": repo, "branch": branch, "command": command}))
+PY
+}
+
 # --- Hook mode: PostToolUse Bash (no arguments) ---
 # When registered as PostToolUse hook, stdin contains tool invocation JSON.
 # Detect codex exec review commands and auto-record completion.
 if [[ $# -eq 0 ]]; then
-  INPUT=$(cat)
-  COMMAND=$(echo "$INPUT" | python3 -c "
-import json,sys
-d=json.load(sys.stdin)
-ti=d.get('tool_input',{})
-if isinstance(ti,str):
-    try: ti=json.loads(ti)
-    except (json.JSONDecodeError, ValueError, TypeError): ti={}
-print(ti.get('command',''))
-" 2>/dev/null || echo "")
+  INPUT=$(cat 2>/dev/null || echo "")
+  CONTEXT_JSON=$(resolve_review_context)
+  COMMAND=$(echo "$CONTEXT_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin).get('command',''))" 2>/dev/null || echo "")
 
   # Only trigger on codex review commands
   echo "$COMMAND" | grep -qE 'codex\s+exec.*review|codex-parallel\.sh\s+--review' || exit 0
 
-  # Extract branch and repo path from git
-  BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+  BRANCH=$(echo "$CONTEXT_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin).get('branch',''))" 2>/dev/null || echo "")
   [[ -z "$BRANCH" ]] && exit 0
-  REPO_PATH=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+  REPO_PATH=$(echo "$CONTEXT_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin).get('repo',''))" 2>/dev/null || echo "")
 
   # In hook mode, severity is not available from command output
   # Record codex_review_ran=true with pass=true (no severity data)
@@ -76,24 +192,24 @@ with open(f_path, 'r+') as f:
   GLOBAL_STATE="$HOME/.claude/state/review-status.json"
   write_codex_review_hook "$GLOBAL_STATE"
 
-  PROJECT_STATE_DIR=""
+  PROJECT_STATE_DIRS=()
   if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
-    PROJECT_STATE_DIR="${CLAUDE_PROJECT_DIR}/.claude/state"
-  elif [[ -d "$REPO_PATH/.git" ]] || [[ -f "$REPO_PATH/.git" ]]; then
-    PROJECT_STATE_DIR="$REPO_PATH/.claude/state"
+    PROJECT_STATE_DIRS+=("${CLAUDE_PROJECT_DIR}/.claude/state")
   fi
-  if [[ -n "$PROJECT_STATE_DIR" ]] && [[ "$PROJECT_STATE_DIR" != "$HOME/.claude/state" ]]; then
+  if [[ -n "$REPO_PATH" ]]; then
+    PROJECT_STATE_DIRS+=("$REPO_PATH/.claude/state")
+  elif git rev-parse --show-toplevel &>/dev/null; then
+    PROJECT_STATE_DIRS+=("$(git rev-parse --show-toplevel)/.claude/state")
+  fi
+
+  for PROJECT_STATE_DIR in "${PROJECT_STATE_DIRS[@]}"; do
+    [[ -z "$PROJECT_STATE_DIR" ]] && continue
+    [[ "$PROJECT_STATE_DIR" == "$HOME/.claude/state" ]] && continue
     write_codex_review_hook "$PROJECT_STATE_DIR/review-status.json"
-  fi
+  done
 
   echo "✅ [review-gate] Codex CLI レビュー完了を自動記録: branch=$BRANCH (hook mode)" >&2
   exit 0
-fi
-
-if ! command -v python3 &>/dev/null; then
-  echo "[WARN] python3 が見つかりません。Codexレビュー記録をスキップできないため fail-closed します。" >&2
-  echo "  python3 をインストールしてください。" >&2
-  exit 2
 fi
 
 BRANCH="${1:?branch required}"

--- a/tests/test-record-codex-review-worktree-context.sh
+++ b/tests/test-record-codex-review-worktree-context.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# test-record-codex-review-worktree-context.sh -- Codex reviews use tool worktree context
+set -euo pipefail
+
+PASS=0
+FAIL=0
+TOTAL=0
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { PASS=$((PASS+1)); TOTAL=$((TOTAL+1)); echo -e "${GREEN}  PASS${NC} $1"; }
+fail() { FAIL=$((FAIL+1)); TOTAL=$((TOTAL+1)); echo -e "${RED}  FAIL${NC} $1"; }
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$ROOT/hooks/record-codex-review.sh"
+TMP_DIR=""
+
+cleanup() {
+  if [[ -n "$TMP_DIR" ]]; then
+    git -C "$TMP_DIR/repo" worktree remove --force "$TMP_DIR/worktree" >/dev/null 2>&1 || true
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+state_has_codex_review() {
+  local state_file="$1"
+  local branch="$2"
+  python3 - "$state_file" "$branch" <<'PY'
+import json, sys
+path, branch = sys.argv[1:]
+with open(path) as f:
+    data = json.load(f)
+entry = data.get(branch, {})
+assert entry.get("codex_review_ran") is True
+assert entry.get("codex_review") is True
+PY
+}
+
+echo "=== record-codex-review worktree context tests ==="
+
+if bash -n "$HOOK" 2>/dev/null; then
+  pass "T1: syntax check"
+else
+  fail "T1: syntax check failed"
+fi
+
+TMP_DIR="$(mktemp -d)"
+REPO="$TMP_DIR/repo"
+WT="$TMP_DIR/worktree"
+HOME_DIR="$TMP_DIR/home"
+PROJECT_DIR="$TMP_DIR/project"
+mkdir -p "$HOME_DIR/.claude/state" "$PROJECT_DIR/.claude/state"
+
+git init "$REPO" >/dev/null
+git -C "$REPO" config user.email "test@example.com"
+git -C "$REPO" config user.name "Test User"
+git -C "$REPO" checkout -b develop >/dev/null
+printf 'base\n' > "$REPO/base.txt"
+git -C "$REPO" add base.txt
+git -C "$REPO" commit -m "base" >/dev/null
+
+git -C "$REPO" checkout -b opencode/investigation-spikes >/dev/null
+printf 'wrong branch\n' > "$REPO/wrong.txt"
+git -C "$REPO" add wrong.txt
+git -C "$REPO" commit -m "wrong branch" >/dev/null
+
+git -C "$REPO" worktree add -b feat/governance-policy-gate "$WT" develop >/dev/null
+
+payload=$(python3 - <<PY
+import json
+print(json.dumps({
+    "tool_name": "Bash",
+    "tool_input": {
+        "command": "codex exec review --base develop",
+        "cwd": "$WT",
+    },
+}))
+PY
+)
+
+out=""
+ec=0
+out=$(cd "$REPO" && HOME="$HOME_DIR" CLAUDE_PROJECT_DIR="$PROJECT_DIR" bash "$HOOK" <<<"$payload" 2>&1) || ec=$?
+if [[ "$ec" -eq 0 ]]; then
+  pass "T2: hook exits 0 from wrong parent branch"
+else
+  fail "T2: hook failed (exit $ec: $out)"
+fi
+
+if state_has_codex_review "$HOME_DIR/.claude/state/review-status.json" "feat/governance-policy-gate"; then
+  pass "T3: global state uses reviewed worktree branch"
+else
+  fail "T3: global state missing feat/governance-policy-gate"
+fi
+
+if state_has_codex_review "$PROJECT_DIR/.claude/state/review-status.json" "feat/governance-policy-gate"; then
+  pass "T4: CLAUDE_PROJECT_DIR state uses reviewed worktree branch"
+else
+  fail "T4: project state missing feat/governance-policy-gate"
+fi
+
+if state_has_codex_review "$WT/.claude/state/review-status.json" "feat/governance-policy-gate"; then
+  pass "T5: worktree-local state uses reviewed branch"
+else
+  fail "T5: worktree-local state missing feat/governance-policy-gate"
+fi
+
+if python3 - "$HOME_DIR/.claude/state/review-status.json" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+assert not data.get("opencode/investigation-spikes", {}).get("codex_review_ran")
+PY
+then
+  pass "T6: parent CWD branch was not marked reviewed"
+else
+  fail "T6: parent CWD branch was incorrectly marked reviewed"
+fi
+
+payload=$(python3 - <<PY
+import json
+print(json.dumps({
+    "tool_name": "Bash",
+    "tool_input": {
+        "command": "codex exec review --base develop",
+        "branch": "feat/governance-policy-gate",
+    },
+}))
+PY
+)
+rm -f "$HOME_DIR/.claude/state/review-status.json"
+out=$(cd "$REPO" && HOME="$HOME_DIR" bash "$HOOK" <<<"$payload" 2>&1) || ec=$?
+if state_has_codex_review "$HOME_DIR/.claude/state/review-status.json" "feat/governance-policy-gate"; then
+  pass "T7: explicit tool_input.branch overrides parent CWD branch"
+else
+  fail "T7: explicit branch resolution failed"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed (total $TOTAL)"
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Fixes Cor-Incorporated/persona-village-v2#148.

- Aligns `record-codex-review.sh` hook-mode context resolution with `record-code-review.sh`.
- Reads `tool_input.cwd` / `worktree` / `branch` before falling back to the hook CWD.
- Dual-writes to global state, `CLAUDE_PROJECT_DIR`, and the resolved worktree-local `.claude/state`.
- Adds a regression test proving a parent CWD branch is not marked when the reviewed worktree branch is supplied by payload.

## Verification

- `bash tests/test-record-codex-review-worktree-context.sh` -> 7 passed
- `bash tests/test-issue-207.sh` -> 7 passed
- `bash tests/test-record-code-review-worktree-context.sh` -> 7 passed
- `git diff --check` -> clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * Codex review 状態記録機能のテストを追加し、worktree コンテキストでの動作検証を強化しました。

* **Chores**
  * コードレビュー状態管理の処理を最適化し、エラーハンドリングを改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terisuke/claude-code-skills/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->