### PR TITLE
fix: force-pushガードのプロセス置換バイパス(pre-existing)を修正

### DIFF
--- a/hooks/git-push-guard.sh
+++ b/hooks/git-push-guard.sh
@@ -6,6 +6,16 @@ set -euo pipefail
 input=$(cat)
 cmd=$(echo "$input" | jq -r '.tool_input.command // ""')
 
+# mentions_protected_ref <cmd> <branch>
+# Returns 0 if <branch> appears as a push ref token anywhere in <cmd>, tolerant
+# of process substitution `<(...)`, command chains, redirects and refspec forms
+# (origin main / :main / refs/heads/main). Position-independent so a force push
+# wrapped as `cat <(git push --force origin main)` can no longer hide the
+# protected branch from extraction (parser-gap fix).
+mentions_protected_ref() {
+  printf '%s' "$1" | grep -qE "(^|[^A-Za-z0-9._/-])(refs/heads/)?$2([^A-Za-z0-9._/-]|$)"
+}
+
 # --- 0. Early exit: only run on git push commands (Issue #150) ---
 # Without this guard, black/ruff checks in section 3 block ALL Bash commands,
 # creating an unrecoverable deadlock where even `black .` is blocked.
@@ -20,7 +30,7 @@ if echo "$cmd" | grep -qE 'git\s+push\b.*(--(force|force-with-lease)\b|-f\b)' ||
    echo "$cmd" | grep -qE 'git\s+push\s+-[a-zA-Z]*f'; then
     # Check explicit branch names in the command
     for branch in develop main master; do
-        if echo "$cmd" | grep -qE "(^|[[:space:]])${branch}([[:space:]]|$|:)"; then
+        if mentions_protected_ref "$cmd" "$branch"; then
             cat >&2 <<ERRMSG
 [BLOCK] 共有ブランチ '${branch}' への force push を検出
 
@@ -63,7 +73,7 @@ fi
 for branch in develop main master; do
     if echo "$cmd" | grep -qE "git\s+push\s+.*\b${branch}\b" && \
        ! echo "$cmd" | grep -qE "(--delete|:${branch})"; then
-        push_target=$(echo "$cmd" | grep -oE "push\s+[^|;&]*" | sed 's/push\s*//' | sed 's/\s*-[a-zA-Z-]*//g' | xargs)
+        push_target=$(echo "$cmd" | grep -oE "push\s+[^|;&)<>]*" | sed 's/push\s*//' | sed 's/\s*-[a-zA-Z-]*//g' | xargs)
         refspec=$(echo "$push_target" | awk '{print $NF}')
         if [ "$refspec" = "$branch" ] || echo "$refspec" | grep -qE ":${branch}$"; then
             echo "[BLOCKED] Direct push to '${branch}'. Use PR instead." >&2

--- a/hooks/protect-branches.sh
+++ b/hooks/protect-branches.sh
@@ -72,6 +72,14 @@ is_force_push() {
   return 1
 }
 
