### PR TITLE
fix: レビューゲート過剰の是正 + Codex sandbox 見直し

### DIFF
--- a/hooks/block-manual-merge-ops.sh
+++ b/hooks/block-manual-merge-ops.sh
@@ -16,6 +16,18 @@ set -euo pipefail
 
 input=$(cat)
 cmd=$(echo "$input" | jq -r '.tool_input.command // ""')
+
+# Skip ONLY a single read-only inspection command that merely MENTIONS the operation
+# (e.g. grep "gh pr create" ...). Requires a single-line command with NO shell operator,
+# so a real operation cannot be chained after a benign first token (prevents
+# `echo x && git push --force` style bypass). Executor tools excluded.
+if [[ -n "$cmd" ]] \
+   && [[ "$cmd" != *$'\n'* ]] \
+   && ! printf '%s' "$cmd" | grep -qE '[;&|`<>]|\$\(' \
+   && printf '%s' "$cmd" | grep -qE '^[[:space:]]*(grep|egrep|fgrep|cat|head|tail|wc|comm|diff|cut|tr|uniq|jq|ls|which|type|echo|printf)\b'; then
+  exit 0
+fi
+
 CMD_FIRST=$(echo "$cmd" | head -1)
 
 # --- State file for rebase session tracking ---

--- a/hooks/block-merge-without-ci.sh
+++ b/hooks/block-merge-without-ci.sh
@@ -14,6 +14,18 @@ fi
 
 input=$(cat)
 cmd=$(echo "$input" | jq -r '.tool_input.command // ""')
+
+# Skip ONLY a single read-only inspection command that merely MENTIONS the operation
+# (e.g. grep "gh pr create" ...). Requires a single-line command with NO shell operator,
+# so a real operation cannot be chained after a benign first token (prevents
+# `echo x && git push --force` style bypass). Executor tools excluded.
+if [[ -n "$cmd" ]] \
+   && [[ "$cmd" != *$'\n'* ]] \
+   && ! printf '%s' "$cmd" | grep -qE '[;&|`<>]|\$\(' \
+   && printf '%s' "$cmd" | grep -qE '^[[:space:]]*(grep|egrep|fgrep|cat|head|tail|wc|comm|diff|cut|tr|uniq|jq|ls|which|type|echo|printf)\b'; then
+  exit 0
+fi
+
 cmd_first_line=$(echo "$cmd" | head -1)
 
 # Only trigger for merge commands

--- a/hooks/block-merge-without-review.sh
+++ b/hooks/block-merge-without-review.sh
@@ -22,8 +22,19 @@ mkdir -p "$_STATE_BASE"
 input=$(cat)
 cmd=$(echo "$input" | jq -r '.tool_input.command // ""')
 
+# Skip ONLY a single read-only inspection command that merely MENTIONS the operation
+# (e.g. grep "gh pr create" ...). Requires a single-line command with NO shell operator,
+# so a real operation cannot be chained after a benign first token (prevents
+# `echo x && git push --force` style bypass). Executor tools excluded.
+if [[ -n "$cmd" ]] \
+   && [[ "$cmd" != *$'\n'* ]] \
+   && ! printf '%s' "$cmd" | grep -qE '[;&|`<>]|\$\(' \
+   && printf '%s' "$cmd" | grep -qE '^[[:space:]]*(grep|egrep|fgrep|cat|head|tail|wc|comm|diff|cut|tr|uniq|jq|ls|which|type|echo|printf)\b'; then
+  exit 0
+fi
+
 cmd_first_line=$(echo "$cmd" | head -1)
-if ! echo "$cmd_first_line" | grep -q 'gh.*pr.*merge'; then
+if ! echo "$cmd_first_line" | grep -qE 'gh[[:space:]]+pr[[:space:]]+merge\b'; then
     exit 0
 fi
 
@@ -44,41 +55,28 @@ fi
 # Get PR branch for tier classification
 PR_BRANCH=$(gh api "repos/${REPO}/pulls/${PR_NUM}" --jq '.head.ref' 2>/dev/null || echo "")
 HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR_NUM}" --jq '.head.sha' 2>/dev/null || echo "")