+# mentions_protected_ref <cmd> <branch>: position-independent protected-branch
+# detection (mirror of git-push-guard.sh). Catches force push hidden in process
+# substitution `<(...)`, command chains, or redirects where token-position
+# extraction fails.
+mentions_protected_ref() {
+  printf '%s' "$1" | grep -qE "(^|[^A-Za-z0-9._/-])(refs/heads/)?$2([^A-Za-z0-9._/-]|$)"
+}
+
 extract_push_remote() {
   local push_cmd="$1"
   # Strip 'git push', then remove all flags, take first positional arg
@@ -114,39 +122,56 @@ if echo "$cmd" | grep -qE '\bgit\s+push\b' && echo "$cmd" | grep -qE '\s--(all|m
   exit 2
 fi
 
-# --- Check 0b: Force push guard (fork-aware) (#192, #195) ---
+# --- Check 0b: Force push guard (fork-aware) (#192, #195, parser-gap fix) ---
 if echo "$cmd" | grep -qE '\bgit\s+push\b' && is_force_push "$cmd"; then
-  push_remote=$(extract_push_remote "$cmd")
-  push_remote="${push_remote:-origin}"
+  # Position-independent protected-branch detection: a protected branch ref
+  # appearing anywhere in a force-push command is caught, even when hidden in
+  # process substitution `cat <(git push --force origin main)`, command chains
+  # `echo x && git push --force origin main`, or redirects. The previous
+  # token-position extraction assumed `git push` led the command and mis-read
+  # the branch (e.g. `main)`), allowing the push through.
+  matched_protected=""
+  for pb in $PROTECTED_BRANCHES; do
+    if mentions_protected_ref "$cmd" "$pb"; then
+      matched_protected="$pb"
+      break
+    fi
+  done
 
   if is_fork_workflow; then
-    # Standard fork layout: origin=fork, upstream=parent
-    # Block force push to upstream (parent repo)
-    if [ "$push_remote" = "upstream" ]; then
-      echo "[BLOCK] upstream (親リポジトリ) への force push を検出。" >&2
-      echo "  fork ワークフローでは upstream への force push は禁止です。" >&2
-      echo "  WHY: 親リポジトリの履歴を書き換えると他の contributor に影響します。" >&2
+    push_remote=$(extract_push_remote "$cmd")
+    push_remote="${push_remote:-origin}"
+    # Standard fork layout: origin=fork, upstream=parent.
+    # Block force push to the parent (upstream remote or upstream token), and
+    # block any protected branch ref as a safety net against obfuscated targets.
+    if [ "$push_remote" = "upstream" ] \
+       || printf '%s' "$cmd" | grep -qE '(^|[^A-Za-z0-9._/-])upstream([^A-Za-z0-9._/-]|$)' \
+       || [ -n "$matched_protected" ]; then
+      echo "[BLOCK] upstream (親リポジトリ) / 保護ブランチ への force push を検出。" >&2
+      echo "  fork ワークフローでは upstream・保護ブランチへの force push は禁止です。" >&2
+      echo "  WHY: 親リポジトリ/共有ブランチの履歴を書き換えると他の contributor に影響します。" >&2
       echo "  FIX: PR 経由でマージしてください。" >&2
       exit 2
-    else
-      # origin = fork, allow with warning
-      echo "[WARN] fork リモート '${push_remote}' への force push を検出。" >&2
-      echo "  自分の fork への force push は許可しますが、注意してください。" >&2
     fi
+    # origin = fork, allow with warning
+    echo "[WARN] fork リモート '${push_remote}' への force push を検出。" >&2
+    echo "  自分の fork への force push は許可しますが、注意してください。" >&2
   else
-    # Non-fork: block force push to protected branches
+    # Non-fork: explicit protected branch ref anywhere -> block.
+    if [ -n "$matched_protected" ]; then
+      echo "[BLOCK] 保護ブランチ '${matched_protected}' への force push を検出。" >&2
+      echo "  WHY: 共有ブランチの履歴書き換えは禁止です。" >&2
+      echo "  FIX: feature ブランチで作業し、PR 経由でマージしてください。" >&2
+      exit 2
+    fi
+    # No explicit protected ref: fall back to current branch (implicit push).
     target_branch=$(extract_push_branch "$cmd")
     if [ -z "$target_branch" ]; then
       target_branch=$(git branch --show-current 2>/dev/null || echo "")
     fi
-    # If no explicit remote, check tracking remote (#195)
-    push_remote_explicit=$(extract_push_remote "$cmd")
-    if [ -z "$push_remote_explicit" ]; then
-      push_remote=$(git config "branch.${target_branch}.remote" 2>/dev/null || echo "origin")
-    fi
     for branch in $PROTECTED_BRANCHES; do
       if [ "$target_branch" = "$branch" ]; then
-        echo "[BLOCK] 保護ブランチ '${branch}' への force push を検出。" >&2
+        echo "[BLOCK] 保護ブランチ '${branch}' への force push を検出（暗黙的ブランチ）。" >&2
         echo "  WHY: 共有ブランチの履歴書き換えは禁止です。" >&2
         echo "  FIX: feature ブランチで作業し、PR 経由でマージしてください。" >&2
         exit 2
@@ -175,7 +200,7 @@ done
 
 # --- Check 3: Remote branch deletion (git push origin :branch) ---
 for branch in $PROTECTED_BRANCHES; do
-    if echo "$cmd" | grep -qE "push\s+\S+\s+:${branch}(\s|$)"; then
+    if echo "$cmd" | grep -qE "push\s+\S+\s+:${branch}([^A-Za-z0-9._/-]|$)"; then
         echo "[Hook] BLOCKED: Protected branch '${branch}' cannot be deleted from remote." >&2
         echo "[Hook] develop/main/master branches are tied to CI/CD and must NEVER be deleted." >&2
         exit 2

--- a/tests/test-push-guard-process-substitution-bypass.sh
+++ b/tests/test-push-guard-process-substitution-bypass.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# =============================================================================
+# Regression test: process-substitution / chain / redirect force-push bypass
+# =============================================================================
+# Pre-existing parser gap: git-push-guard.sh and protect-branches.sh extracted
+# the push remote/branch position-dependently, assuming `git push` is the first
+# token. Wrapping the push in a process substitution `cat <(git push --force
+# origin main)` (or a chain / redirect) shifted the tokens, so the protected
+# branch was mis-extracted (e.g. `main)` instead of `main`) and the force push
+# was ALLOWED (exit 0).
+#
+# Falsifiability: run this against the UNFIXED hooks and the BYPASS cases must
+# FAIL (hook exits 0 where 2 is expected) — proving the test detects the bug.
+# After the fix, every case must PASS.
+#
+# Trigger strings live ONLY inside this file and are fed to the hooks as JSON on
+# stdin via jq; the test never executes any git command, so host PreToolUse
+# guards on the runner's own Bash calls are never triggered.
+#
+# Usage:
+#   bash tests/test-push-guard-process-substitution-bypass.sh            # source hooks
+#   HOOK_DIR=~/.claude/hooks bash tests/test-...-bypass.sh               # deployed hooks
+# =============================================================================
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK_DIR="${HOOK_DIR:-$SCRIPT_DIR/../hooks}"
+PUSH_GUARD="$HOOK_DIR/git-push-guard.sh"
+PROTECT="$HOOK_DIR/protect-branches.sh"
+PASS=0
+FAIL=0
+
+# test_case <hook> <name> <expected_exit> <command>
+test_case() {
+  local hook="$1" name="$2" expected_exit="$3" cmd="$4"
+  local json actual_exit=0
+  json=$(jq -n --arg cmd "$cmd" '{tool_input:{command:$cmd}}')
+  printf '%s' "$json" | bash "$hook" >/dev/null 2>&1 || actual_exit=$?
+  if [ "$actual_exit" -eq "$expected_exit" ]; then
+    echo "  PASS: $name (exit $actual_exit)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name (expected=$expected_exit actual=$actual_exit)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== HOOK_DIR: $HOOK_DIR ==="
+echo ""
+echo "### git-push-guard.sh ###"
+
+echo "--- BYPASS: force push hidden in process substitution / chain / redirect ---"
+test_case "$PUSH_GUARD" "procsub force main"            2 'cat <(git push --force origin main)'
+test_case "$PUSH_GUARD" "procsub force-with-lease dev"  2 'cat <(git push --force-with-lease origin develop)'
+test_case "$PUSH_GUARD" "procsub force master"          2 'diff <(git push --force origin master) /dev/null'
+test_case "$PUSH_GUARD" "chain && force main"           2 'echo ok && git push --force origin main'
+test_case "$PUSH_GUARD" "chain ; force develop"         2 'true ; git push --force origin develop'
+test_case "$PUSH_GUARD" "redirect > force main"         2 'git push --force origin main > /tmp/x'
+test_case "$PUSH_GUARD" "procsub direct (non-force) main" 2 'cat <(git push origin main)'
+
+echo "--- Baseline (already detected pre-fix) ---"
+test_case "$PUSH_GUARD" "plain force main"              2 'git push --force origin main'
+test_case "$PUSH_GUARD" "plain force-with-lease master" 2 'git push --force-with-lease origin master'
+
+echo "--- Must stay ALLOWED (feature branches, no false positives) ---"
+test_case "$PUSH_GUARD" "feature force-with-lease"      0 'git push --force-with-lease origin feat/test'
+test_case "$PUSH_GUARD" "feature force"                 0 'git push --force origin feat/x'
+test_case "$PUSH_GUARD" "normal feature push"           0 'git push origin feat/test'
+test_case "$PUSH_GUARD" "feat/main-fix not 'main'"      0 'git push --force origin feat/main-fix'
+test_case "$PUSH_GUARD" "mainline not 'main'"           0 'git push --force origin mainline'
+test_case "$PUSH_GUARD" "develop-2 not 'develop'"       0 'git push --force origin develop-2'
+
+echo ""
+echo "### protect-branches.sh ###"
+
+echo "--- BYPASS: force push hidden in process substitution / chain / redirect ---"
+test_case "$PROTECT" "procsub force main"               2 'cat <(git push --force origin main)'
+test_case "$PROTECT" "procsub force develop"            2 'cat <(git push --force origin develop)'
+test_case "$PROTECT" "chain && force main"              2 'echo ok && git push --force origin main'
+test_case "$PROTECT" "redirect > force master"          2 'git push --force origin master > /tmp/x'
+test_case "$PROTECT" "procsub colon-delete main"        2 'cat <(git push origin :main)'
+
+echo "--- Baseline (already detected pre-fix) ---"
+test_case "$PROTECT" "plain force develop"              2 'git push --force origin develop'
+test_case "$PROTECT" "force-with-lease HEAD:develop"    2 'git push --force-with-lease origin HEAD:develop'
+test_case "$PROTECT" "remote delete develop"           2 'git push origin --delete develop'
+test_case "$PROTECT" "colon delete develop"            2 'git push origin :develop'
+
+echo "--- Must stay ALLOWED (feature branches, no false positives) ---"
+test_case "$PROTECT" "feature force"                    0 'git push --force origin feat/test'
+test_case "$PROTECT" "normal feature push"             0 'git push origin feat/test'
+test_case "$PROTECT" "feat/main-fix not 'main'"        0 'git push --force origin feat/main-fix'
+test_case "$PROTECT" "mainline not 'main'"             0 'git push --force origin mainline'
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## 概要
protected-branch ガード (`git-push-guard.sh` / `protect-branches.sh`) に pre-existing なパーサギャップがあり、`cat <(git push --force origin main)` のようにプロセス置換 `<(...)` の内側に force push を埋め込むと、コマンド先頭前提の位置依存トークン抽出が remote/branch を誤抽出し、保護ブランチ(main)への force push を検知できず exit 0（許可）になっていた。develop レベルの pre-existing バグで、review-gate 緩和 PR #232 とは独立。

develop を本ブランチにマージ済みで、#232 の inspection-skip / 安全 allow-list / `<>` 演算子ガードと本修正の `mentions_protected_ref` を両立。

## 原因
両 hook が「`git push` がコマンド先頭にある」前提で branch/remote を抽出していたため、末尾の `)` が branch トークンに付着（`main` → `main)`）して保護ブランチ名と一致せず、`extract_push_branch` / refspec 抽出が `<(` や `main)` を拾っていた。チェーン (`&& / ;`)・リダイレクト経由でも同様に誤抽出。

## 修正
- 位置非依存ヘルパー `mentions_protected_ref()` を両 hook に追加:
  `grep -qE "(^|[^A-Za-z0-9._/-])(refs/heads/)?<branch>([^A-Za-z0-9._/-]|$)"`
  空白・プロセス置換 `)`・refspec `:`・チェーン・リダイレクトを境界として保護ブランチ ref を検出。
- `/` と `-` は境界から除外 → `feat/main-fix`・`mainline`・`develop-2` 等は誤検知しない。
- feature ブランチへの `--force-with-lease` 許容は維持。暗黙 push の current-branch fallback も維持。
- 同クラスの抽出ギャップ（git-push-guard の直 push 抽出 `)<>` 停止、protect-branches の colon-delete 境界）も併せて修正。

## 検証（反証可能性）
新規回帰テスト `tests/test-push-guard-process-substitution-bypass.sh`（トリガー語をファイル内に隔離し jq→stdin JSON で検証）。
- **修正前**: 8 件の bypass を検出（本来 exit 2 すべきが exit 0 = falsifiability 成立）
- **修正後**: 28 passed / 0 failed（source・deployed 両方で確認）
- 既存 `tests/test-issue-195.sh`: 13 passed / 0 failed（回帰なし）
- #232 の inspection-skip 維持（単独 grep は SKIP、awk は非 skip）を確認。

## 既知のトレードオフ
「保護ブランチトークンが出現したらブロック」方針のため、コミットメッセージや doc 生成スクリプト等で当該文字列をコマンドラインに直書きすると hook が発火する（安全側＝偽陽性 > 偽陰性を許容）。回避策は `-F` / `--body-file` でファイル経由にすること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #233


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * 保護されたブランチへの不正なプッシュ検出をより堅牢に改善
  * フォーク環境でのフォースプッシュ対策を強化し、位置に依存しない確実な検出を実現
  * コマンド文字列の解析精度向上により誤検知を削減

* **Tests**
  * プッシュガード機能の回帰テストを追加

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terisuke/claude-code-skills/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->