-TIER="FULL"
-case "$PR_BRANCH" in
-    docs/*|chore/*|ci/*) TIER="EXEMPT" ;;
-    *)
-        # Use remote URL for defense-in-depth (aligned with classify_review_tier)
-        ;;
-esac
+# Content-based tier (Fix B): a docs/config-only PR on a feat/*/fix/* branch must
+# resolve LIGHT, not FULL. classify_review_tier inspects the actual changed files
+# via the GitHub API (REPO already resolved above) and only escalates to FULL when
+# a non-low-risk (source) file changed. Branch-prefix EXEMPT is handled inside it.
+TIER=$(classify_review_tier "$PR_BRANCH" "$PR_NUM")
 
 # --- EXEMPT/LIGHT tier: skip pessimistic lock ---
 # LIGHT tier (hook infrastructure) doesn't need pessimistic lock.
 # Safety is enforced by CRITICAL/HIGH/BUG grep check below.
 # Only FULL tier (source code changes) requires pessimistic lock.
 if [[ "$TIER" == "FULL" ]]; then
-    # --- Pessimistic Lock Check (non-EXEMPT only) ---
-    REVIEW_LOCK="$_STATE_BASE/pr-review-lock.json"
-    if [ -f "$REVIEW_LOCK" ]; then
-        LOCK_STATUS=$(_REVIEW_LOCK="$REVIEW_LOCK" _PR="$PR_NUM" python3 -c "
-import json, os
-with open(os.environ['_REVIEW_LOCK']) as f:
-    s = json.load(f)
-pr = s.get(os.environ['_PR'], {})
-if not pr.get('verified', False):
-    print('LOCKED')
-else:
-    print('OK')
-" 2>/dev/null || echo "OK")
-
-        if [ "$LOCK_STATUS" = "LOCKED" ]; then
-            echo "🔒 [Pessimistic Lock] PR #${PR_NUM} は review_pending 状態です。マージ不可。" >&2
-            echo "" >&2
-            echo "push後のclaude-review 3ソース全確認が未完了です。" >&2
-            echo "解除: bash ~/.claude/scripts/verify-pr-review.sh ${PR_NUM}" >&2
-            echo "または /review-loop ${PR_NUM} で自動検証" >&2
-            exit 2
-        fi
+    # --- Pessimistic Lock Check (non-EXEMPT only) — Fix8 dual-location ---
+    # Read BOTH project-scoped AND global lock files (OR-logic via common.sh).
+    # Treat as verified if EITHER file has verified=true; locked only if a lock
+    # entry exists somewhere and NO file has verified=true.
+    if [[ "$(lock_pr_locked "$PR_NUM")" == "yes" ]]; then
+        echo "🔒 [Pessimistic Lock] PR #${PR_NUM} は review_pending 状態です。マージ不可。" >&2
+        echo "" >&2
+        echo "push後のclaude-review 3ソース全確認が未完了です。" >&2
+        echo "解除: bash ~/.claude/scripts/verify-pr-review.sh ${PR_NUM}" >&2
+        echo "または /review-loop ${PR_NUM} で自動検証" >&2
+        exit 2
     fi
 fi
 

--- a/hooks/block-subagent-github-write.sh
+++ b/hooks/block-subagent-github-write.sh
@@ -26,6 +26,17 @@ tool_name=$(echo "$input" | jq -r '.tool_name // ""' 2>/dev/null || echo "")
 cmd=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 [[ -z "$cmd" ]] && exit 0
 
+# Skip ONLY a single read-only inspection command that merely MENTIONS the operation
+# (e.g. grep "gh pr create" ...). Requires a single-line command with NO shell operator,
+# so a real operation cannot be chained after a benign first token (prevents
+# `echo x && git push --force` style bypass). Executor tools excluded.
+if [[ -n "$cmd" ]] \
+   && [[ "$cmd" != *$'\n'* ]] \
+   && ! printf '%s' "$cmd" | grep -qE '[;&|`<>]|\$\(' \
+   && printf '%s' "$cmd" | grep -qE '^[[:space:]]*(grep|egrep|fgrep|cat|head|tail|wc|comm|diff|cut|tr|uniq|jq|ls|which|type|echo|printf)\b'; then
+  exit 0
+fi
+
 first_line=$(echo "$cmd" | head -1 | xargs 2>/dev/null || echo "$cmd")
 
 if ! echo "$first_line" | grep -qE '^(git\s+push\b|gh\s+pr\s+(create|merge|ready|edit)\b|gh\s+issue\s+(create|comment|edit|close)\b)'; then

--- a/hooks/context-budget-agent-gate.sh
+++ b/hooks/context-budget-agent-gate.sh
@@ -21,10 +21,25 @@
 
 set -euo pipefail
 
-# --- Subagent exemption ---
-if [[ "${CLAUDE_AGENT_DEPTH:-0}" -ge 1 ]] || [[ -n "${CLAUDE_AGENT_ID:-}" ]]; then
-  exit 0
+# --- Capture stdin (hook input JSON) EARLY so the subagent exemption can read agent_id ---
+INPUT_JSON=""
+if [[ ! -t 0 ]]; then
+  INPUT_JSON=$(cat)
 fi
+
+# --- Subagent exemption ---
+# Subagents ARE the delegated work and must not be blocked. CLAUDE_AGENT_DEPTH may
+# NOT propagate to the hook subprocess, so we ALSO honor the stdin JSON .agent_id
+# field (official Claude Code hook spec). Mirrors git-commit-guard.sh.
+_is_subagent="false"
+if [[ "${CLAUDE_AGENT_DEPTH:-0}" -ge 1 ]] || [[ -n "${CLAUDE_AGENT_ID:-}" ]]; then
+  _is_subagent="true"
+fi
+if command -v jq &>/dev/null && [[ -n "${INPUT_JSON:-}" ]]; then
+  _aid=$(printf '%s' "$INPUT_JSON" | jq -r '.agent_id // ""' 2>/dev/null || echo "")
+  [[ -n "$_aid" ]] && _is_subagent="true"
+fi
+[[ "$_is_subagent" == "true" ]] && exit 0
 
 STATE_DIR="$HOME/.claude/state"
 STATE_FILE="$STATE_DIR/context-budget.json"
@@ -60,10 +75,7 @@ if [[ "$MODE" == "planning" ]] || [[ "$MODE" == "research" ]]; then
   exit 0
 fi
 
-INPUT_JSON=""
-if [[ ! -t 0 ]]; then
-  INPUT_JSON=$(cat)
-fi
+# (stdin already captured into $INPUT_JSON at the top of this script)
 
 NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 

--- a/hooks/context-budget-edit-write-gate.sh
+++ b/hooks/context-budget-edit-write-gate.sh
@@ -22,16 +22,25 @@
 
 set -euo pipefail
 
-# --- Subagent exemption ---
-if [[ "${CLAUDE_AGENT_DEPTH:-0}" -ge 1 ]] || [[ -n "${CLAUDE_AGENT_ID:-}" ]]; then
-  exit 0
-fi
-
 # --- Read stdin (hook input JSON) ---
 INPUT_JSON=""
 if [[ ! -t 0 ]]; then
   INPUT_JSON=$(cat)
 fi
+
+# --- Subagent exemption ---
+# Subagents ARE the delegated work and must not be blocked. CLAUDE_AGENT_DEPTH may
+# NOT propagate to the hook subprocess, so we ALSO honor the stdin JSON .agent_id
+# field (official Claude Code hook spec). Mirrors git-commit-guard.sh.
+_is_subagent="false"
+if [[ "${CLAUDE_AGENT_DEPTH:-0}" -ge 1 ]] || [[ -n "${CLAUDE_AGENT_ID:-}" ]]; then
+  _is_subagent="true"
+fi
+if command -v jq &>/dev/null && [[ -n "${INPUT_JSON:-}" ]]; then
+  _aid=$(printf '%s' "$INPUT_JSON" | jq -r '.agent_id // ""' 2>/dev/null || echo "")
+  [[ -n "$_aid" ]] && _is_subagent="true"
+fi
+[[ "$_is_subagent" == "true" ]] && exit 0
 
 if [[ -z "$INPUT_JSON" ]]; then
   exit 0

--- a/hooks/context-budget-read-gate.sh
+++ b/hooks/context-budget-read-gate.sh
@@ -18,12 +18,26 @@
 
 set -euo pipefail
 
-# --- Subagent exemption ---
-# Agent tool spawns subprocesses with depth tracking.
-# Subagents should NOT be warned to delegate to Codex — they ARE the delegated work.
-if [[ "${CLAUDE_AGENT_DEPTH:-0}" -ge 1 ]] || [[ -n "${CLAUDE_AGENT_ID:-}" ]]; then
-  exit 0
+# --- Capture stdin (hook input JSON) EARLY so the subagent exemption can read agent_id ---
+input=""
+if [[ ! -t 0 ]]; then
+  input=$(cat)
 fi
+
+# --- Subagent exemption ---
+# Agent tool spawns subprocesses; subagents ARE the delegated work and must not be
+# warned/blocked. CLAUDE_AGENT_DEPTH may NOT propagate to the hook subprocess, so we
+# ALSO honor the stdin JSON .agent_id field (official Claude Code hook spec).
+# Mirrors git-commit-guard.sh.
+_is_subagent="false"
+if [[ "${CLAUDE_AGENT_DEPTH:-0}" -ge 1 ]] || [[ -n "${CLAUDE_AGENT_ID:-}" ]]; then
+  _is_subagent="true"
+fi
+if command -v jq &>/dev/null && [[ -n "${input:-}" ]]; then
+  _aid=$(printf '%s' "$input" | jq -r '.agent_id // ""' 2>/dev/null || echo "")
+  [[ -n "$_aid" ]] && _is_subagent="true"
+fi
+[[ "$_is_subagent" == "true" ]] && exit 0
 
 STATE_DIR="$HOME/.claude/state"
 STATE_FILE="$STATE_DIR/context-budget.json"
@@ -58,11 +72,8 @@ if [[ "$MODE" == "planning" ]] || [[ "$MODE" == "research" ]]; then
   exit 0
 fi
 
-# Get the file being read from tool_input (passed via stdin in hook context)
-INPUT_JSON=""
-if [[ ! -t 0 ]]; then
-  INPUT_JSON=$(cat)
-fi
+# Get the file being read from tool_input (stdin already captured into $input above)
+INPUT_JSON="$input"
 
 FILE_PATH=""
 if [[ -n "$INPUT_JSON" ]]; then

--- a/hooks/context-budget-write-gate.sh
+++ b/hooks/context-budget-write-gate.sh
@@ -16,10 +16,25 @@
 
 set -euo pipefail
 
-# --- Subagent exemption ---
-if [[ "${CLAUDE_AGENT_DEPTH:-0}" -ge 1 ]] || [[ -n "${CLAUDE_AGENT_ID:-}" ]]; then
-  exit 0
+# --- Capture stdin (hook input JSON) EARLY so the subagent exemption can read agent_id ---
+INPUT_JSON=""
+if [[ ! -t 0 ]]; then
+  INPUT_JSON=$(cat)
 fi
+
+# --- Subagent exemption ---
+# Subagents ARE the delegated work and must not be blocked. CLAUDE_AGENT_DEPTH may
+# NOT propagate to the hook subprocess, so we ALSO honor the stdin JSON .agent_id
+# field (official Claude Code hook spec). Mirrors git-commit-guard.sh.
+_is_subagent="false"
+if [[ "${CLAUDE_AGENT_DEPTH:-0}" -ge 1 ]] || [[ -n "${CLAUDE_AGENT_ID:-}" ]]; then
+  _is_subagent="true"
+fi
+if command -v jq &>/dev/null && [[ -n "${INPUT_JSON:-}" ]]; then
+  _aid=$(printf '%s' "$INPUT_JSON" | jq -r '.agent_id // ""' 2>/dev/null || echo "")
+  [[ -n "$_aid" ]] && _is_subagent="true"
+fi
+[[ "$_is_subagent" == "true" ]] && exit 0
 
 STATE_DIR="$HOME/.claude/state"
 STATE_FILE="$STATE_DIR/context-budget.json"
@@ -42,10 +57,7 @@ if [[ ! -f "$STATE_FILE" ]]; then
 EOF
 fi
 
-INPUT_JSON=""
-if [[ ! -t 0 ]]; then
-  INPUT_JSON=$(cat)
-fi
+# (stdin already captured into $INPUT_JSON at the top of this script)
 
 FILE_PATH=""
 TRANSCRIPT_PATH=""

--- a/hooks/enforce-deploy-verify-on-pr.sh
+++ b/hooks/enforce-deploy-verify-on-pr.sh
@@ -66,6 +66,18 @@ TOOL_NAME=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.std
 [[ "$TOOL_NAME" == "Bash" ]] || exit 0
 
 COMMAND=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null || echo "")
+
+# Skip ONLY a single read-only inspection command that merely MENTIONS the operation
+# (e.g. grep "gh pr create" ...). Requires a single-line command with NO shell operator,
+# so a real operation cannot be chained after a benign first token (prevents
+# `echo x && git push --force` style bypass). Executor tools excluded.
+if [[ -n "$COMMAND" ]] \
+   && [[ "$COMMAND" != *$'\n'* ]] \
+   && ! printf '%s' "$COMMAND" | grep -qE '[;&|`<>]|\$\(' \
+   && printf '%s' "$COMMAND" | grep -qE '^[[:space:]]*(grep|egrep|fgrep|cat|head|tail|wc|comm|diff|cut|tr|uniq|jq|ls|which|type|echo|printf)\b'; then
+  exit 0
+fi
+
 echo "$COMMAND" | grep -qE '\bgh\s+pr\s+create\b' || exit 0
 
 _cmd_context=$(command_git_context_dir "$COMMAND")

--- a/hooks/enforce-develop-base.sh
+++ b/hooks/enforce-develop-base.sh
@@ -28,6 +28,17 @@ input=""
 cmd=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 [[ -z "$cmd" ]] && exit 0
 
+# Skip ONLY a single read-only inspection command that merely MENTIONS the operation
+# (e.g. grep "gh pr create" ...). Requires a single-line command with NO shell operator,
+# so a real operation cannot be chained after a benign first token (prevents
+# `echo x && git push --force` style bypass). Executor tools excluded.
+if [[ -n "$cmd" ]] \
+   && [[ "$cmd" != *$'\n'* ]] \
+   && ! printf '%s' "$cmd" | grep -qE '[;&|`<>]|\$\(' \
+   && printf '%s' "$cmd" | grep -qE '^[[:space:]]*(grep|egrep|fgrep|cat|head|tail|wc|comm|diff|cut|tr|uniq|jq|ls|which|type|echo|printf)\b'; then
+  exit 0
+fi
+
 # Check if develop branch exists (local or remote)
 has_develop="no"
 git rev-parse --verify develop >/dev/null 2>&1 && has_develop="yes"

--- a/hooks/enforce-factcheck-github-ops.sh
+++ b/hooks/enforce-factcheck-github-ops.sh
@@ -31,6 +31,17 @@ fi
 input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 
+# Skip ONLY a single read-only inspection command that merely MENTIONS the operation
+# (e.g. grep "gh pr create" ...). Requires a single-line command with NO shell operator,
+# so a real operation cannot be chained after a benign first token (prevents
+# `echo x && git push --force` style bypass). Executor tools excluded.
+if [[ -n "$command" ]] \
+   && [[ "$command" != *$'\n'* ]] \
+   && ! printf '%s' "$command" | grep -qE '[;&|`<>]|\$\(' \
+   && printf '%s' "$command" | grep -qE '^[[:space:]]*(grep|egrep|fgrep|cat|head|tail|wc|comm|diff|cut|tr|uniq|jq|ls|which|type|echo|printf)\b'; then
+  exit 0
+fi
+
 # Extract first command from chain (before &&, ||, ;, |)
 # This prevents bypass via "gh issue create && gh issue view"
 first_cmd=$(echo "$command" | sed 's/[&|;].*//' | xargs 2>/dev/null || echo "$command")

--- a/hooks/enforce-follow-up-limit.sh
+++ b/hooks/enforce-follow-up-limit.sh
@@ -16,6 +16,17 @@ set -euo pipefail
 input=$(cat)
 cmd=$(echo "$input" | jq -r '.tool_input.command // ""')
 
+# Skip ONLY a single read-only inspection command that merely MENTIONS the operation
+# (e.g. grep "gh pr create" ...). Requires a single-line command with NO shell operator,
+# so a real operation cannot be chained after a benign first token (prevents
+# `echo x && git push --force` style bypass). Executor tools excluded.
+if [[ -n "$cmd" ]] \
+   && [[ "$cmd" != *$'\n'* ]] \
+   && ! printf '%s' "$cmd" | grep -qE '[;&|`<>]|\$\(' \
+   && printf '%s' "$cmd" | grep -qE '^[[:space:]]*(grep|egrep|fgrep|cat|head|tail|wc|comm|diff|cut|tr|uniq|jq|ls|which|type|echo|printf)\b'; then
+  exit 0
+fi
+
 # Only act on gh pr create commands
 cmd_first=$(echo "$cmd" | head -1)
 if ! echo "$cmd_first" | grep -qE 'gh\s+pr\s+create\b'; then

--- a/hooks/enforce-review-reading.sh
+++ b/hooks/enforce-review-reading.sh
@@ -24,6 +24,17 @@ input=""
 [[ ! -t 0 ]] && input=$(cat)
 cmd=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 
+# Skip ONLY a single read-only inspection command that merely MENTIONS the operation
+# (e.g. grep "gh pr create" ...). Requires a single-line command with NO shell operator,
+# so a real operation cannot be chained after a benign first token (prevents
+# `echo x && git push --force` style bypass). Executor tools excluded.
+if [[ -n "$cmd" ]] \
+   && [[ "$cmd" != *$'\n'* ]] \
+   && ! printf '%s' "$cmd" | grep -qE '[;&|`<>]|\$\(' \
+   && printf '%s' "$cmd" | grep -qE '^[[:space:]]*(grep|egrep|fgrep|cat|head|tail|wc|comm|diff|cut|tr|uniq|jq|ls|which|type|echo|printf)\b'; then
+  exit 0
+fi
+
 # Read pending state
 REVIEW_DATA=$(_PENDING_FILE="$PENDING_FILE" python3 -c "
 import json, os

--- a/hooks/enforce-soak-time.sh
+++ b/hooks/enforce-soak-time.sh
@@ -26,6 +26,17 @@ fi
 input=$(cat)
 cmd=$(echo "$input" | jq -r '.tool_input.command // ""')
 
+# Skip ONLY a single read-only inspection command that merely MENTIONS the operation
+# (e.g. grep "gh pr create" ...). Requires a single-line command with NO shell operator,
+# so a real operation cannot be chained after a benign first token (prevents
+# `echo x && git push --force` style bypass). Executor tools excluded.
+if [[ -n "$cmd" ]] \
+   && [[ "$cmd" != *$'\n'* ]] \
+   && ! printf '%s' "$cmd" | grep -qE '[;&|`<>]|\$\(' \
+   && printf '%s' "$cmd" | grep -qE '^[[:space:]]*(grep|egrep|fgrep|cat|head|tail|wc|comm|diff|cut|tr|uniq|jq|ls|which|type|echo|printf)\b'; then
+  exit 0
+fi
+
 # Only act on gh pr merge commands
 cmd_first=$(echo "$cmd" | head -1)
 if ! echo "$cmd_first" | grep -qE 'gh\s+pr\s+merge\b'; then

--- a/hooks/gate-modes/cleanup.sh
+++ b/hooks/gate-modes/cleanup.sh
@@ -18,32 +18,49 @@ if [[ -z "$REPO" ]]; then
   exit 1
 fi
 
-CLEANED=$(_LOCK="$LOCK_STATE" _REVIEW="$REVIEW_STATE" _REPO="$REPO" python3 -c "
+# Fix8: clean the lock entry from BOTH project-scoped AND global lock files.
+# Pass a newline-separated, deduped list so a merged PR is purged everywhere.
+LOCK_PATHS=$(lock_files)
+
+CLEANED=$(_LOCK_PATHS="$LOCK_PATHS" _REVIEW="$REVIEW_STATE" _REPO="$REPO" python3 -c "
 import json, subprocess, os, fcntl
 
-lock_path = os.environ['_LOCK']
+lock_paths = [p for p in os.environ['_LOCK_PATHS'].splitlines() if p.strip()]
 review_path = os.environ['_REVIEW']
 repo = os.environ['_REPO']
 lock_cleaned = []
 review_cleaned = []
 
-# Clean lock state (with file lock)
-with open(lock_path, 'r+') as f:
-    fcntl.flock(f, fcntl.LOCK_EX)
-    lock = json.load(f)
-    for pr in list(lock.keys()):
+# Cache PR state lookups so we don't re-query the same PR across files
+_state_cache = {}
+def pr_state(pr):
+    if pr not in _state_cache:
         try:
             r = subprocess.run(['gh','api','repos/'+repo+'/pulls/'+pr,'--jq','.state'],
                 capture_output=True, text=True, timeout=10)
-            if r.stdout.strip() in ('closed','merged'):
+            _state_cache[pr] = r.stdout.strip()
+        except Exception:
+            _state_cache[pr] = ''
+    return _state_cache[pr]
+
+# Clean lock state in every location (with file lock)
+for lock_path in lock_paths:
+    if not os.path.exists(lock_path):
+        continue
+    with open(lock_path, 'r+') as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        try:
+            lock = json.load(f)
+        except Exception:
+            lock = {}
+        for pr in list(lock.keys()):
+            if pr_state(pr) in ('closed','merged'):
                 branch = lock[pr].get('branch', '?')
                 del lock[pr]
-                lock_cleaned.append(f'PR #{pr} ({branch})')
-        except Exception:
-            pass
-    f.seek(0); f.truncate()
-    json.dump(lock, f, indent=2)
-    fcntl.flock(f, fcntl.LOCK_UN)
+                lock_cleaned.append(f'PR #{pr} ({branch}) [{os.path.basename(os.path.dirname(lock_path))}]')
+        f.seek(0); f.truncate()
+        json.dump(lock, f, indent=2)
+        fcntl.flock(f, fcntl.LOCK_UN)
 
 # Clean review state (with file lock)
 with open(review_path, 'r+') as f:

--- a/hooks/gate-modes/common.sh
+++ b/hooks/gate-modes/common.sh
@@ -41,6 +41,118 @@ REVIEW_STATE="$STATE_DIR/review-status.json"
 LOCK_STATE="$STATE_DIR/pr-review-lock.json"
 mkdir -p "$STATE_DIR"
 
+# =========================================================================
+# Dual-location lock files — project-scoped AND global (Issue #19 / Fix8)
+# The pessimistic lock (pr-review-lock.json) was written and read from
+# INCONSISTENT directories: writers land in the repo-scoped state when run
+# inside a repo, but block-merge-without-review.sh (with CLAUDE_PROJECT_DIR
+# unset) reads $HOME/.claude/state — so clearing the lock never satisfied the
+# merge gate. Mirror the read_review() dual-location pattern: every lock
+# read/write must consider BOTH the project-scoped file AND the global one.
+# =========================================================================
+GLOBAL_STATE_DIR="$HOME/.claude/state"
+mkdir -p "$GLOBAL_STATE_DIR" 2>/dev/null || true
+
+# lock_files — echo the deduped list of lock file paths (project, then global)
+lock_files() {
+  echo "$LOCK_STATE"
+  if [[ "$GLOBAL_STATE_DIR/pr-review-lock.json" != "$LOCK_STATE" ]]; then
+    echo "$GLOBAL_STATE_DIR/pr-review-lock.json"
+  fi
+}
+
+# lock_pr_verified <pr> — "yes" if ANY lock file has verified=true for the PR
+lock_pr_verified() {
+  local pr="$1" lf
+  while IFS= read -r lf; do
+    [[ -z "$lf" || ! -f "$lf" ]] && continue
+    local val
+    val=$(_LOCK="$lf" _PR="$pr" python3 -c "
+import json, os
+try:
+    with open(os.environ['_LOCK']) as f:
+        s = json.load(f)
+    print('yes' if s.get(os.environ['_PR'], {}).get('verified', False) else 'no')
+except Exception:
+    print('no')
+" 2>/dev/null || echo "no")
+    [[ "$val" == "yes" ]] && { echo "yes"; return; }
+  done < <(lock_files)
+  echo "no"
+}
+
+# lock_pr_locked <pr> — "yes" if a lock entry exists in ANY file AND no file
+# has verified=true (i.e. still review_pending somewhere, verified nowhere).
+lock_pr_locked() {
+  local pr="$1"
+  [[ "$(lock_pr_verified "$pr")" == "yes" ]] && { echo "no"; return; }
+  local lf
+  while IFS= read -r lf; do
+    [[ -z "$lf" || ! -f "$lf" ]] && continue
+    local has
+    has=$(_LOCK="$lf" _PR="$pr" python3 -c "
+import json, os
+try:
+    with open(os.environ['_LOCK']) as f:
+        s = json.load(f)
+    print('yes' if os.environ['_PR'] in s else 'no')
+except Exception:
+    print('no')
+" 2>/dev/null || echo "no")
+    [[ "$has" == "yes" ]] && { echo "yes"; return; }
+  done < <(lock_files)
+  echo "no"
+}
+
+# lock_apply <pr> <python-mutator> — run the same python mutation against EVERY
+# lock file (dual-write). The mutator (passed via env, dedented + exec'd so its
+# indentation is independent of this heredoc) operates on the loaded dict `s`
+# with `PR` and `os` in scope; file lock + atomic rewrite handled here.
+# SECURITY: <python-mutator> MUST be a static literal. Never interpolate
+# shell variables into it (RCE risk via untrusted PR/branch data). Pass
+# dynamic values via env (e.g. _BR="$BRANCH" lock_apply ...) and read them
+# inside the mutator with os.environ[...].
+lock_apply() {
+  local pr="$1" mutator="$2" lf rc
+  # Fix C: do NOT swallow python failures. A silent failure here means a lock may
+  # never be SET (a review-required PR is left unlocked) or never CLEARED (VERIFY
+  # reports success but verified=true is never persisted). Capture the python exit
+  # status per file; on nonzero, warn to stderr identifying the lock + PR and mark
+  # the whole call failed so the caller can react. Callers that tolerate partial
+  # failure may ignore the return; happy path (rc 0) is unchanged.
+  local failed=0
+  while IFS= read -r lf; do
+    [[ -z "$lf" ]] && continue
+    mkdir -p "$(dirname "$lf")" 2>/dev/null || true
+    [[ ! -f "$lf" ]] && echo '{}' > "$lf"
+    _LOCK="$lf" _PR="$pr" _MUTATOR="$mutator" python3 -c "
+import json, os, fcntl, textwrap
+f_path = os.environ['_LOCK']
+PR = os.environ['_PR']
+mutator = textwrap.dedent(os.environ['_MUTATOR'])
+with open(f_path, 'r+') as f:
+    fcntl.flock(f, fcntl.LOCK_EX)
+    try:
+        s = json.load(f)
+    except Exception:
+        s = {}
+    _ns = {'s': s, 'PR': PR, 'os': os, 'json': json}
+    exec(mutator, _ns)
+    s = _ns['s']
+    f.seek(0); f.truncate()
+    json.dump(s, f, indent=2)
+    fcntl.flock(f, fcntl.LOCK_UN)
+"
+    rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+      echo "[lock_apply] WARNING: lock write FAILED (exit $rc) for PR #${pr} on '${lf}'." >&2
+      echo "[lock_apply]   Lock state may be inconsistent (not set/cleared). Investigate before merging." >&2
+      failed=1
+    fi
+  done < <(lock_files)
+  return "$failed"
+}
+
 # Fail-closed: python3 is required for state file operations
 if ! command -v python3 &>/dev/null; then
   echo "[pr-ci-review-gate] python3 not found. Blocking for safety." >&2
@@ -277,8 +389,11 @@ classify_review_tier() {
   fi
 
   if [[ -z "$changed_files" ]]; then
-    # Cannot determine changes — default to FULL for safety
-    echo "FULL"
+    # Detection failure (API timeout / run-from-develop / pre-push) must NOT
+    # escalate docs/small PRs to 2-reviewer FULL. Default to LIGHT (code-reviewer
+    # only, warn-only at create). Genuine source PRs classify FULL once files are
+    # detected at merge time (GitHub API reliable).
+    echo "LIGHT"
     return
   fi
 
@@ -316,6 +431,43 @@ classify_review_tier() {
   else
     echo "LIGHT"
   fi
+}
+
+# =========================================================================
+# Helper: low-risk (non-source) path test — mirrors classify_review_tier globs.
+# Returns 0 if the path is low-risk (docs/config), 1 if it is source code.
+# =========================================================================
+is_low_risk_path() {
+  case "$1" in
+    .github/*) return 0 ;;
+    Dockerfile|Dockerfile.*|.dockerignore|docker-compose*.yml|docker-compose*.yaml) return 0 ;;
+    *.md|docs/*|LICENSE|CHANGELOG*|CONTRIBUTING*) return 0 ;;
+    .claude/*|CLAUDE.md|.cursor/*|.vscode/*|.editorconfig) return 0 ;;
+    .eslintrc*|.prettierrc*|.stylelintrc*|biome.json|.biomeignore) return 0 ;;
+    .gitignore|.gitattributes) return 0 ;;
+    renovate.json|.renovaterc*) return 0 ;;
+    tsconfig*.json) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# =========================================================================
+# Helper: did any SOURCE file change between two git refs?
+# Returns 0 (true) if a non-low-risk file changed OR the diff cannot be computed
+# / baseline unknown (fail-closed); 1 (false) if only low-risk files changed.
+# =========================================================================
+source_changed_between() {
+  local from_ref="$1" to_ref="${2:-HEAD}"
+  [[ -z "$from_ref" ]] && return 0
+  local files
+  files=$(git_ctx diff --name-only "${from_ref}..${to_ref}" 2>/dev/null) || return 0
+  [[ -z "$files" ]] && return 1
+  local f
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    is_low_risk_path "$f" || return 0
+  done <<< "$files"
+  return 1
 }
 
 # =========================================================================

--- a/hooks/gate-modes/post-push.sh
+++ b/hooks/gate-modes/post-push.sh
@@ -11,6 +11,16 @@ GATE_MODES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${GATE_MODES_DIR}/common.sh"
 
 cmd=$(extract_cmd)
+# Skip ONLY a single read-only inspection command that merely MENTIONS the operation
+# (e.g. grep "gh pr create" ...). Requires a single-line command with NO shell operator,
+# so a real operation cannot be chained after a benign first token (prevents
+# `echo x && git push --force` style bypass). Executor tools excluded.
+if [[ -n "$cmd" ]] \
+   && [[ "$cmd" != *$'\n'* ]] \
+   && ! printf '%s' "$cmd" | grep -qE '[;&|`<>]|\$\(' \
+   && printf '%s' "$cmd" | grep -qE '^[[:space:]]*(grep|egrep|fgrep|cat|head|tail|wc|comm|diff|cut|tr|uniq|jq|ls|which|type|echo|printf)\b'; then
+  exit 0
+fi
 if [[ -n "$cmd" ]] && ! echo "$(echo "$cmd" | head -1)" | grep -qE 'git\s+push'; then
   exit 0
 fi
@@ -21,41 +31,60 @@ BRANCH=$(current_branch)
 PR_NUMBER=$(gh pr list --head "$BRANCH" --json number -q '.[0].number' 2>/dev/null || echo "")
 [ -z "$PR_NUMBER" ] && exit 0
 
-# Set pessimistic lock (safe: env vars, not string interpolation)
-_LOCK="$LOCK_STATE" _PR="$PR_NUMBER" _BR="$BRANCH" python3 -c "
-import json, os, fcntl
-f_path = os.environ['_LOCK']
-with open(f_path, 'r+') as f:
-    fcntl.flock(f, fcntl.LOCK_EX)
-    s = json.load(f)
-    s[os.environ['_PR']] = {
-        'status': 'review_pending',
-        'branch': os.environ['_BR'],
-        'ci_green': False,
-        'review_lgtm': False,
-        'verified': False,
-    }
-    f.seek(0); f.truncate()
-    json.dump(s, f, indent=2)
-    fcntl.flock(f, fcntl.LOCK_UN)
-" 2>/dev/null
+# Set pessimistic lock in BOTH project-scoped AND global state (Fix8).
+# A later reader (block-merge-without-review.sh) with no/other CLAUDE_PROJECT_DIR
+# resolves to $HOME/.claude/state, so the lock must exist there too.
+# Fix C: tolerate (but surface) a lock write failure. If the lock cannot be set,
+# lock_apply warns to stderr; `|| _lock_rc=$?` keeps set -e from aborting here so
+# the SHA-smart invalidation below still runs. A failed SET means a review-required
+# PR may be left UNLOCKED — the stderr warning is the operator's signal.
+_lock_rc=0
+_BR="$BRANCH" lock_apply "$PR_NUMBER" "
+s[PR] = {
+    'status': 'review_pending',
+    'branch': os.environ['_BR'],
+    'ci_green': False,
+    'review_lgtm': False,
+    'verified': False,
+}
+" || _lock_rc=$?
+if [[ "$_lock_rc" -ne 0 ]]; then
+  echo "[post-push] WARNING: PR #${PR_NUMBER} のロック設定に失敗しました（上記参照）。マージ前に手動確認してください。" >&2
+fi
 
-# Reset review status for this branch (push invalidates prior reviews)
-# Dual-reset: clear from BOTH project-scoped AND global state
-# to prevent stale code_review=true from satisfying gates (Codex P2 finding)
+# SHA-smart review invalidation (replaces the old unconditional reset).
+# A completed review stays valid across pushes UNLESS the push introduced SOURCE
+# changes since the reviewed commit. docs/config-only pushes keep the review
+# intact, eliminating needless re-review (the rework loop).
 GLOBAL_REVIEW="$HOME/.claude/state/review-status.json"
-review_was_set=false
+HEAD_SHA=$(git_ctx rev-parse HEAD 2>/dev/null || echo "")
+review_invalidated=false
+review_kept=false
 for _target in "$REVIEW_STATE" "$GLOBAL_REVIEW"; do
   [[ ! -f "$_target" ]] && continue
-  # Check if review was previously marked as complete before clearing
-  had_review=$(_STATE="$_target" _BR="$BRANCH" python3 -c "
+  _info=$(_STATE="$_target" _BR="$BRANCH" python3 -c "
 import json, os
-with open(os.environ['_STATE']) as f:
-    s = json.load(f)
+try:
+    with open(os.environ['_STATE']) as f:
+        s = json.load(f)
+except Exception:
+    print('false|'); raise SystemExit
 br = s.get(os.environ['_BR'], {})
-print('true' if br.get('code_review') or br.get('codex_review') else 'false')
-" 2>/dev/null || echo "false")
-  [[ "$had_review" == "true" ]] && review_was_set=true
+had = 'true' if (br.get('code_review') or br.get('codex_review')) else 'false'
+sha = br.get('code_review_sha') or br.get('codex_review_sha') or ''
+print(had + '|' + sha)
+" 2>/dev/null || echo "false|")
+  _had="${_info%%|*}"
+  _reviewed_sha="${_info#*|}"
+  [[ "$_had" != "true" ]] && continue
+
+  # Keep the review if NO source file changed since the reviewed commit.
+  if [[ -n "$_reviewed_sha" ]] && [[ -n "$HEAD_SHA" ]] && ! source_changed_between "$_reviewed_sha" "$HEAD_SHA"; then
+    review_kept=true
+    continue
+  fi
+
+  # Otherwise invalidate (source changed, or baseline/HEAD unknown -> fail-closed).
   _STATE="$_target" _BR="$BRANCH" python3 -c "
 import json, os, fcntl
 f_path = os.environ['_STATE']
@@ -67,15 +96,17 @@ with open(f_path, 'r+') as f:
     json.dump(s, f, indent=2)
     fcntl.flock(f, fcntl.LOCK_UN)
 " 2>/dev/null
+  review_invalidated=true
 done
 
-# Issue #33: Warn when push invalidated a completed review
-if [[ "$review_was_set" == "true" ]]; then
+if [[ "$review_invalidated" == "true" ]]; then
   echo "" >&2
-  echo "⚠️ [Review Reset] Push でレビューステータスがリセットされました。" >&2
+  echo "⚠️ [Review Reset] ソース変更を含む push のため既存レビューを無効化しました。" >&2
   echo "  ブランチ: ${BRANCH} (PR #${PR_NUMBER})" >&2
-  echo "  push前のレビュー結果は無効化されました。" >&2
-  echo "  → PR作成/マージ前に code-reviewer + Codex CLI を再実行してください。" >&2
+  echo "  → マージ前に code-reviewer（FULL tier は + Codex CLI）を再実行してください。" >&2
+elif [[ "$review_kept" == "true" ]]; then
+  echo "" >&2
+  echo "✅ [Review Kept] 非ソース変更のみのため既存レビューを維持します（再レビュー不要）。" >&2
 fi
 
 REPO=$(resolve_repo "")

--- a/hooks/gate-modes/pre-create.sh
+++ b/hooks/gate-modes/pre-create.sh
@@ -15,6 +15,16 @@ LOG_FILE="${STATE_DIR}/pr-gate-diagnostic.log"
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) PRE_CREATE invoked. CWD=$(pwd) STATE=$REVIEW_STATE" >> "$LOG_FILE" 2>/dev/null
 
 cmd=$(extract_cmd)
+# Skip ONLY a single read-only inspection command that merely MENTIONS the operation
+# (e.g. grep "gh pr create" ...). Requires a single-line command with NO shell operator,
+# so a real operation cannot be chained after a benign first token (prevents
+# `echo x && git push --force` style bypass). Executor tools excluded.
+if [[ -n "$cmd" ]] \
+   && [[ "$cmd" != *$'\n'* ]] \
+   && ! printf '%s' "$cmd" | grep -qE '[;&|`<>]|\$\(' \
+   && printf '%s' "$cmd" | grep -qE '^[[:space:]]*(grep|egrep|fgrep|cat|head|tail|wc|comm|diff|cut|tr|uniq|jq|ls|which|type|echo|printf)\b'; then
+  exit 0
+fi
 
 # Verify this is a gh pr create command
 if [[ -n "$cmd" ]] && ! printf '%s\n' "$cmd" | grep -qE 'gh[[:space:]]+pr[[:space:]]+create'; then

--- a/hooks/gate-modes/pre-merge.sh
+++ b/hooks/gate-modes/pre-merge.sh
@@ -13,6 +13,16 @@ source "${GATE_MODES_DIR}/common.sh"
 # DIAGNOSTIC: Log hook invocation
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) PRE_MERGE invoked. cmd=$(extract_cmd)" >> "${STATE_DIR}/pr-gate-diagnostic.log" 2>/dev/null
 cmd=$(extract_cmd)
+# Skip ONLY a single read-only inspection command that merely MENTIONS the operation
+# (e.g. grep "gh pr create" ...). Requires a single-line command with NO shell operator,
+# so a real operation cannot be chained after a benign first token (prevents
+# `echo x && git push --force` style bypass). Executor tools excluded.
+if [[ -n "$cmd" ]] \
+   && [[ "$cmd" != *$'\n'* ]] \
+   && ! printf '%s' "$cmd" | grep -qE '[;&|`<>]|\$\(' \
+   && printf '%s' "$cmd" | grep -qE '^[[:space:]]*(grep|egrep|fgrep|cat|head|tail|wc|comm|diff|cut|tr|uniq|jq|ls|which|type|echo|printf)\b'; then
+  exit 0
+fi
 
 # Verify this is a gh pr merge command
 if [[ -n "$cmd" ]] && ! echo "$(echo "$cmd" | head -1)" | grep -qE 'gh\s+pr\s+merge'; then
@@ -157,11 +167,10 @@ if [[ -f "$PENDING_FILE" ]] && command -v jq &>/dev/null; then
   fi
 fi
 
-# --- Pass C: Manual verification via pr-review-lock.json ---
-if [[ -f "$LOCK_STATE" ]] && command -v jq &>/dev/null; then
-  _verified=$(jq -r --arg pr "$PR_NUMBER" '.[$pr].verified // false' "$LOCK_STATE" 2>/dev/null || echo "false")
-  [[ "$_verified" == "true" ]] && PASS_C="yes"
-fi
+# --- Pass C: Manual verification via pr-review-lock.json (Fix8 dual-location) ---
+# Check BOTH project-scoped AND global lock files (OR-logic) so a verified=true
+# written to either location releases the gate.
+[[ "$(lock_pr_verified "$PR_NUMBER")" == "yes" ]] && PASS_C="yes"
 
 # --- Tier-aware judgment ---
 CODEX_REVIEW=$(read_review "$BRANCH" "codex_review")

--- a/hooks/gate-modes/stop.sh
+++ b/hooks/gate-modes/stop.sh
@@ -49,15 +49,21 @@ if ! git diff --quiet HEAD 2>/dev/null; then
 fi
 
 # Auto-cleanup: remove merged/closed PRs from lock state (housekeeping)
+# Fix8: clean BOTH project-scoped AND global lock files.
 REPO=$(resolve_repo "")
 if [[ -n "$REPO" ]]; then
-  _LOCK="$LOCK_STATE" _REPO="$REPO" python3 -c "
+  while IFS= read -r _lf; do
+    [[ -z "$_lf" || ! -f "$_lf" ]] && continue
+    _LOCK="$_lf" _REPO="$REPO" python3 -c "
 import json, subprocess, os, fcntl
 lock_path = os.environ['_LOCK']
 repo = os.environ['_REPO']
 with open(lock_path, 'r+') as f:
     fcntl.flock(f, fcntl.LOCK_EX)
-    s = json.load(f)
+    try:
+        s = json.load(f)
+    except Exception:
+        s = {}
     for pr in list(s.keys()):
         try:
             r = subprocess.run(['gh','api','repos/'+repo+'/pulls/'+pr,'--jq','.state'],
@@ -70,23 +76,57 @@ with open(lock_path, 'r+') as f:
     json.dump(s, f, indent=2)
     fcntl.flock(f, fcntl.LOCK_UN)
 " 2>/dev/null || true
+  done < <(lock_files)
 fi
 
 # =========================================================================
 # Gather PR status — informational warnings only (never block)
 # =========================================================================
-UNVERIFIED=$(_LOCK="$LOCK_STATE" python3 -c "
+# Fix8: gather warnings across BOTH lock files; a PR verified in EITHER file is
+# treated as verified (OR-logic), so only genuinely-unverified PRs are warned.
+LOCK_PATHS_STOP=$(lock_files)
+UNVERIFIED=$(_LOCK_PATHS="$LOCK_PATHS_STOP" python3 -c "
 import json, os
-with open(os.environ['_LOCK']) as f: s = json.load(f)
-unverified = [f'PR #{pr} ({d.get(\"branch\",\"?\")})' for pr, d in s.items()
-              if isinstance(d, dict) and d.get('ci_green', False) and not d.get('verified', False)]
+paths = [p for p in os.environ['_LOCK_PATHS'].splitlines() if p.strip()]
+merged = {}
+for p in paths:
+    if not os.path.exists(p):
+        continue
+    try:
+        with open(p) as f: s = json.load(f)
+    except Exception:
+        continue
+    for pr, d in s.items():
+        if not isinstance(d, dict):
+            continue
+        cur = merged.setdefault(pr, {'branch': d.get('branch', '?'), 'ci_green': False, 'verified': False})
+        cur['ci_green'] = cur['ci_green'] or d.get('ci_green', False)
+        cur['verified'] = cur['verified'] or d.get('verified', False)
+        if d.get('branch'): cur['branch'] = d.get('branch')
+unverified = [f'PR #{pr} ({d[\"branch\"]})' for pr, d in merged.items()
+              if d['ci_green'] and not d['verified']]
 print('|'.join(unverified) if unverified else '')
 " 2>/dev/null || echo "")
-CI_PENDING=$(_LOCK="$LOCK_STATE" python3 -c "
+CI_PENDING=$(_LOCK_PATHS="$LOCK_PATHS_STOP" python3 -c "
 import json, os
-with open(os.environ['_LOCK']) as f: s = json.load(f)
-pending = [f'PR #{pr} ({d.get(\"branch\",\"?\")})' for pr, d in s.items()
-           if isinstance(d, dict) and not d.get('ci_green', False) and not d.get('verified', False)]
+paths = [p for p in os.environ['_LOCK_PATHS'].splitlines() if p.strip()]
+merged = {}
+for p in paths:
+    if not os.path.exists(p):
+        continue
+    try:
+        with open(p) as f: s = json.load(f)
+    except Exception:
+        continue
+    for pr, d in s.items():
+        if not isinstance(d, dict):
+            continue
+        cur = merged.setdefault(pr, {'branch': d.get('branch', '?'), 'ci_green': False, 'verified': False})
+        cur['ci_green'] = cur['ci_green'] or d.get('ci_green', False)
+        cur['verified'] = cur['verified'] or d.get('verified', False)
+        if d.get('branch'): cur['branch'] = d.get('branch')
+pending = [f'PR #{pr} ({d[\"branch\"]})' for pr, d in merged.items()
+           if not d['ci_green'] and not d['verified']]
 print('|'.join(pending) if pending else '')
 " 2>/dev/null || echo "")
 

--- a/hooks/gate-modes/verify.sh
+++ b/hooks/gate-modes/verify.sh
@@ -44,11 +44,20 @@ if [[ "$CI_PENDING" -gt 0 ]]; then
   exit 1
 fi
 
-BRANCH=$(_LOCK="$LOCK_STATE" _PR="$PR" python3 -c "
+# Read branch from ANY lock file (project or global) — Fix8 dual-location
+BRANCH=""
+while IFS= read -r _lf; do
+  [[ -z "$_lf" || ! -f "$_lf" ]] && continue
+  BRANCH=$(_LOCK="$_lf" _PR="$PR" python3 -c "
 import json, os
-with open(os.environ['_LOCK']) as f: s = json.load(f)
-print(s.get(os.environ['_PR'], {}).get('branch', ''))
+try:
+    with open(os.environ['_LOCK']) as f: s = json.load(f)
+    print(s.get(os.environ['_PR'], {}).get('branch', ''))
+except Exception:
+    print('')
 " 2>/dev/null || echo "")
+  [[ -n "$BRANCH" ]] && break
+done < <(lock_files)
 
 # If branch not in lock state, try GitHub API
 if [[ -z "$BRANCH" ]]; then
@@ -104,22 +113,26 @@ else
   fi
 fi
 
-# All checks passed — mark as verified
-_LOCK="$LOCK_STATE" _PR="$PR" python3 -c "
-import json, os, fcntl
-f_path = os.environ['_LOCK']
-pr = os.environ['_PR']
-with open(f_path, 'r+') as f:
-    fcntl.flock(f, fcntl.LOCK_EX)
-    s = json.load(f)
-    if pr in s:
-        s[pr]['ci_green'] = True
-        s[pr]['review_lgtm'] = True
-        s[pr]['verified'] = True
-    f.seek(0); f.truncate()
-    json.dump(s, f, indent=2)
-    fcntl.flock(f, fcntl.LOCK_UN)
-" 2>/dev/null
+# All checks passed — mark as verified in BOTH project + global state (Fix8).
+# Use setdefault so the global file (which may lack the entry) also gets
+# verified=true, satisfying block-merge-without-review.sh's global read.
+# Fix C: capture lock_apply's status so a silent write failure cannot make VERIFY
+# falsely report success while verified=true was never persisted. lock_apply emits
+# its own stderr warning; `|| _lock_rc=$?` prevents set -e from aborting before we
+# decide. On failure, do NOT print the success line — exit non-zero so the operator
+# knows the lock is still pending.
+_lock_rc=0
+_BR="$BRANCH" lock_apply "$PR" "
+e = s.setdefault(PR, {'status': 'review_pending', 'branch': os.environ['_BR']})
+e['ci_green'] = True
+e['review_lgtm'] = True
+e['verified'] = True
+" || _lock_rc=$?
+
+if [[ "$_lock_rc" -ne 0 ]]; then
+  echo "❌ PR #${PR}: 検証は通りましたがロック解除の保存に失敗しました。再実行してください。" >&2
+  exit 1
+fi
 
 echo "✅ PR #${PR}: CI green + レビュー LGTM 確認完了。ロック解除。" >&2
 exit 0

--- a/hooks/git-commit-guard.sh
+++ b/hooks/git-commit-guard.sh
@@ -38,19 +38,17 @@ if [[ "$IS_SUBAGENT" == "false" ]]; then
         case "$current_branch" in
             develop|main|master) ;; # allowed base branches
             "")
-                echo "🚫 [Delegation Required] detached HEAD状態でのcommitはsubagentに委任してください。" >&2
+                echo "🚫 [Claude Code hook: git-commit-guard.sh] Delegation Required" >&2
+                echo "  detached HEAD 状態での commit は subagent に委任してください。" >&2
+                echo "  NOTE: これは Claude Code 側の PreToolUse hook です（Cursor / pre-commit のリポジトリフックではありません）。" >&2
+                echo "  Source: ~/.claude/hooks/git-commit-guard.sh / settings.json (PreToolUse: Bash)" >&2
                 exit 2
                 ;;
             *)
-                echo "🚫 [Delegation Required] メインエージェントは非ベースブランチに直接commitできません。" >&2
-                echo "" >&2
-                echo "ブランチ: $current_branch" >&2
-                echo "" >&2
-                echo "対応方法:" >&2
-                echo "  1. Agent tool (subagent_type=general-purpose) でcommitを委任" >&2
-                echo "  2. TeamCreate でワーカーに委任する" >&2
-                echo "" >&2
-                exit 2
+                # Relaxed (2026-05-30): main agent may commit directly on feature
+                # branches. Review is enforced at PR create/merge, so commit-level
+                # delegation (Issue #10) is redundant friction. Detached HEAD still
+                # requires delegation; format/issue-ref/lint checks below still apply.
                 ;;
         esac
     fi

--- a/hooks/git-push-guard.sh
+++ b/hooks/git-push-guard.sh
@@ -6,6 +6,17 @@ set -euo pipefail
 input=$(cat)
 cmd=$(echo "$input" | jq -r '.tool_input.command // ""')
 
+# Skip ONLY a single read-only inspection command that merely MENTIONS the operation
+# (e.g. grep "gh pr create" ...). Requires a single-line command with NO shell operator,
+# so a real operation cannot be chained after a benign first token (prevents
+# `echo x && git push --force` style bypass). Executor tools excluded.
+if [[ -n "$cmd" ]] \
+   && [[ "$cmd" != *$'\n'* ]] \
+   && ! printf '%s' "$cmd" | grep -qE '[;&|`<>]|\$\(' \
+   && printf '%s' "$cmd" | grep -qE '^[[:space:]]*(grep|egrep|fgrep|cat|head|tail|wc|comm|diff|cut|tr|uniq|jq|ls|which|type|echo|printf)\b'; then
+  exit 0
+fi
+
 # --- 0. Early exit: only run on git push commands (Issue #150) ---
 # Without this guard, black/ruff checks in section 3 block ALL Bash commands,
 # creating an unrecoverable deadlock where even `black .` is blocked.

--- a/hooks/post-pr-create-review-trigger.sh
+++ b/hooks/post-pr-create-review-trigger.sh
@@ -69,17 +69,28 @@ mkdir -p "$STATE_DIR"
 
 BRANCH=$(git branch --show-current 2>/dev/null || echo "")
 
-# Write review-pending state
-LOCK_STATE="$STATE_DIR/pr-review-lock.json"
-[[ ! -f "$LOCK_STATE" ]] && echo '{}' > "$LOCK_STATE"
+# Write review-pending state to BOTH project-scoped AND global lock files (Fix8).
+# block-merge-without-review.sh (CLAUDE_PROJECT_DIR unset) reads the global file,
+# so the lock must be present there too. Build a deduped list of targets.
+GLOBAL_STATE_DIR="$HOME/.claude/state"
+mkdir -p "$GLOBAL_STATE_DIR" 2>/dev/null || true
+LOCK_TARGETS=("$STATE_DIR/pr-review-lock.json")
+if [[ "$GLOBAL_STATE_DIR/pr-review-lock.json" != "$STATE_DIR/pr-review-lock.json" ]]; then
+  LOCK_TARGETS+=("$GLOBAL_STATE_DIR/pr-review-lock.json")
+fi
 
 if command -v python3 &>/dev/null; then
-  _PR="$PR_NUMBER" _BRANCH="$BRANCH" _LOCK="$LOCK_STATE" python3 -c "
+  for _lock_file in "${LOCK_TARGETS[@]}"; do
+    [[ ! -f "$_lock_file" ]] && echo '{}' > "$_lock_file"
+    _PR="$PR_NUMBER" _BRANCH="$BRANCH" _LOCK="$_lock_file" python3 -c "
 import json, os, fcntl
 lock_file = os.environ['_LOCK']
 with open(lock_file, 'r+') as f:
     fcntl.flock(f, fcntl.LOCK_EX)
-    s = json.load(f)
+    try:
+        s = json.load(f)
+    except Exception:
+        s = {}
     s[os.environ['_PR']] = {
         'status': 'review_pending',
         'branch': os.environ['_BRANCH'],
@@ -92,6 +103,7 @@ with open(lock_file, 'r+') as f:
     json.dump(s, f, indent=2)
     fcntl.flock(f, fcntl.LOCK_UN)
 " 2>/dev/null
+  done
 fi
 
 # Inject review instructions via additionalContext

--- a/hooks/pr-guard.sh
+++ b/hooks/pr-guard.sh
@@ -6,8 +6,22 @@ set -euo pipefail
 input=$(cat)
 cmd=$(echo "$input" | jq -r '.tool_input.command // ""')
 
+# Skip ONLY a single read-only inspection command that merely MENTIONS the operation
+# (e.g. grep "gh pr create" ...). Requires a single-line command with NO shell operator,
+# so a real operation cannot be chained after a benign first token (prevents
+# `echo x && git push --force` style bypass). Executor tools excluded.
+if [[ -n "$cmd" ]] \
+   && [[ "$cmd" != *$'\n'* ]] \
+   && ! printf '%s' "$cmd" | grep -qE '[;&|`<>]|\$\(' \
+   && printf '%s' "$cmd" | grep -qE '^[[:space:]]*(grep|egrep|fgrep|cat|head|tail|wc|comm|diff|cut|tr|uniq|jq|ls|which|type|echo|printf)\b'; then
+  exit 0
+fi
+
+# Tightened (Fix3-ext): require an ACTUAL `gh pr create` invocation — gh directly
+# followed by pr followed by create with only whitespace between. This prevents a
+# loose match from firing on a regex/string that merely contains the tokens.
 cmd_first_line=$(echo "$cmd" | head -1)
-if ! echo "$cmd_first_line" | grep -qE 'gh\s+pr\s+create\b'; then
+if ! echo "$cmd_first_line" | grep -qE 'gh[[:space:]]+pr[[:space:]]+create\b'; then
     exit 0
 fi
 

--- a/hooks/pr-merge-claude-review-gate.sh
+++ b/hooks/pr-merge-claude-review-gate.sh
@@ -35,6 +35,17 @@ input=""
 
 cmd=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 
+# Skip ONLY a single read-only inspection command that merely MENTIONS the operation
+# (e.g. grep "gh pr create" ...). Requires a single-line command with NO shell operator,
+# so a real operation cannot be chained after a benign first token (prevents
+# `echo x && git push --force` style bypass). Executor tools excluded.
+if [[ -n "$cmd" ]] \
+   && [[ "$cmd" != *$'\n'* ]] \
+   && ! printf '%s' "$cmd" | grep -qE '[;&|`<>]|\$\(' \
+   && printf '%s' "$cmd" | grep -qE '^[[:space:]]*(grep|egrep|fgrep|cat|head|tail|wc|comm|diff|cut|tr|uniq|jq|ls|which|type|echo|printf)\b'; then
+  exit 0
+fi
+
 # Only apply to gh pr merge
 if ! echo "$(echo "$cmd" | head -1)" | grep -qE 'gh\s+pr\s+merge'; then
   exit 0

--- a/hooks/protect-branches.sh
+++ b/hooks/protect-branches.sh
@@ -25,6 +25,17 @@ set -euo pipefail
 input=$(cat)
 cmd=$(echo "$input" | jq -r '.tool_input.command // ""')
 
+# Skip ONLY a single read-only inspection command that merely MENTIONS the operation
+# (e.g. grep "gh pr create" ...). Requires a single-line command with NO shell operator,
+# so a real operation cannot be chained after a benign first token (prevents
+# `echo x && git push --force` style bypass). Executor tools excluded.
+if [[ -n "$cmd" ]] \
+   && [[ "$cmd" != *$'\n'* ]] \
+   && ! printf '%s' "$cmd" | grep -qE '[;&|`<>]|\$\(' \
+   && printf '%s' "$cmd" | grep -qE '^[[:space:]]*(grep|egrep|fgrep|cat|head|tail|wc|comm|diff|cut|tr|uniq|jq|ls|which|type|echo|printf)\b'; then
+  exit 0
+fi
+
 PROTECTED_BRANCHES="develop main master"
 
 # --- Fork detection (#191) ---

--- a/hooks/record-code-review.sh
+++ b/hooks/record-code-review.sh
@@ -108,6 +108,38 @@ def git_branch(repo):
         return ""
 
 
+def git_branch_exists(repo, branch):
+    """Return True if branch is a real ref in repo (local or remote)."""
+    if not repo or not branch:
+        return False
+    for ref in (
+        "refs/heads/%s" % branch,
+        "refs/remotes/origin/%s" % branch,
+    ):
+        try:
+            subprocess.check_call(
+                ["git", "-C", repo, "rev-parse", "--verify", "--quiet", ref],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return True
+        except Exception:
+            continue
+    return False
+
+
+# Trailing punctuation that natural-language prompts append to a branch token
+# (e.g. "branch: fix/x. Look for ..."). The `.` is a legal git ref char, so the
+# greedy regex captures it; strip it here. A real branch never ends in these.
+_TRAILING_PUNCT = ".,:;]})\"'`"
+
+
+def clean_branch_token(value):
+    if not isinstance(value, str):
+        return ""
+    return value.strip().split(":", 1)[-1].strip().rstrip(_TRAILING_PUNCT)
+
+
 tool_input = load_tool_input(os.environ.get("_HOOK_INPUT", ""))
 text_fields = []
 for key in ("prompt", "description", "message", "task", "instructions"):
@@ -116,24 +148,7 @@ for key in ("prompt", "description", "message", "task", "instructions"):
         text_fields.append(value)
 text = "\n".join(text_fields)
 
-branch = ""
-for key in ("branch", "head_branch", "head", "target_branch", "review_branch"):
-    value = tool_input.get(key)
-    if isinstance(value, str) and value.strip():
-        branch = value.strip().split(":", 1)[-1]
-        break
-
-if not branch:
-    patterns = [
-        r"(?:^|[\s,;])--head(?:=|\s+)([A-Za-z0-9._/-]+)",
-        r"(?:^|[\s,;])(?:branch|head|review_branch|target_branch)\s*[:=]\s*`?([A-Za-z0-9._/-]+)`?",
-    ]
-    for pattern in patterns:
-        match = re.search(pattern, text)
-        if match:
-            branch = match.group(1).split(":", 1)[-1]
-            break
-
+# --- Resolve repo FIRST so branch resolution can use it authoritatively ---
 repo = ""
 for key in ("cwd", "worktree", "worktree_path", "repo_path", "repository_path", "project_path", "working_directory"):
     value = tool_input.get(key)
@@ -148,11 +163,51 @@ if not repo:
         if repo:
             break
 
+if not repo and os.environ.get("CLAUDE_PROJECT_DIR"):
+    repo = git_root(os.environ["CLAUDE_PROJECT_DIR"])
+
 if not repo:
     repo = git_root(os.getcwd())
 
+# --- Resolve branch: explicit token (cleaned) is authoritative ---
+explicit_branch = ""
+for key in ("branch", "head_branch", "head", "target_branch", "review_branch"):
+    value = tool_input.get(key)
+    if isinstance(value, str) and value.strip():
+        explicit_branch = clean_branch_token(value)
+        break
+
+if not explicit_branch:
+    patterns = [
+        r"(?:^|[\s,;])--head(?:=|\s+)([A-Za-z0-9._/-]+)",
+        r"(?:^|[\s,;])(?:branch|head|review_branch|target_branch)\s*[:=]\s*`?([A-Za-z0-9._/-]+)`?",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, text)
+        if match:
+            explicit_branch = clean_branch_token(match.group(1))
+            break
+
+repo_branch = git_branch(repo)
+
+# An explicit, punctuation-cleaned token from the prompt is AUTHORITATIVE — it is
+# what the caller said to record, and read_review() looks up by that exact key.
+# This is the source of the fix: the regex char class [A-Za-z0-9._/-] greedily
+# captured a trailing sentence period (e.g. "branch: fix/x." -> "fix/x."), so the
+# record landed on a key the gate never reads. clean_branch_token() strips it.
+#
+# Only when the cleaned token STILL does not resolve to a real ref do we snap to a
+# punctuation-equivalent ref. A brand-new branch that is not yet a ref is kept
+# as-is (never silently reattributed to the repo's HEAD branch).
+branch = explicit_branch
+if explicit_branch and repo and not git_branch_exists(repo, explicit_branch):
+    stripped = explicit_branch.rstrip(_TRAILING_PUNCT)
+    if stripped != explicit_branch and git_branch_exists(repo, stripped):
+        branch = stripped
+
+# No explicit token at all -> fall back to the resolved repo's checked-out branch.
 if not branch:
-    branch = git_branch(repo)
+    branch = repo_branch
 
 print(json.dumps({"repo": repo, "branch": branch}))
 PY
@@ -182,14 +237,32 @@ fi
 REVIEW_STATE="$GLOBAL_STATE_DIR/review-status.json"
 
 if [[ -z "$BRANCH" ]]; then
-  exit 0
+  # Hardened fallback: avoid silently failing to record (caused "reviewed but not recorded")
+  if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    BRANCH=$(git -C "$CLAUDE_PROJECT_DIR" branch --show-current 2>/dev/null || echo "")
+  fi
+  [[ -z "$BRANCH" ]] && BRANCH="${GITHUB_HEAD_REF:-}"
+  if [[ -z "$BRANCH" ]]; then
+    echo "⚠️ [review-gate] code-reviewer 完了を記録できません（branch 解決失敗）。" >&2
+    echo "   レビューは行われましたが状態が未記録です。手動で再レビュー or branch を明示してください。" >&2
+    exit 0
+  fi
 fi
 
 # Update review-status.json: mark code_review as true for this branch
 NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+# Fix D: record the SHA of the BRANCH that was reviewed, not the dir's HEAD. HEAD
+# is whatever commit happens to be checked out in $_SHA_DIR, which can be a
+# DIFFERENT branch than $BRANCH (e.g. reviewing fix/x while sitting on develop).
+# Resolve the resolved-branch ref: local refs/heads/<BRANCH>, then origin/<BRANCH>,
+# then fall back to HEAD only if neither ref exists.
+_SHA_DIR="${REPO_PATH:-${CLAUDE_PROJECT_DIR:-.}}"
+REVIEW_SHA=$(git -C "$_SHA_DIR" rev-parse --verify --quiet "refs/heads/${BRANCH}" 2>/dev/null \
+  || git -C "$_SHA_DIR" rev-parse --verify --quiet "refs/remotes/origin/${BRANCH}" 2>/dev/null \
+  || git -C "$_SHA_DIR" rev-parse HEAD 2>/dev/null || echo "")
 if command -v python3 &>/dev/null; then
   # Primary: python3 + fcntl for atomic flock write
-  _STATE="$REVIEW_STATE" _BR="$BRANCH" _NOW="$NOW" python3 -c "
+  _STATE="$REVIEW_STATE" _BR="$BRANCH" _NOW="$NOW" _SHA="$REVIEW_SHA" python3 -c "
 import json, os, fcntl
 f_path = os.environ['_STATE']
 with open(f_path, 'r+') as f:
@@ -200,6 +273,8 @@ with open(f_path, 'r+') as f:
         s = {}
     s.setdefault(os.environ['_BR'], {})['code_review'] = True
     s[os.environ['_BR']]['code_review_at'] = os.environ['_NOW']
+    if os.environ.get('_SHA'):
+        s[os.environ['_BR']]['code_review_sha'] = os.environ['_SHA']
     f.seek(0); f.truncate()
     json.dump(s, f, indent=2)
     fcntl.flock(f, fcntl.LOCK_UN)
@@ -221,7 +296,7 @@ for PROJECT_STATE_DIR in "${PROJECT_STATE_DIRS[@]}"; do
   [ ! -f "$PROJECT_REVIEW" ] && echo '{}' > "$PROJECT_REVIEW"
   if command -v python3 &>/dev/null; then
     # Primary: python3 + fcntl for atomic flock write
-    _STATE="$PROJECT_REVIEW" _BR="$BRANCH" _NOW="$NOW" python3 -c "
+    _STATE="$PROJECT_REVIEW" _BR="$BRANCH" _NOW="$NOW" _SHA="$REVIEW_SHA" python3 -c "
 import json, os, fcntl
 f_path = os.environ['_STATE']
 with open(f_path, 'r+') as f:
@@ -232,6 +307,8 @@ with open(f_path, 'r+') as f:
         s = {}
     s.setdefault(os.environ['_BR'], {})['code_review'] = True
     s[os.environ['_BR']]['code_review_at'] = os.environ['_NOW']
+    if os.environ.get('_SHA'):
+        s[os.environ['_BR']]['code_review_sha'] = os.environ['_SHA']
     f.seek(0); f.truncate()
     json.dump(s, f, indent=2)
     fcntl.flock(f, fcntl.LOCK_UN)

--- a/hooks/record-codex-review.sh
+++ b/hooks/record-codex-review.sh
@@ -77,6 +77,38 @@ def git_branch(repo):
         return ""
 
 
+def git_branch_exists(repo, branch):
+    """Return True if branch is a real ref in repo (local or remote)."""
+    if not repo or not branch:
+        return False
+    for ref in (
+        "refs/heads/%s" % branch,
+        "refs/remotes/origin/%s" % branch,
+    ):
+        try:
+            subprocess.check_call(
+                ["git", "-C", repo, "rev-parse", "--verify", "--quiet", ref],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return True
+        except Exception:
+            continue
+    return False
+
+
+# Trailing punctuation that natural-language prompts append to a branch token
+# (e.g. "branch: fix/x. Review now."). The `.` is a legal git ref char, so the
+# greedy regex captures it; strip it here. A real branch never ends in these.
+_TRAILING_PUNCT = ".,:;]})\"'`"
+
+
+def clean_branch_token(value):
+    if not isinstance(value, str):
+        return ""
+    return value.strip().split(":", 1)[-1].strip().rstrip(_TRAILING_PUNCT)
+
+
 tool_input = load_tool_input(os.environ.get("_HOOK_INPUT", ""))
 command = tool_input.get("command", "")
 if not isinstance(command, str):
@@ -89,24 +121,7 @@ for key in ("prompt", "description", "message", "task", "instructions"):
         text_fields.append(value)
 text = "\n".join(text_fields)
 
-branch = ""
-for key in ("branch", "head_branch", "head", "target_branch", "review_branch"):
-    value = tool_input.get(key)
-    if isinstance(value, str) and value.strip():
-        branch = value.strip().split(":", 1)[-1]
-        break
-
-if not branch:
-    patterns = [
-        r"(?:^|[\s,;])--head(?:=|\s+)([A-Za-z0-9._/-]+)",
-        r"(?:^|[\s,;])(?:branch|head|review_branch|target_branch)\s*[:=]\s*`?([A-Za-z0-9._/-]+)`?",
-    ]
-    for pattern in patterns:
-        match = re.search(pattern, text)
-        if match:
-            branch = match.group(1).split(":", 1)[-1]
-            break
-
+# --- Resolve repo FIRST so branch resolution can use it authoritatively ---
 repo = ""
 for key in (
     "cwd",
@@ -129,11 +144,47 @@ if not repo:
         if repo:
             break
 
+if not repo and os.environ.get("CLAUDE_PROJECT_DIR"):
+    repo = git_root(os.environ["CLAUDE_PROJECT_DIR"])
+
 if not repo:
     repo = git_root(os.getcwd())
 
+# --- Resolve branch: explicit token (cleaned) is authoritative ---
+explicit_branch = ""
+for key in ("branch", "head_branch", "head", "target_branch", "review_branch"):
+    value = tool_input.get(key)
+    if isinstance(value, str) and value.strip():
+        explicit_branch = clean_branch_token(value)
+        break
+
+if not explicit_branch:
+    patterns = [
+        r"(?:^|[\s,;])--head(?:=|\s+)([A-Za-z0-9._/-]+)",
+        r"(?:^|[\s,;])(?:branch|head|review_branch|target_branch)\s*[:=]\s*`?([A-Za-z0-9._/-]+)`?",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, text)
+        if match:
+            explicit_branch = clean_branch_token(match.group(1))
+            break
+
+repo_branch = git_branch(repo)
+
+# An explicit, punctuation-cleaned token from the prompt/command is AUTHORITATIVE.
+# The regex char class [A-Za-z0-9._/-] greedily captured a trailing sentence period
+# (e.g. "branch: fix/x." -> "fix/x."), landing the record on a key the gate never
+# reads. clean_branch_token() strips it. Only snap to a punctuation-equivalent ref
+# when the cleaned token still does not resolve; a brand-new branch is kept as-is.
+branch = explicit_branch
+if explicit_branch and repo and not git_branch_exists(repo, explicit_branch):
+    stripped = explicit_branch.rstrip(_TRAILING_PUNCT)
+    if stripped != explicit_branch and git_branch_exists(repo, stripped):
+        branch = stripped
+
+# No explicit token at all -> fall back to the resolved repo's checked-out branch.
 if not branch:
-    branch = git_branch(repo)
+    branch = repo_branch
 
 print(json.dumps({"repo": repo, "branch": branch, "command": command}))
 PY
@@ -158,13 +209,16 @@ if [[ $# -eq 0 ]]; then
   # Record codex_review_ran=true with pass=true (no severity data)
   # codex-parallel.sh path provides severity data when available
   NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  REVIEW_SHA=$(git -C "${REPO_PATH:-.}" rev-parse --verify --quiet "refs/heads/${BRANCH}" 2>/dev/null \
+  || git -C "${REPO_PATH:-.}" rev-parse --verify --quiet "refs/remotes/origin/${BRANCH}" 2>/dev/null \
+  || git -C "${REPO_PATH:-.}" rev-parse HEAD 2>/dev/null || echo "")
 
   write_codex_review_hook() {
     local target="$1"
     mkdir -p "$(dirname "$target")"
     [ ! -f "$target" ] && echo '{}' > "$target"
 
-    _STATE="$target" _BR="$BRANCH" _NOW="$NOW" \
+    _STATE="$target" _BR="$BRANCH" _NOW="$NOW" _SHA="$REVIEW_SHA" \
     python3 -c "
 import json, os, fcntl
 f_path = os.environ['_STATE']
@@ -180,6 +234,8 @@ with open(f_path, 'r+') as f:
         data[br] = {}
     data[br]['codex_review_ran'] = True
     data[br]['codex_review_at'] = now
+    if os.environ.get('_SHA'):
+        data[br]['codex_review_sha'] = os.environ['_SHA']
     if 'codex_review' not in data[br]:
         data[br]['codex_review'] = True
     f.seek(0)
@@ -250,6 +306,9 @@ if [[ "$HAS_SEVERITY" == "true" ]]; then
 fi
 
 NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+REVIEW_SHA=$(git -C "${REPO_PATH:-.}" rev-parse --verify --quiet "refs/heads/${BRANCH}" 2>/dev/null \
+  || git -C "${REPO_PATH:-.}" rev-parse --verify --quiet "refs/remotes/origin/${BRANCH}" 2>/dev/null \
+  || git -C "${REPO_PATH:-.}" rev-parse HEAD 2>/dev/null || echo "")
 
 # --- Helper: write codex_review to a single state file ---
 write_codex_review() {
@@ -257,7 +316,7 @@ write_codex_review() {
   mkdir -p "$(dirname "$target")"
   [ ! -f "$target" ] && echo '{}' > "$target"
 
-  _STATE="$target" _BR="$BRANCH" _NOW="$NOW" \
+  _STATE="$target" _BR="$BRANCH" _NOW="$NOW" _SHA="$REVIEW_SHA" \
   _PASS="$CODEX_REVIEW_PASS" _HAS_SEV="$HAS_SEVERITY" \
   _CRIT="$CODEX_CRITICAL" _HIGH="$CODEX_HIGH" \
   _MED="$CODEX_MEDIUM" _LOW="$CODEX_LOW" \
@@ -279,6 +338,8 @@ with open(f_path, 'r+') as f:
     data[br]['codex_review'] = review_pass
     data[br]['codex_review_ran'] = True
     data[br]['codex_review_at'] = now
+    if os.environ.get('_SHA'):
+        data[br]['codex_review_sha'] = os.environ['_SHA']
     if has_sev:
         for key, env in [('codex_critical','_CRIT'),('codex_high','_HIGH'),('codex_medium','_MED'),('codex_low','_LOW')]:
             try:

--- a/scripts/verify-pr-review.sh
+++ b/scripts/verify-pr-review.sh
@@ -12,13 +12,32 @@ if [ -z "$PR_NUM" ]; then
     exit 1
 fi
 
-REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "")
+# Resolve REPO independent of cwd (Fix8):
+#   1. CLAUDE_FORK_REPO env override
+#   2. explicit 2nd CLI arg (owner/repo)
+#   3. gh repo view from cwd
+#   4. git remote (origin/upstream) of CLAUDE_PROJECT_DIR or git toplevel
+REPO="${CLAUDE_FORK_REPO:-${2:-}}"
+if [ -z "$REPO" ]; then
+    REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "")
+fi
+if [ -z "$REPO" ]; then
+    _repo_dir="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || echo "")}"
+    if [ -n "$_repo_dir" ]; then
+        REPO=$(git -C "$_repo_dir" remote get-url upstream 2>/dev/null \
+                 | sed 's|.*github.com[:/]||;s|\.git$||')
+        [ -z "$REPO" ] && REPO=$(git -C "$_repo_dir" remote get-url origin 2>/dev/null \
+                 | sed 's|.*github.com[:/]||;s|\.git$||')
+    fi
+fi
 if [ -z "$REPO" ]; then
     echo "❌ リポジトリ情報を取得できません。" >&2
     exit 1
 fi
 
-# Project-scoped state: match block-merge-without-review.sh resolution (Issue #19)
+# Project-scoped state: match block-merge-without-review.sh resolution (Issue #19).
+# Fix8: write the lock to BOTH the project-scoped dir AND the global dir so a
+# later reader with no/other CLAUDE_PROJECT_DIR (block-merge) sees verified=true.
 if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
   _STATE_BASE="${CLAUDE_PROJECT_DIR}/.claude/state"
 elif git rev-parse --show-toplevel &>/dev/null; then
@@ -26,21 +45,41 @@ elif git rev-parse --show-toplevel &>/dev/null; then
 else
   _STATE_BASE="$HOME/.claude/state"
 fi
+_GLOBAL_STATE_BASE="$HOME/.claude/state"
 REVIEW_LOCK="$_STATE_BASE/pr-review-lock.json"
 mkdir -p "$(dirname "$REVIEW_LOCK")"
 [ ! -f "$REVIEW_LOCK" ] && echo '{}' > "$REVIEW_LOCK"
 
+# Build deduped list of lock targets (project-scoped, then global)
+LOCK_TARGETS=("$REVIEW_LOCK")
+if [[ "$_GLOBAL_STATE_BASE/pr-review-lock.json" != "$REVIEW_LOCK" ]]; then
+  LOCK_TARGETS+=("$_GLOBAL_STATE_BASE/pr-review-lock.json")
+fi
+mkdir -p "$_GLOBAL_STATE_BASE"
+for _lt in "${LOCK_TARGETS[@]}"; do
+  [ ! -f "$_lt" ] && echo '{}' > "$_lt"
+done
+
 echo "🔍 PR #${PR_NUM} claude-review 3ソース検証中..."
 
 # --- Check if auto-review was needed (no claude-review workflow) ---
-AUTO_REVIEW_NEEDED=$(_LOCK="$REVIEW_LOCK" _PR="$PR_NUM" python3 -c "
+# Fix8: OR-logic across ALL lock locations.
+AUTO_REVIEW_NEEDED="no"
+for _lt in "${LOCK_TARGETS[@]}"; do
+  [ ! -f "$_lt" ] && continue
+  _arn=$(_LOCK="$_lt" _PR="$PR_NUM" python3 -c "
 import json, os, fcntl
-with open(os.environ['_LOCK']) as f:
-    fcntl.flock(f, fcntl.LOCK_SH)
-    s = json.load(f)
-    fcntl.flock(f, fcntl.LOCK_UN)
-print('yes' if s.get(os.environ['_PR'], {}).get('auto_review_needed', False) else 'no')
+try:
+    with open(os.environ['_LOCK']) as f:
+        fcntl.flock(f, fcntl.LOCK_SH)
+        s = json.load(f)
+        fcntl.flock(f, fcntl.LOCK_UN)
+    print('yes' if s.get(os.environ['_PR'], {}).get('auto_review_needed', False) else 'no')
+except Exception:
+    print('no')
 " 2>/dev/null || echo "no")
+  [ "$_arn" = "yes" ] && { AUTO_REVIEW_NEEDED="yes"; break; }
+done
 
 # Source 1: Review bodies
 REVIEWS=$(gh api "repos/${REPO}/pulls/${PR_NUM}/reviews" 2>/dev/null || echo "[]")
@@ -206,12 +245,17 @@ fi
 if [ "$BLOCKING" -gt 0 ] || [ "$MUST_FIX" -gt 0 ] || [ "$CRITICAL" -gt 0 ] || [ "$HIGH" -gt 0 ] || [ "$BUG" -gt 0 ]; then
     echo "❌ PR #${PR_NUM} にBlocking/MustFix/Critical/High/Bug指摘が残っています。ロック解除できません。"
 
-    _LOCK="$REVIEW_LOCK" _PR="$PR_NUM" _BLOCKING="$BLOCKING" _MUST_FIX="$MUST_FIX" _CRITICAL="$CRITICAL" _HIGH="$HIGH" _BUG="$BUG" python3 -c "
+    # Fix8: write failure state (verified=False) to ALL lock locations
+    for _lt in "${LOCK_TARGETS[@]}"; do
+      _LOCK="$_lt" _PR="$PR_NUM" _BLOCKING="$BLOCKING" _MUST_FIX="$MUST_FIX" _CRITICAL="$CRITICAL" _HIGH="$HIGH" _BUG="$BUG" python3 -c "
 import json, os, fcntl
 f_path = os.environ['_LOCK']
 with open(f_path, 'r+') as f:
     fcntl.flock(f, fcntl.LOCK_EX)
-    s = json.load(f)
+    try:
+        s = json.load(f)
+    except Exception:
+        s = {}
     s.setdefault(os.environ['_PR'], {})
     s[os.environ['_PR']]['blocking_count'] = int(os.environ['_BLOCKING'])
     s[os.environ['_PR']]['must_fix_count'] = int(os.environ['_MUST_FIX'])
@@ -224,16 +268,23 @@ with open(f_path, 'r+') as f:
     json.dump(s, f, indent=2)
     fcntl.flock(f, fcntl.LOCK_UN)
 " 2>/dev/null
+    done
     exit 1
 fi
 
-# ALL CLEAN — release lock
-_LOCK="$REVIEW_LOCK" _PR="$PR_NUM" _NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)" python3 -c "
+# ALL CLEAN — release lock in ALL locations (Fix8 dual-write).
+# block-merge-without-review.sh reads $HOME/.claude/state when CLAUDE_PROJECT_DIR
+# is unset, so verified=true MUST land in the global file too.
+for _lt in "${LOCK_TARGETS[@]}"; do
+  _LOCK="$_lt" _PR="$PR_NUM" _NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)" python3 -c "
 import json, os, fcntl
 f_path = os.environ['_LOCK']
 with open(f_path, 'r+') as f:
     fcntl.flock(f, fcntl.LOCK_EX)
-    s = json.load(f)
+    try:
+        s = json.load(f)
+    except Exception:
+        s = {}
     s.setdefault(os.environ['_PR'], {})
     s[os.environ['_PR']]['blocking_count'] = 0
     s[os.environ['_PR']]['must_fix_count'] = 0
@@ -247,6 +298,7 @@ with open(f_path, 'r+') as f:
     json.dump(s, f, indent=2)
     fcntl.flock(f, fcntl.LOCK_UN)
 " 2>/dev/null
+done
 
 # Also mark review as read (resolves pr-merge-claude-review-gate.sh / block-state-file-tampering-bash.sh design gap — Issue #99)
 # verify-pr-review.sh fetches and displays all review comments above, satisfying the "read" requirement.


### PR DESCRIPTION
## 概要

過剰に発火していたレビュー/PR ゲートを **バグ修正に限定して**是正し、サブエージェント免除の不具合と Codex の sandbox 設定も合わせて修正する。レビュー必須数（FULL tier の2レビュアー）は維持。

Closes #231

## 変更内容

1. **tier 誤判定** `gate-modes/common.sh`: 変更ファイル検出失敗時のフォールバックを FULL → LIGHT（docs/小PR を誤って2レビュアーFULLに巻き込まない。本物のソース変更は merge 時に FULL へ再分類）。
2. **手戻り (SHA賢い無効化)** `gate-modes/post-push.sh` + `record-*-review.sh`: push 毎の無条件レビュー削除を廃止し、`reviewed_sha` を記録して **ソースファイルが変わった push のみ**無効化（docs/config のみの push はレビュー維持）。
3. **記録漏れ** `record-code-review.sh`: branch 解決失敗時のフォールバック（`CLAUDE_PROJECT_DIR`/`GITHUB_HEAD_REF`）＋可視警告でサイレント未記録を解消。`_SHA_DIR` を branch 解決と同一に。
4. **過剰マッチ** gate-modes 3種 + gh/git 系 hook 14種: 読み取り専用コマンド（grep/cat 等）が操作を**文字列に含むだけ**で誤ブロックされる問題を抑制。チェーン（`;`/`&&`/`||`/`|`/バッククォート/`$(`/`<(`/改行）が1つでもあれば skip しない fail-safe 設計（実操作は必ず検知）。
5. **regex 厳格化** `pr-guard.sh`/`block-merge-without-review.sh`: ルーズな `gh.*pr.*create` を `gh[[:space:]]+pr[[:space:]]+create` へ。
6. **commit 委任緩和** `git-commit-guard.sh`: メインエージェントの feature ブランチ直接 commit を許可（detached HEAD ブロック・format/issue/lint は維持）。
7. **サブエージェント免除修正** `context-budget-*.sh`: env が hook サブプロセスに伝播しない問題を、stdin `.agent_id` 検出で実機能化。
8. **Codex sandbox**（リポジトリ外・参考）: `~/.codex/config.toml` を `sandbox_mode = "workspace-write"` + `[sandbox_workspace_write] network_access = true` へ。per-task の danger override は既存 `codex-parallel.sh` が担保。

## レビュー注目点

- 各 hook の **enforcement 後退がないこと**（実 `gh pr create`/`gh pr merge`/`git push --force`/直接main push は依然ブロック）。
- skip の fail-safe 設計（チェーン/プロセス置換で skip しない）。
- SHA-smart 無効化の fail-closed（reviewed_sha 欠落・diff 失敗時は無効化）。

## テスト/確認

- 反証検証: チェーン bypass（`echo x && force-push` 等）→ BLOCK、単独 grep 言及 → SKIP、実操作 → BLOCK、免除（agent_id）→ exit 0、tier 検出失敗 → LIGHT。全て stdin JSON で exit code 検証済み。
- source/deployed MD5 一致、全編集ファイル `bash -n` クリーン。
- code-reviewer: 3ラウンド（round1で実在のチェーンbypass CRITICALを検出→修正、最終 **LGTM**）。
- Codex CLI review: 実行(exit 0)。structured severity 出力は空のため、code-reviewer の3ラウンド精査(round1で実在CRITICAL検出→修正、最終LGTM)を主たる検証とする。

## 既知の follow-up（本PR対象外・別途対応）

- `git-push-guard.sh`/`protect-branches.sh` の枝抽出パーサが `cat <(git push --force origin main)` 等のプロセス置換を検知できない **pre-existing** ギャップ（develop でも exit 0 を確認済み）。別タスクで強化予定。
- 17 hook に重複する skip 述語の共通ヘルパー化。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 変更内容

* **バグ修正**
  * 単一行の参照/検査系コマンドが誤ってブロックされる問題を修正し、安全な参照操作を許可するようにしました。

* **改善**
  * サブエージェント判定を入力JSONのagent_idまで拡張して精度向上。
  * レビュー状態にコミットSHAを記録、ブランチ解決ロジックを強化。
  * ロック状態をプロジェクト側とグローバル側の両方で管理し、レビュー無効化の判定をより正確に。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terisuke/claude-code-skills/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->