### PR TITLE
fix(review): classify-reviewのstate更新経路を修正

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 [Claude Code](https://claude.com/claude-code)（Anthropic 公式 CLI）のためのスキル・ルール・フック集です。
 
-27 のカスタムスキル、72 の hook スクリプト（64 シェル + 7 ゲートモードモジュール + 1 Python）、6 つのルールセット、6 つのユーティリティスクリプトを含む、本番環境レベルの Claude Code 設定を提供します。
+27 のカスタムスキル、72 の hook スクリプト（64 シェル + 7 ゲートモードモジュール + 1 Python）、6 つのルールセット、8 つのユーティリティスクリプトを含む、本番環境レベルの Claude Code 設定を提供します。
 
 [English](README.md) | **日本語**
 
@@ -24,7 +24,7 @@ claude-code-skills/
 ├── skills/           # 27 カスタムスキル定義 (SKILL.md + scripts + references)
 ├── rules/            # 6 グローバルルール (コーディング規約, Git, 品質, テスト, 委任, hookデプロイ)
 ├── hooks/            # 72 hook スクリプト (64 シェル + 7 ゲートモードモジュール + 1 Python) (品質ゲート, 安全ガード, ワークフロー強制)
-├── scripts/          # 6 ユーティリティ (Codex 連携, PR レビュー, コンテキスト監視)
+├── scripts/          # 8 ユーティリティ (Codex 連携, PR レビュー, コンテキスト監視)
 ├── setup.sh          # ワンコマンドインストール
 ├── settings.json     # 設定テンプレート (パス等サニタイズ済み)
 ├── README.md         # 英語版 README
@@ -188,6 +188,8 @@ hook スクリプトが委任ルールを自動的に強制します:
 | `codex-parallel.sh` | 単一タスク Codex 実行（sandbox 自動選択） |
 | `codex-orchestrate.sh` | マルチタスク並列実行（JSON/CSV 入力、worktree 分離） |
 | `check-pr-reviews.sh` | PR レビュータイムスタンプと最新 push の照合 |
+| `classify-review-state.sh` | `/classify-review` 偽陽性判定結果の検証済み state 更新 |
+| `review-comment-set-hash.sh` | 現在の GitHub レビューコメント集合 hash の決定論的計算 |
 | `verify-pr-review.sh` | マージ前のレビューカバレッジ検証 |
 | `context-monitor.py` | コンテキストウィンドウ使用量とトークン消費の監視 |
 
@@ -347,8 +349,8 @@ P2-MEDIUM Issue #136-#147 も後続 PR で解決済みです。現在のオー�
 - `audit-docker-build-args.sh` — Docker build args の http:// チェック
 - `block-local-hooks-write.sh` — settings.local.json によるグローバル hook 上書きを防止
 - `block-codex-mcp.sh` — Codex MCP 使用をブロック、CLI 経由のみ強制 (PreToolUse)
-- `block-state-file-tampering.sh` — AI による状態ファイル自己改ざん防止 (Write/Edit)
-- `block-state-file-tampering-bash.sh` — AI による状態ファイル自己改ざん防止 (Bash)
+- `block-state-file-tampering.sh` — `pending-review-comments.json` を含む gate state の自己改ざん防止 (Write/Edit)
+- `block-state-file-tampering-bash.sh` — `pending-review-comments.json` を含む gate state の自己改ざん防止 (Bash)
 - `protect-linter-config.sh` — リンター設定の不正変更を防止
 
 ### コンテキスト予算管理

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A curated collection of skills, rules, and hooks for [Claude Code](https://claude.com/claude-code) — Anthropic's official CLI for Claude.
 
-This repository provides a production-ready Claude Code configuration with 27 custom skills, 72 hook scripts (64 shell + 7 gate-mode modules + 1 Python), 6 rule sets, 6 utility scripts, and integration with third-party skill frameworks.
+This repository provides a production-ready Claude Code configuration with 27 custom skills, 72 hook scripts (64 shell + 7 gate-mode modules + 1 Python), 6 rule sets, 8 utility scripts, and integration with third-party skill frameworks.
 
 > **Design Philosophy**: This project implements the principles from [Harness Engineering Best Practices 2026](https://nyosegawa.com/posts/harness-engineering-best-practices-2026/) — deterministic quality gates via hooks, pointer-based documentation (ADR-002), and the feedback speed hierarchy (PostToolUse > pre-commit > CI > human review).
 
@@ -26,7 +26,7 @@ claude-code-skills/
 ├── skills/           # 27 custom skill definitions (SKILL.md + scripts + references)
 ├── rules/            # 6 global rule files (coding-style, git-workflow, quality, testing, delegation, hook-deployment)
 ├── hooks/            # 72 hook scripts (64 shell + 7 gate-mode modules + 1 Python) (quality gates, safety guards, workflow enforcement)
-├── scripts/          # 6 utility scripts (Codex orchestration, PR review, context monitoring)
+├── scripts/          # 8 utility scripts (Codex orchestration, PR review, context monitoring)
 ├── setup.sh          # One-command installation
 ├── settings.json     # Template settings (sanitized, no personal paths)
 └── README.md
@@ -189,6 +189,8 @@ Task received
 | `codex-parallel.sh` | Single-task Codex execution with auto sandbox selection |
 | `codex-orchestrate.sh` | Multi-task parallel execution via worktrees (JSON or CSV input) |
 | `check-pr-reviews.sh` | Verify PR review timestamps against latest push |
+| `classify-review-state.sh` | Verified updater for `/classify-review` false-positive results |
+| `review-comment-set-hash.sh` | Deterministic current GitHub review comment-set hash |
 | `verify-pr-review.sh` | Validate review coverage before merge |
 | `delivery_score.py` | Quantitative delivery quality scoring (hook coverage, CI, reviews) |
 | `context-monitor.py` | Monitor context window usage and token consumption |
@@ -353,8 +355,8 @@ P2-MEDIUM issues #136-#147 resolved in subsequent PRs. Current open items:
 - `audit-docker-build-args.sh` — Check for http:// in Docker build args
 - `block-local-hooks-write.sh` — Prevent settings.local.json from overriding global hooks
 - `block-codex-mcp.sh` — Block Codex MCP usage, enforce CLI-only (PreToolUse)
-- `block-state-file-tampering.sh` — Prevent AI self-bypass of state files (Write/Edit)
-- `block-state-file-tampering-bash.sh` — Prevent AI self-bypass of state files (Bash)
+- `block-state-file-tampering.sh` — Prevent AI self-bypass of gate state files, including `pending-review-comments.json` (Write/Edit)
+- `block-state-file-tampering-bash.sh` — Prevent AI self-bypass of gate state files, including `pending-review-comments.json` (Bash)
 - `protect-linter-config.sh` — Prevent unauthorized linter config modifications
 
 ### Context Budget Management

--- a/docs/requirements/design-requirements-2026-03-24.md
+++ b/docs/requirements/design-requirements-2026-03-24.md
@@ -163,8 +163,8 @@ AI駆動開発（Claude Code + Codex CLI）を用いて、**プロダクショ�
 ### 5.1 state file保護
 - block-state-file-tampering.sh (Write/Edit PreToolUse)
 - block-state-file-tampering-bash.sh (Bash PreToolUse)
-- 保護対象: review-status.json, pr-review-lock.json, pr-review-read.json, context-budget.json, factcheck-status.json, rebase-session.json
-- 正規更新ルート: PostToolUse hook スクリプトのみ
+- 保護対象: review-status.json, pending-review-comments.json, pr-review-lock.json, pr-review-read.json, context-budget.json, factcheck-status.json, rebase-session.json, pr-gate-diagnostic.log
+- 正規更新ルート: hook スクリプトまたは検証済み utility script のみ
 
 ### 5.2 hookスキップ禁止
 - --no-verify 等のフラグ禁止

--- a/hooks/block-state-file-tampering-bash.sh
+++ b/hooks/block-state-file-tampering-bash.sh
@@ -27,7 +27,8 @@ if [[ -z "$CMD" ]]; then
 fi
 
 # 保護対象のファイル名パターン
-PROTECTED="review-status\.json|pr-review-lock\.json|pr-review-read\.json|context-budget\.json|factcheck-status\.json|rebase-session\.json|pr-gate-diagnostic\.log"
+PROTECTED="review-status\.json|pending-review-comments\.json|pr-review-lock\.json|pr-review-read\.json|context-budget\.json|factcheck-status\.json|rebase-session\.json|pr-gate-diagnostic\.log"
+PROTECTED_STEMS="review-status|pending-review-comments|pr-review-lock|pr-review-read|context-budget|factcheck-status|rebase-session|pr-gate-diagnostic"
 
 # --- gh CLI 免除 (Issue #179) ---
 # gh コマンドはGitHub API操作であり、ローカルファイルへの書き込みではない
@@ -36,10 +37,53 @@ PROTECTED="review-status\.json|pr-review-lock\.json|pr-review-read\.json|context
 # 多行コマンドは免除しない（2行目に書込みを隠せるため）
 # 注意: クォート内の ; や && も検出される（fail-closed設計）
 GH_LINE_COUNT=$(echo "$CMD" | wc -l | tr -d ' ')
+GH_LOCAL_WRITE='(release\s+download|run\s+download|repo\s+clone|gist\s+clone|codespace\s+cp|--dir|-D|--output|-o|--clobber)'
 if [[ "$GH_LINE_COUNT" -eq 1 ]] && \
    echo "$CMD" | grep -qE '^\s*gh\s' && \
-   ! echo "$CMD" | grep -qE ';|&&|\|\|'; then
+   echo "$CMD" | grep -qE '(\.claude/state|~/.claude/state|\$HOME/.claude/state)' && \
+   echo "$CMD" | grep -qE "$PROTECTED_STEMS" && \
+   echo "$CMD" | grep -qE "$GH_LOCAL_WRITE"; then
+  cat >&2 <<ERRMSG
+
+⛔ [BLOCKED] gh コマンドによる状態ファイル書き込みの疑い
+
+コマンド（先頭200文字）: $(echo "$CMD" | head -c 200)
+理由: gh のローカル書き込み系サブコマンド/オプションで保護 state path が指定されています。
+
+ERRMSG
+  exit 2
+fi
+
+if [[ "$GH_LINE_COUNT" -eq 1 ]] && \
+   echo "$CMD" | grep -qE '^\s*gh\s' && \
+   ! echo "$CMD" | grep -qE '[<>|;`]|&&|\|\||\$\('; then
   exit 0
+fi
+
+# --- 書き込みパターン（広範に検出） ---
+WRITE_PATTERNS='(>|>>|json\.dump|json\.dumps|echo\s.*>|printf\s.*>|tee\s|sponge\s|sed\s+-i|write_text|open\s*\(.*["\x27]w|open\s*\(.*["\x27]a|\.write\s*\(|Path\s*\(.*write_|truncate|dd\s+of=|cp\s+.*\.(json|log)|mv\s+.*\.(json|log)|ln\s+-[sf]|eval\s|exec\s+[0-9]*>|curl\s.*-o|wget\s.*-O|ruby\s+-e|perl\s+-e|perl\s+-i|node\s+-e|deno\s+(eval|run)|php\s+-r)'
+
+# 書き込み判定用: 既知の安全なリダイレクトのみを除去
+# 除去対象: 2>/dev/null, >/dev/null（stderr/stdout抑制）, 2>&1, 2>&2（fd複製）
+# 注意: 以前の広範パターン s/[0-9]*>[>&\/][^ ]*//g は >/absolute/path も除去し
+# cat file >/path/to/protected.json のバイパスを許していた (Codex P1)
+CMD_FOR_WRITE_CHECK=$(echo "$CMD" | sed -E 's/[0-9]*>\/dev\/null//g; s/[0-9]*>&[0-9]+//g')
+
+# Literal filename splitting bypass guard:
+#   p=.claude/state/pending-review-comments; printf '{}' > "$p".json
+# The full filename never appears, so protect state-dir + protected stem writes too.
+if echo "$CMD" | grep -qE '(\.claude/state|~/.claude/state|\$HOME/.claude/state)' && \
+   echo "$CMD" | grep -qE "$PROTECTED_STEMS" && \
+   echo "$CMD_FOR_WRITE_CHECK" | grep -qE "$WRITE_PATTERNS"; then
+  cat >&2 <<ERRMSG
+
+⛔ [BLOCKED] Bash経由の状態ファイル改ざんを検出
+
+コマンド（先頭200文字）: $(echo "$CMD" | head -c 200)
+理由: 状態ファイル名を変数/連結で分割した書き込みの可能性があります。
+
+ERRMSG
+  exit 2
 fi
 
 # コマンド全体（多行含む）で保護対象ファイルを検出
@@ -48,9 +92,6 @@ if echo "$CMD" | grep -qE "$PROTECTED"; then
   # --- 監査ログ: 保護ファイル参照を全て記録（allow/block問わず） ---
   AUDIT_LOG="${HOME}/.claude/state/tampering-audit.log"
   echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) CMD=$(echo "$CMD" | head -c 300 | tr '\n' '\\n')" >> "$AUDIT_LOG" 2>/dev/null || true
-
-  # --- 書き込みパターン（広範に検出） ---
-  WRITE_PATTERNS='(>|>>|json\.dump|json\.dumps|echo\s.*>|printf\s.*>|tee\s|sponge\s|sed\s+-i|write_text|open\s*\(.*["\x27]w|open\s*\(.*["\x27]a|\.write\s*\(|Path\s*\(.*write_|truncate|dd\s+of=|cp\s+.*\.(json|log)|mv\s+.*\.(json|log)|ln\s+-[sf]|eval\s|exec\s+[0-9]*>|curl\s.*-o|wget\s.*-O|ruby\s+-e|perl\s+-e|perl\s+-i|node\s+-e|deno\s+(eval|run)|php\s+-r)'
 
   # --- read-only allowlistパターン ---
   # 単純な読み取りコマンドのみ許可（1行コマンド限定）
@@ -62,12 +103,6 @@ if echo "$CMD" | grep -qE "$PROTECTED"; then
   fi
 
   READ_ONLY_PATTERNS='^\s*(cat|jq(\s+-[re]+)*|less|head|tail|wc|file|stat|md5sum|sha256sum|diff|git\s+(log|show|diff|status|ls-files|rev-parse|branch|remote|tag|describe|shortlog|blame|commit|add|push|pull|fetch|merge|rebase|cherry-pick|stash)|gh|grep|rg|find|which|type|command|test)\s'
-
-  # 書き込み判定用: 既知の安全なリダイレクトのみを除去
-  # 除去対象: 2>/dev/null, >/dev/null（stderr/stdout抑制）, 2>&1, 2>&2（fd複製）
-  # 注意: 以前の広範パターン s/[0-9]*>[>&\/][^ ]*//g は >/absolute/path も除去し
-  # cat file >/path/to/protected.json のバイパスを許していた (Codex P1)
-  CMD_FOR_WRITE_CHECK=$(echo "$CMD" | sed -E 's/[0-9]*>\/dev\/null//g; s/[0-9]*>&[0-9]+//g')
 
   # 判定: read-only AND NOT compound AND NOT multiline AND NOT write → 許可
   # 全てのshell複合演算子 (|, ||, &&, ;) をブロック
@@ -108,6 +143,7 @@ ERRMSG
 
 正しい方法:
   - review-status.json → code-reviewer実行 → record-code-review.sh が自動更新
+  - pending-review-comments.json → inject-claude-review-helper.py / classify-review-state.sh が自動更新
   - pr-review-lock.json → git push → pr-ci-review-gate.sh が自動設定
   - context-budget.json → context-budget-reset.sh がセッション開始時に初期化
 

--- a/hooks/block-state-file-tampering.sh
+++ b/hooks/block-state-file-tampering.sh
@@ -23,6 +23,7 @@ BASENAME=$(basename "$FILE_PATH")
 # 保護対象の状態ファイル一覧
 PROTECTED_FILES=(
   "review-status.json"
+  "pending-review-comments.json"
   "pr-review-lock.json"
   "pr-review-read.json"
   "context-budget.json"
@@ -43,6 +44,7 @@ for protected in "${PROTECTED_FILES[@]}"; do
 
 正しい方法:
   - review-status.json → code-reviewer実行後に record-code-review.sh が自動更新
+  - pending-review-comments.json → inject-claude-review-helper.py / classify-review-state.sh が自動更新
   - pr-review-lock.json → pr-ci-review-gate.sh が POST_PUSH モードで自動設定
   - context-budget.json → context-budget-reset.sh がセッション開始時に初期化
   - rebase-session.json → block-manual-merge-ops.sh が同期rebase許可時に自動記録

--- a/hooks/gate-modes/common.sh
+++ b/hooks/gate-modes/common.sh
@@ -28,6 +28,43 @@ else
 fi
 
 # =========================================================================
+# Helper: verify pending-review-comments.json still matches GitHub comments
+# =========================================================================
+review_comment_set_hash_script() {
+  local common_dir candidate
+  common_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  for candidate in \
+    "$HOME/.claude/scripts/review-comment-set-hash.sh" \
+    "${common_dir}/../../scripts/review-comment-set-hash.sh"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+pending_comment_set_current() {
+  local pending_file="$1"
+  local repo="$2"
+  local pr_number="$3"
+  local head_sha="$4"
+  local state_hash script current_hash
+
+  [[ -f "$pending_file" ]] || return 1
+  [[ -n "$repo" && -n "$pr_number" && -n "$head_sha" ]] || return 1
+
+  state_hash=$(jq -r '.comment_set_hash // ""' "$pending_file" 2>/dev/null || echo "")
+  [[ -n "$state_hash" && "$state_hash" != "null" ]] || return 1
+
+  script="$(review_comment_set_hash_script || true)"
+  [[ -n "$script" ]] || return 1
+
+  current_hash=$(_timeout 30 bash "$script" "$pr_number" "$repo" "$head_sha" 2>/dev/null || echo "")
+  [[ -n "$current_hash" && "$current_hash" == "$state_hash" ]]
+}
+
+# =========================================================================
 # State directory — project-scoped
 # =========================================================================
 if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then

--- a/hooks/gate-modes/pre-merge.sh
+++ b/hooks/gate-modes/pre-merge.sh
@@ -124,6 +124,25 @@ fi
 
 # PRIMARY_LGTM override: Tier 1 trust bypasses Tier 2 severity
 if [[ "$PRIMARY_LGTM" == "true" ]]; then
+  PENDING_FILE="$STATE_DIR/pending-review-comments.json"
+  if [[ -f "$PENDING_FILE" ]] && command -v jq &>/dev/null; then
+    _primary_pr_in_file=$(jq -r '.pr // ""' "$PENDING_FILE" 2>/dev/null || echo "")
+    _primary_head_sha_in_file=$(jq -r '.head_sha // ""' "$PENDING_FILE" 2>/dev/null || echo "")
+    if [[ "$_primary_pr_in_file" == "$PR_NUMBER" ]]; then
+      if [[ -z "$HEAD_SHA" ]]; then
+        echo "🚫 [BLOCKED] PR #${PR_NUMBER}: HEAD SHA を確認できないため pending-review-comments.json を検証できません。" >&2
+        exit 2
+      fi
+      if [[ "$_primary_head_sha_in_file" != "$HEAD_SHA" ]]; then
+        echo "🚫 [BLOCKED] PR #${PR_NUMBER}: pending-review-comments.json が古い HEAD を参照しています。gh pr checks ${PR_NUMBER} を再実行してください。" >&2
+        exit 2
+      fi
+      if ! pending_comment_set_current "$PENDING_FILE" "$REPO" "$PR_NUMBER" "$HEAD_SHA"; then
+        echo "🚫 [BLOCKED] PR #${PR_NUMBER}: pending-review-comments.json が現在のレビューコメント集合と一致しません。gh pr checks ${PR_NUMBER} を再実行してください。" >&2
+        exit 2
+      fi
+    fi
+  fi
   echo "  ℹ️ [pre-merge] Tier 1 LGTM により Tier 2 findings を許可。マージ可。" >&2
   # Still record the review status
   exit 0
@@ -150,19 +169,32 @@ if [[ -f "$PENDING_FILE" ]] && command -v jq &>/dev/null; then
   _pr_in_file=$(jq -r '.pr // ""' "$PENDING_FILE" 2>/dev/null || echo "")
   _head_sha_in_file=$(jq -r '.head_sha // ""' "$PENDING_FILE" 2>/dev/null || echo "")
   # Validate scope: pending-review-comments must match current PR
-  if [[ "$_pr_in_file" == "$PR_NUMBER" ]] && [[ -n "$HEAD_SHA" ]] && [[ "$_head_sha_in_file" == "$HEAD_SHA" ]]; then
-    # Issue #165: Check classification_method — prefer AI classification if available
-    _method=$(jq -r '.classification_method // "regex"' "$PENDING_FILE" 2>/dev/null || echo "regex")
-    if [[ "$_method" == "ai" ]]; then
-      _critical=$(jq -r '.ai_classification.critical // 0' "$PENDING_FILE" 2>/dev/null || echo "0")
-      _high=$(jq -r '.ai_classification.high // 0' "$PENDING_FILE" 2>/dev/null || echo "0")
-    else
-      _critical=$(jq -r '.critical // 0' "$PENDING_FILE" 2>/dev/null || echo "0")
-      _high=$(jq -r '.high // 0' "$PENDING_FILE" 2>/dev/null || echo "0")
+  if [[ "$_pr_in_file" == "$PR_NUMBER" ]]; then
+    if [[ -z "$HEAD_SHA" ]]; then
+      echo "🚫 [BLOCKED] PR #${PR_NUMBER}: HEAD SHA を確認できないため pending-review-comments.json を検証できません。" >&2
+      exit 2
     fi
-    _total=$(jq -r '.total // 0' "$PENDING_FILE" 2>/dev/null || echo "0")
-    if [[ "$_critical" -eq 0 ]] && [[ "$_high" -eq 0 ]] && [[ "$_total" -gt 0 ]]; then
-      PASS_B="yes"
+    if [[ "$_head_sha_in_file" != "$HEAD_SHA" ]]; then
+      echo "🚫 [BLOCKED] PR #${PR_NUMBER}: pending-review-comments.json が古い HEAD を参照しています。gh pr checks ${PR_NUMBER} を再実行してください。" >&2
+      exit 2
+    fi
+    if ! pending_comment_set_current "$PENDING_FILE" "$REPO" "$PR_NUMBER" "$HEAD_SHA"; then
+      echo "🚫 [BLOCKED] PR #${PR_NUMBER}: pending-review-comments.json が現在のレビューコメント集合と一致しません。gh pr checks ${PR_NUMBER} を再実行してください。" >&2
+      exit 2
+    else
+      # Issue #165: Check classification_method — prefer AI classification if available
+      _method=$(jq -r '.classification_method // "regex"' "$PENDING_FILE" 2>/dev/null || echo "regex")
+      if [[ "$_method" == "ai" ]]; then
+        _critical=$(jq -r '.ai_classification.critical // 0' "$PENDING_FILE" 2>/dev/null || echo "0")
+        _high=$(jq -r '.ai_classification.high // 0' "$PENDING_FILE" 2>/dev/null || echo "0")
+      else
+        _critical=$(jq -r '.critical // 0' "$PENDING_FILE" 2>/dev/null || echo "0")
+        _high=$(jq -r '.high // 0' "$PENDING_FILE" 2>/dev/null || echo "0")
+      fi
+      _total=$(jq -r '.total // 0' "$PENDING_FILE" 2>/dev/null || echo "0")
+      if [[ "$_critical" -eq 0 ]] && [[ "$_high" -eq 0 ]] && [[ "$_total" -gt 0 ]]; then
+        PASS_B="yes"
+      fi
     fi
   fi
 fi

--- a/hooks/inject-claude-review-helper.py
+++ b/hooks/inject-claude-review-helper.py
@@ -10,10 +10,14 @@ Handles three scenarios:
 Issue #66 Fix #5: Added head_sha to state file for PR scope validation.
 """
 
+import hashlib
+import fcntl
 import json
+import os
 import re
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass, field
 
 
@@ -34,6 +38,7 @@ class ReviewSummary:
         default_factory=list
     )  # Issue #165: raw data for AI classification
     head_sha: str = ""  # Issue #66 Fix #5: track HEAD SHA for scope validation
+    comment_set_hash: str = ""  # Issue #235: detect same-head review changes
 
 
 def gh_api(path: str) -> list | dict:
@@ -154,6 +159,83 @@ def count_severity(text: str) -> tuple[int, int, int, int]:
     return critical, high, warning, suggestion
 
 
+def raw_comment_entry(
+    *,
+    source: str,
+    user: str,
+    body: str,
+    path: str | None = None,
+    line: str | int | None = None,
+    comment_id: str | int | None = None,
+    updated_at: str | None = None,
+) -> dict:
+    """Build a stable raw comment record for downstream AI classification."""
+    critical, high, warning, suggestion = count_severity(body)
+    entry = {
+        "user": user,
+        "body_preview": body[:500],
+        "source": source,
+        "critical": critical,
+        "high": high,
+        "warning": warning,
+        "suggestion": suggestion,
+    }
+    if path is not None:
+        entry["path"] = path
+    if line is not None:
+        entry["line"] = line
+    if comment_id is not None:
+        entry["comment_id"] = comment_id
+    if updated_at is not None:
+        entry["updated_at"] = updated_at
+    digest_src = json.dumps(entry, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    entry["comment_hash"] = hashlib.sha256(digest_src.encode("utf-8")).hexdigest()
+    return entry
+
+
+def comment_set_hash(raw_comments: list[dict]) -> str:
+    """Hash the review comment set used by severity classification."""
+    digest_src = json.dumps(
+        [
+            {
+                "comment_hash": c.get("comment_hash", ""),
+                "critical": c.get("critical", 0),
+                "high": c.get("high", 0),
+            }
+            for c in raw_comments
+        ],
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(digest_src.encode("utf-8")).hexdigest()
+
+
+def write_json_atomic(path: str, payload: dict) -> None:
+    """Write pending-review state through a shared lock and atomic replace."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    lock_path = f"{path}.lock"
+    with open(lock_path, "w") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=".pending-review-comments.",
+            suffix=".tmp",
+            dir=os.path.dirname(path),
+            text=True,
+        )
+        try:
+            with os.fdopen(fd, "w") as tmp:
+                json.dump(payload, tmp, indent=2, ensure_ascii=False)
+                tmp.write("\n")
+                tmp.flush()
+                os.fsync(tmp.fileno())
+            os.replace(tmp_path, path)
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+        fcntl.flock(lock, fcntl.LOCK_UN)
+
+
 def fetch_reviews(repo: str, pr: str) -> ReviewSummary:
     """Fetch all review data for a PR."""
     summary = ReviewSummary()
@@ -180,6 +262,8 @@ def fetch_reviews(repo: str, pr: str) -> ReviewSummary:
                 "line": c.get("line") or c.get("original_line") or "?",
                 "body": c.get("body", ""),
                 "user": c.get("user", {}).get("login", "?"),
+                "id": c.get("id"),
+                "updated_at": c.get("updated_at"),
             }
         )
 
@@ -205,10 +289,24 @@ def fetch_reviews(repo: str, pr: str) -> ReviewSummary:
         has_review_keyword = any(kw in body_lower for kw in review_keywords)
 
         if is_bot:
-            bot_comments.append({"user": user, "body": body})
+            bot_comments.append(
+                {
+                    "user": user,
+                    "body": body,
+                    "id": c.get("id"),
+                    "updated_at": c.get("updated_at"),
+                }
+            )
             summary.has_claude_review = True
         elif has_review_keyword:
-            human_review_comments.append({"user": user, "body": body})
+            human_review_comments.append(
+                {
+                    "user": user,
+                    "body": body,
+                    "id": c.get("id"),
+                    "updated_at": c.get("updated_at"),
+                }
+            )
 
     if bot_comments:
         summary.issue_comments.append(bot_comments[-1])
@@ -226,35 +324,44 @@ def fetch_reviews(repo: str, pr: str) -> ReviewSummary:
                     {
                         "user": r.get("user", {}).get("login", "?"),
                         "body": f"[{state}] {body}",
+                        "id": r.get("id"),
+                        "updated_at": r.get("submitted_at"),
                     }
                 )
 
-    # Count totals and severity
+    # Count totals. Severity is derived from per-comment raw entries below so
+    # negation-line stripping cannot accidentally hide another comment's finding.
     summary.total = len(summary.inline_comments) + len(summary.issue_comments)
-    all_text = " ".join(
-        c.get("body", "") for c in summary.inline_comments + summary.issue_comments
-    )
-    (summary.critical, summary.high, summary.warning, summary.suggestion) = (
-        count_severity(all_text)
-    )
 
     # Issue #165: Store raw comments for AI classification skill
     for c in summary.inline_comments:
         summary.raw_comments.append(
-            {
-                "user": c.get("user", "?"),
-                "body_preview": c.get("body", "")[:500],
-                "source": "inline",
-            }
+            raw_comment_entry(
+                source="inline",
+                user=c.get("user", "?"),
+                body=c.get("body", ""),
+                path=c.get("path", "?"),
+                line=c.get("line", "?"),
+                comment_id=c.get("id"),
+                updated_at=c.get("updated_at"),
+            )
         )
     for c in summary.issue_comments:
         summary.raw_comments.append(
-            {
-                "user": c.get("user", "?"),
-                "body_preview": c.get("body", "")[:500],
-                "source": "issue_comment",
-            }
+            raw_comment_entry(
+                source="issue_comment",
+                user=c.get("user", "?"),
+                body=c.get("body", ""),
+                comment_id=c.get("id"),
+                updated_at=c.get("updated_at"),
+            )
         )
+
+    summary.critical = sum(int(c.get("critical", 0) or 0) for c in summary.raw_comments)
+    summary.high = sum(int(c.get("high", 0) or 0) for c in summary.raw_comments)
+    summary.warning = sum(int(c.get("warning", 0) or 0) for c in summary.raw_comments)
+    summary.suggestion = sum(int(c.get("suggestion", 0) or 0) for c in summary.raw_comments)
+    summary.comment_set_hash = comment_set_hash(summary.raw_comments)
 
     if summary.total > 0:
         summary.has_any_review = True
@@ -356,11 +463,7 @@ def main() -> None:
     except Exception:
         pass
     if not state_dir:
-        import os
-
         state_dir = os.path.expanduser("~/.claude/state")
-
-    import os
 
     os.makedirs(state_dir, exist_ok=True)
     pending_file = os.path.join(state_dir, "pending-review-comments.json")
@@ -368,23 +471,22 @@ def main() -> None:
     # Issue #66 Fix #5: Include head_sha for scope validation
     # Issue #165: Include raw_comments + classification_method for AI skill
     # Consumers validate that state matches current PR/SHA before trusting it.
-    with open(pending_file, "w") as f:
-        json.dump(
-            {
-                "pr": pr,
-                "repo": repo,
-                "head_sha": summary.head_sha,
-                "total": summary.total,
-                "critical": summary.critical,
-                "high": summary.high,
-                "output": output,
-                "classification_method": "regex",
-                "raw_comments": summary.raw_comments,
-                "ai_classification": None,
-            },
-            f,
-            indent=2,
-        )
+    write_json_atomic(
+        pending_file,
+        {
+            "pr": pr,
+            "repo": repo,
+            "head_sha": summary.head_sha,
+            "comment_set_hash": summary.comment_set_hash,
+            "total": summary.total,
+            "critical": summary.critical,
+            "high": summary.high,
+            "output": output,
+            "classification_method": "regex",
+            "raw_comments": summary.raw_comments,
+            "ai_classification": None,
+        },
+    )
 
     result = {
         "hookSpecificOutput": {

--- a/hooks/inject-claude-review-on-checks.sh
+++ b/hooks/inject-claude-review-on-checks.sh
@@ -39,6 +39,40 @@ print(f'{c}|{h}|{d.get(\"pr\", \"\")}|{d.get(\"head_sha\", \"\")}|{d.get(\"total
 " 2>/dev/null || echo "0|0|||0|regex"
 }
 
+_review_comment_set_hash_script() {
+  local hook_dir candidate
+  hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  for candidate in \
+    "$HOME/.claude/scripts/review-comment-set-hash.sh" \
+    "${hook_dir}/../scripts/review-comment-set-hash.sh"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+_pending_comment_set_current() {
+  local pending_file="$1"
+  local repo="$2"
+  local pr_number="$3"
+  local head_sha="$4"
+  local state_hash script current_hash
+
+  [[ -f "$pending_file" ]] || return 1
+  [[ -n "$repo" && -n "$pr_number" && -n "$head_sha" ]] || return 1
+
+  state_hash=$(jq -r '.comment_set_hash // ""' "$pending_file" 2>/dev/null || echo "")
+  [[ -n "$state_hash" && "$state_hash" != "null" ]] || return 1
+
+  script="$(_review_comment_set_hash_script || true)"
+  [[ -n "$script" ]] || return 1
+
+  current_hash="$(bash "$script" "$pr_number" "$repo" "$head_sha" 2>/dev/null || echo "")"
+  [[ -n "$current_hash" && "$current_hash" == "$state_hash" ]]
+}
+
 input=""
 [[ ! -t 0 ]] && input=$(cat)
 cmd=$(echo "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
@@ -84,15 +118,28 @@ fi
 # =========================================================================
 if echo "$(echo "$cmd" | head -1)" | grep -qE 'gh\s+pr\s+merge'; then
   if [[ -f "$PENDING_FILE" ]]; then
+    MERGE_PR=$(echo "$(echo "$cmd" | head -1)" | grep -oE 'gh\s+pr\s+merge\s+([0-9]+)' | grep -oE '[0-9]+' || echo "")
     REPO=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||' || echo "")
     # Issue #169: Use shared severity reader instead of duplicated python3 one-liners
     IFS='|' read -r CRITICAL HIGH PR PENDING_HEAD_SHA _TOTAL _METHOD <<< "$(_read_severity "$PENDING_FILE")"
 
+    if [[ -n "$MERGE_PR" && -n "$PR" && "$MERGE_PR" != "$PR" ]]; then
+      exit 0
+    fi
+
     if [[ -n "$REPO" ]] && [[ -n "$PR" ]] && [[ -n "$PENDING_HEAD_SHA" ]]; then
       CURRENT_HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha' 2>/dev/null || echo "")
+      if [[ -z "$CURRENT_HEAD_SHA" ]]; then
+        echo "[inject-claude-review] could not resolve current head SHA for PR #${PR}; rerun gh pr checks ${PR}." >&2
+        exit 2
+      fi
       if [[ -n "$CURRENT_HEAD_SHA" ]] && [[ "$PENDING_HEAD_SHA" != "$CURRENT_HEAD_SHA" ]]; then
-        echo "[inject-claude-review] pending-review-comments.json is stale for PR #${PR}; skip merge block." >&2
-        exit 0
+        echo "[inject-claude-review] pending-review-comments.json is stale for PR #${PR}; rerun gh pr checks ${PR}." >&2
+        exit 2
+      fi
+      if [[ -n "$CURRENT_HEAD_SHA" ]] && ! _pending_comment_set_current "$PENDING_FILE" "$REPO" "$PR" "$CURRENT_HEAD_SHA"; then
+        echo "[inject-claude-review] pending-review-comments.json does not match current review comments for PR #${PR}; rerun gh pr checks ${PR}." >&2
+        exit 2
       fi
     fi
 

--- a/hooks/inject-claude-review-on-checks.sh
+++ b/hooks/inject-claude-review-on-checks.sh
@@ -127,7 +127,11 @@ if echo "$(echo "$cmd" | head -1)" | grep -qE 'gh\s+pr\s+merge'; then
       exit 0
     fi
 
-    if [[ -n "$REPO" ]] && [[ -n "$PR" ]] && [[ -n "$PENDING_HEAD_SHA" ]]; then
+    if [[ -n "$REPO" ]] && [[ -n "$PR" ]]; then
+      if [[ -z "$PENDING_HEAD_SHA" ]]; then
+        echo "[inject-claude-review] pending-review-comments.json has no head SHA for PR #${PR}; rerun gh pr checks ${PR}." >&2
+        exit 2
+      fi
       CURRENT_HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha' 2>/dev/null || echo "")
       if [[ -z "$CURRENT_HEAD_SHA" ]]; then
         echo "[inject-claude-review] could not resolve current head SHA for PR #${PR}; rerun gh pr checks ${PR}." >&2

--- a/hooks/task-completion-gate.sh
+++ b/hooks/task-completion-gate.sh
@@ -24,6 +24,41 @@ set -uo pipefail
 export GH_FORCE_TTY=0
 export GH_NO_UPDATE_NOTIFIER=1
 
+_review_comment_set_hash_script() {
+  local hook_dir candidate
+  hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  for candidate in \
+    "$HOME/.claude/scripts/review-comment-set-hash.sh" \
+    "${hook_dir}/../scripts/review-comment-set-hash.sh"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+_pending_comment_set_current() {
+  local pending_file="$1"
+  local repo="$2"
+  local pr_number="$3"
+  local head_sha="$4"
+  local state_hash script current_hash
+
+  [[ -f "$pending_file" ]] || return 1
+  [[ -n "$repo" && -n "$pr_number" && -n "$head_sha" ]] || return 1
+  command -v jq >/dev/null 2>&1 || return 1
+
+  state_hash=$(jq -r '.comment_set_hash // ""' "$pending_file" 2>/dev/null || echo "")
+  [[ -n "$state_hash" && "$state_hash" != "null" ]] || return 1
+
+  script="$(_review_comment_set_hash_script || true)"
+  [[ -n "$script" ]] || return 1
+
+  current_hash="$(bash "$script" "$pr_number" "$repo" "$head_sha" 2>/dev/null || echo "")"
+  [[ -n "$current_hash" && "$current_hash" == "$state_hash" ]]
+}
+
 # Read stdin
 input=""
 if [[ ! -t 0 ]]; then
@@ -176,6 +211,21 @@ PENDING_FILE="$STATE_DIR/pending-review-comments.json"
 if [[ -f "$PENDING_FILE" ]] && command -v jq &>/dev/null; then
   _pr_match=$(jq -r '.pr // ""' "$PENDING_FILE" 2>/dev/null || echo "")
   if [[ "$_pr_match" == "$PR_NUMBER" ]]; then
+    _pending_head_sha=$(jq -r '.head_sha // ""' "$PENDING_FILE" 2>/dev/null || echo "")
+    if [[ "$_pending_head_sha" != "$HEAD_SHA" ]]; then
+      echo "" >&2
+      echo "[task-completion-gate] タスク完了をブロック: PR #${PR_NUMBER} のレビュー状態が古い HEAD を参照しています" >&2
+      echo "  gh pr checks ${PR_NUMBER} を再実行してから完了してください。" >&2
+      echo "" >&2
+      exit 2
+    fi
+    if ! _pending_comment_set_current "$PENDING_FILE" "$REPO" "$PR_NUMBER" "$HEAD_SHA"; then
+      echo "" >&2
+      echo "[task-completion-gate] タスク完了をブロック: PR #${PR_NUMBER} のレビューコメント状態が最新ではありません" >&2
+      echo "  gh pr checks ${PR_NUMBER} を再実行してから完了してください。" >&2
+      echo "" >&2
+      exit 2
+    fi
     _method=$(jq -r '.classification_method // "regex"' "$PENDING_FILE" 2>/dev/null || echo "regex")
     if [[ "$_method" == "ai" ]]; then
       CRITICAL=$(jq -r '.ai_classification.critical // 0' "$PENDING_FILE" 2>/dev/null || echo "0")

--- a/hooks/verify-state-file-integrity.sh
+++ b/hooks/verify-state-file-integrity.sh
@@ -17,7 +17,7 @@ INTEGRITY_FILE="${STATE_DIR}/.integrity-checksums"
 # 整合性チェックファイルがなければ初期化
 if [[ ! -f "$INTEGRITY_FILE" ]]; then
   # 初回実行: ベースラインを作成して次回から検証開始
-  for f in "${STATE_DIR}/review-status.json" "${STATE_DIR}/pr-review-lock.json" "${STATE_DIR}/pr-review-read.json" "${STATE_DIR}/context-budget.json" "${STATE_DIR}/factcheck-status.json" "${STATE_DIR}/rebase-session.json" "${STATE_DIR}/pr-gate-diagnostic.log"; do
+  for f in "${STATE_DIR}/review-status.json" "${STATE_DIR}/pending-review-comments.json" "${STATE_DIR}/pr-review-lock.json" "${STATE_DIR}/pr-review-read.json" "${STATE_DIR}/context-budget.json" "${STATE_DIR}/factcheck-status.json" "${STATE_DIR}/rebase-session.json" "${STATE_DIR}/pr-gate-diagnostic.log"; do
     if [[ -f "$f" ]]; then
       sha=$(shasum -a 256 "$f" 2>/dev/null | cut -d' ' -f1)
       echo "${f}|${sha}" >> "$INTEGRITY_FILE"
@@ -46,7 +46,7 @@ done < "$INTEGRITY_FILE"
 
 # チェックサムを更新（次回比較用）
 true > "$INTEGRITY_FILE"
-for f in "${STATE_DIR}/review-status.json" "${STATE_DIR}/pr-review-lock.json" "${STATE_DIR}/pr-review-read.json" "${STATE_DIR}/context-budget.json" "${STATE_DIR}/factcheck-status.json" "${STATE_DIR}/rebase-session.json" "${STATE_DIR}/pr-gate-diagnostic.log"; do
+for f in "${STATE_DIR}/review-status.json" "${STATE_DIR}/pending-review-comments.json" "${STATE_DIR}/pr-review-lock.json" "${STATE_DIR}/pr-review-read.json" "${STATE_DIR}/context-budget.json" "${STATE_DIR}/factcheck-status.json" "${STATE_DIR}/rebase-session.json" "${STATE_DIR}/pr-gate-diagnostic.log"; do
   if [[ -f "$f" ]]; then
     sha=$(shasum -a 256 "$f" 2>/dev/null | cut -d' ' -f1)
     echo "${f}|${sha}" >> "$INTEGRITY_FILE"

--- a/scripts/classify-review-state.sh
+++ b/scripts/classify-review-state.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# classify-review-state.sh — verified updater for pending-review-comments.json
+#
+# Usage:
+#   bash classify-review-state.sh <PR_NUMBER> <VERDICTS_JSON> [OWNER/REPO]
+#
+# VERDICTS_JSON:
+#   [
+#     {
+#       "index": 0,
+#       "comment_hash": "...",
+#       "verdict": "false_positive|real|unknown",
+#       "reasoning": "..."
+#     }
+#   ]
+#
+# Exit codes:
+#   0: classification saved and CRITICAL/HIGH are now zero
+#   1: invalid input, stale state, or validation failure; state unchanged
+#   2: classification saved but real/unknown CRITICAL/HIGH remain
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: bash classify-review-state.sh <PR_NUMBER> <VERDICTS_JSON> [OWNER/REPO]" >&2
+}
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  usage
+  exit 1
+fi
+
+PR_NUMBER="$1"
+VERDICTS_JSON="$2"
+REPO="${3:-}"
+
+if [[ -z "$PR_NUMBER" || -z "$VERDICTS_JSON" ]]; then
+  usage
+  exit 1
+fi
+
+resolve_project_dir() {
+  if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    printf '%s\n' "$CLAUDE_PROJECT_DIR"
+    return
+  fi
+  git rev-parse --show-toplevel 2>/dev/null || true
+}
+
+PROJECT_DIR="$(resolve_project_dir)"
+if [[ -n "$PROJECT_DIR" ]]; then
+  STATE_DIR="${PROJECT_DIR}/.claude/state"
+else
+  STATE_DIR="${HOME}/.claude/state"
+fi
+
+PENDING_FILE="${STATE_DIR}/pending-review-comments.json"
+if [[ ! -f "$PENDING_FILE" ]]; then
+  echo "ERROR: pending-review-comments.json not found: $PENDING_FILE" >&2
+  exit 1
+fi
+
+if [[ -z "$REPO" ]]; then
+  REPO="$(
+    _PENDING_FILE="$PENDING_FILE" python3 - <<'PY' || true
+import json
+import os
+
+try:
+    with open(os.environ["_PENDING_FILE"]) as f:
+        print(json.load(f).get("repo", ""))
+except Exception:
+    print("")
+PY
+  )"
+fi
+
+if [[ -z "$REPO" ]]; then
+  REPO="$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || true)"
+fi
+
+if [[ -z "$REPO" ]]; then
+  echo "ERROR: repository could not be resolved" >&2
+  exit 1
+fi
+
+HEAD_SHA="$(env -u GH_FORCE_TTY gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha' 2>/dev/null || true)"
+if [[ -z "$HEAD_SHA" ]]; then
+  echo "ERROR: PR #${PR_NUMBER} head SHA could not be resolved for ${REPO}" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASH_SCRIPT="${SCRIPT_DIR}/review-comment-set-hash.sh"
+if [[ ! -f "$HASH_SCRIPT" ]]; then
+  HASH_SCRIPT="${HOME}/.claude/scripts/review-comment-set-hash.sh"
+fi
+if [[ ! -f "$HASH_SCRIPT" ]]; then
+  echo "ERROR: review-comment-set-hash.sh not found" >&2
+  exit 1
+fi
+
+CURRENT_COMMENT_SET_HASH="$(bash "$HASH_SCRIPT" "$PR_NUMBER" "$REPO" "$HEAD_SHA" 2>/dev/null || true)"
+if [[ -z "$CURRENT_COMMENT_SET_HASH" ]]; then
+  echo "ERROR: current review comment set could not be resolved for ${REPO}#${PR_NUMBER}" >&2
+  exit 1
+fi
+
+_PENDING_FILE="$PENDING_FILE" \
+_PR_NUMBER="$PR_NUMBER" \
+_REPO="$REPO" \
+_HEAD_SHA="$HEAD_SHA" \
+_CURRENT_COMMENT_SET_HASH="$CURRENT_COMMENT_SET_HASH" \
+_VERDICTS_JSON="$VERDICTS_JSON" \
+python3 - <<'PY'
+import datetime as dt
+import fcntl
+import json
+import os
+import re
+import tempfile
+import sys
+
+pending_file = os.environ["_PENDING_FILE"]
+pr_number = os.environ["_PR_NUMBER"]
+repo = os.environ["_REPO"]
+head_sha = os.environ["_HEAD_SHA"]
+current_comment_set_hash = os.environ["_CURRENT_COMMENT_SET_HASH"]
+verdicts_text = os.environ["_VERDICTS_JSON"]
+
+
+def fail(message: str, code: int = 1) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def safe_false_positive_comment(comment: dict) -> bool:
+    """Only lines that are themselves severity-zero/negation lines can be cleared."""
+    text = str(comment.get("body_preview", ""))
+    severity_patterns = [
+        r"(?i)\[CRITICAL\]|severity:\s*CRITICAL|\*\*CRITICAL\*\*|^\s*CRITICAL:|>\s*CRITICAL",
+        r"(?i)\[HIGH\]|severity:\s*HIGH|\*\*HIGH\*\*|^\s*HIGH[:\s-]|>\s*HIGH|\bP1\b",
+        r"###\s*Bug:",
+        r"###\s*Security:",
+    ]
+    negation_patterns = [
+        r"(?i)no\s+critical",
+        r"(?i)no\s+high",
+        r"(?i)no\s+critical/high",
+        r"(?i)critical\s*[:=]\s*0",
+        r"(?i)high\s*[:=]\s*0",
+        r"(?i)0\s+critical",
+        r"(?i)0\s+high",
+        r"(?i)critical/high\s*(?:=|:)?\s*0",
+    ]
+    severity_lines = [
+        line
+        for line in text.splitlines()
+        if any(re.search(pattern, line) for pattern in severity_patterns)
+    ]
+    return bool(severity_lines) and all(
+        any(re.search(pattern, line) for pattern in negation_patterns)
+        for line in severity_lines
+    )
+
+
+try:
+    verdicts = json.loads(verdicts_text)
+except Exception as exc:
+    fail(f"invalid verdict JSON: {exc}")
+
+if not isinstance(verdicts, list):
+    fail("verdict JSON must be an array")
+
+lock_path = f"{pending_file}.lock"
+os.makedirs(os.path.dirname(pending_file), exist_ok=True)
+
+with open(lock_path, "w") as lock:
+    fcntl.flock(lock, fcntl.LOCK_EX)
+
+    try:
+        with open(pending_file) as f:
+            state = json.load(f)
+    except Exception as exc:
+        fail(f"could not read pending state: {exc}")
+
+    if str(state.get("pr", "")) != str(pr_number):
+        fail(f"pending state PR mismatch: state={state.get('pr')} requested={pr_number}")
+
+    state_repo = state.get("repo", "")
+    if state_repo and state_repo != repo:
+        fail(f"pending state repo mismatch: state={state_repo} requested={repo}")
+
+    state_head = state.get("head_sha", "")
+    if not state_head:
+        fail("pending state has no head_sha")
+    if state_head != head_sha:
+        fail(f"stale pending state: state={state_head} current={head_sha}")
+
+    state_comment_set_hash = state.get("comment_set_hash", "")
+    if not state_comment_set_hash:
+        fail("pending state has no comment_set_hash; rerun gh pr checks")
+    if state_comment_set_hash != current_comment_set_hash:
+        fail("stale pending review comments; rerun gh pr checks")
+
+    raw_comments = state.get("raw_comments")
+    if not isinstance(raw_comments, list) or not raw_comments:
+        fail("pending state has no raw_comments")
+
+    normalized: dict[int, dict] = {}
+    for item in verdicts:
+        if not isinstance(item, dict):
+            fail("each verdict must be an object")
+        if "index" not in item:
+            fail("verdict is missing index")
+        try:
+            index = int(item["index"])
+        except Exception:
+            fail(f"invalid verdict index: {item.get('index')}")
+        if index < 0 or index >= len(raw_comments):
+            fail(f"verdict index out of range: {index}")
+        if index in normalized:
+            fail(f"duplicate verdict index: {index}")
+
+        expected_hash = raw_comments[index].get("comment_hash", "")
+        if not expected_hash:
+            fail(f"raw_comments[{index}] has no comment_hash; rerun gh pr checks")
+        if item.get("comment_hash") != expected_hash:
+            fail(f"comment_hash mismatch at index {index}")
+
+        verdict = item.get("verdict")
+        if verdict not in ("false_positive", "real", "unknown"):
+            fail(f"invalid verdict at index {index}: {verdict}")
+
+        reasoning = str(item.get("reasoning", "")).strip()
+        if not reasoning:
+            fail(f"verdict at index {index} is missing reasoning")
+
+        normalized[index] = {
+            "index": index,
+            "comment_hash": expected_hash,
+            "user": raw_comments[index].get("user", "?"),
+            "source": raw_comments[index].get("source", "?"),
+            "verdict": verdict,
+            "reasoning": reasoning,
+        }
+
+    state_critical = int(state.get("critical", 0) or 0)
+    state_high = int(state.get("high", 0) or 0)
+    raw_critical = 0
+    raw_high = 0
+    for comment in raw_comments:
+        raw_critical += int(comment.get("critical", 0) or 0)
+        raw_high += int(comment.get("high", 0) or 0)
+
+    if raw_critical != state_critical or raw_high != state_high:
+        fail(
+            "raw comment severity does not match top-level state; rerun gh pr checks "
+            f"(raw C/H={raw_critical}/{raw_high}, state C/H={state_critical}/{state_high})"
+        )
+
+    missing = []
+    for index, comment in enumerate(raw_comments):
+        critical = int(comment.get("critical", 0) or 0)
+        high = int(comment.get("high", 0) or 0)
+        if (critical > 0 or high > 0) and index not in normalized:
+            missing.append(index)
+    if missing:
+        fail(f"missing verdict for severity-bearing comments: {missing}")
+
+    next_critical = 0
+    next_high = 0
+    for index, comment in enumerate(raw_comments):
+        verdict = normalized.get(index, {}).get("verdict")
+        if verdict == "false_positive" and safe_false_positive_comment(comment):
+            continue
+        next_critical += int(comment.get("critical", 0) or 0)
+        next_high += int(comment.get("high", 0) or 0)
+
+    classified_at = dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    ordered_verdicts = [normalized[i] for i in sorted(normalized)]
+
+    state["classification_method"] = "ai"
+    state["critical"] = next_critical
+    state["high"] = next_high
+    state["ai_classification"] = {
+        "critical": next_critical,
+        "high": next_high,
+        "classified_at": classified_at,
+        "classified_by": "classify-review-state.sh",
+        "verdicts": ordered_verdicts,
+    }
+
+    directory = os.path.dirname(pending_file)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=".pending-review-comments.",
+        suffix=".tmp",
+        dir=directory,
+        text=True,
+    )
+    try:
+        with os.fdopen(fd, "w") as tmp:
+            json.dump(state, tmp, indent=2, ensure_ascii=False)
+            tmp.write("\n")
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        os.replace(tmp_path, pending_file)
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+    fcntl.flock(lock, fcntl.LOCK_UN)
+
+if next_critical > 0 or next_high > 0:
+    print(
+        f"classification saved; unresolved CRITICAL={next_critical} HIGH={next_high}",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
+
+print("classification saved; CRITICAL=0 HIGH=0")
+PY

--- a/scripts/review-comment-set-hash.sh
+++ b/scripts/review-comment-set-hash.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# review-comment-set-hash.sh — deterministic hash for current PR review comments
+#
+# Usage:
+#   bash review-comment-set-hash.sh <PR_NUMBER> [OWNER/REPO] [HEAD_SHA]
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: bash review-comment-set-hash.sh <PR_NUMBER> [OWNER/REPO] [HEAD_SHA]" >&2
+}
+
+if [[ $# -lt 1 || $# -gt 3 ]]; then
+  usage
+  exit 1
+fi
+
+PR_NUMBER="$1"
+REPO="${2:-}"
+HEAD_SHA="${3:-}"
+
+if [[ -z "$PR_NUMBER" ]]; then
+  usage
+  exit 1
+fi
+
+if [[ -z "$REPO" ]]; then
+  REPO="$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || true)"
+fi
+
+if [[ -z "$REPO" ]]; then
+  echo "ERROR: repository could not be resolved" >&2
+  exit 1
+fi
+
+if [[ -z "$HEAD_SHA" ]]; then
+  HEAD_SHA="$(env -u GH_FORCE_TTY gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha' 2>/dev/null || true)"
+fi
+
+if [[ -z "$HEAD_SHA" ]]; then
+  echo "ERROR: PR #${PR_NUMBER} head SHA could not be resolved for ${REPO}" >&2
+  exit 1
+fi
+
+_REPO="$REPO" _PR_NUMBER="$PR_NUMBER" _HEAD_SHA="$HEAD_SHA" python3 - <<'PY'
+import hashlib
+import json
+import os
+import re
+import subprocess
+
+repo = os.environ["_REPO"]
+pr = os.environ["_PR_NUMBER"]
+head_sha = os.environ["_HEAD_SHA"]
+
+
+def gh_api(path: str):
+    env = {k: v for k, v in os.environ.items() if k != "GH_FORCE_TTY"}
+    try:
+        r = subprocess.run(["gh", "api", path], capture_output=True, text=True, timeout=20, env=env)
+        if r.returncode == 0 and r.stdout.strip():
+            return json.loads(r.stdout)
+    except Exception:
+        pass
+    return []
+
+
+def gh_api_list(path: str) -> list:
+    result = gh_api(path)
+    return result if isinstance(result, list) else []
+
+
+def strip_negation_lines(text: str) -> str:
+    patterns = [
+        r"(?i)no\s+critical",
+        r"(?i)no\s+high",
+        r"(?i)no\s+critical/high",
+        r"(?i)critical[=/]high\s*(?:issues?|findings?|指摘)?\s*(?::|=|なし|ゼロ|0)",
+        r"(?i)critical\s*=\s*0",
+        r"(?i)high\s*=\s*0",
+        r"(?i)0\s+critical",
+        r"(?i)0\s+high",
+        r"(?i)critical.*(?:free|なし|ありません|ゼロ|0件)",
+        r"(?i)high.*(?:free|なし|ありません|ゼロ|0件)",
+        r"(?i)no\s+(?:bug|warning|suggestion)",
+        r"(?i)critical\s+\w+.*:\s*0\s*$",
+        r"(?i)high\s+\w+.*:\s*0\s*$",
+    ]
+    return "\n".join(line for line in text.split("\n") if not any(re.search(p, line) for p in patterns))
+
+
+def count_severity(text: str) -> tuple[int, int, int, int]:
+    cleaned = re.sub(r"<details>.*?</details>", "", text, flags=re.DOTALL)
+    cleaned = re.sub(r"<!--.*?-->", "", cleaned, flags=re.DOTALL)
+    cleaned = re.sub(r"<[^>]+>", "", cleaned)
+    cleaned = strip_negation_lines(cleaned)
+    critical = len(re.findall(r"(?i)\[CRITICAL\]|severity:\s*CRITICAL|\*\*CRITICAL\*\*|^\s*CRITICAL:|>\s*CRITICAL", cleaned, re.MULTILINE))
+    high = len(re.findall(r"(?i)\[HIGH\]|severity:\s*HIGH|\*\*HIGH\*\*|^\s*HIGH[:\s-]|>\s*HIGH|\bP1\b", cleaned, re.MULTILINE))
+    warning = len(re.findall(r"(?i)\[WARNING\]|severity:\s*WARNING|\*\*WARNING\*\*|^\s*WARNING:", cleaned, re.MULTILINE))
+    suggestion = len(re.findall(r"(?i)\[SUGGESTION\]|severity:\s*SUGGESTION|\*\*SUGGESTION\*\*|^\s*SUGGESTION:", cleaned, re.MULTILINE))
+    high += len(re.findall(r"###\s*Bug:", text))
+    high += len(re.findall(r"###\s*Security:", text))
+    warning += len(re.findall(r"###\s*Performance:", text))
+    suggestion += len(re.findall(r"###\s*Minor:", text))
+    return critical, high, warning, suggestion
+
+
+def raw_entry(source: str, user: str, body: str, **extra) -> dict:
+    critical, high, warning, suggestion = count_severity(body)
+    entry = {
+        "user": user,
+        "body_preview": body[:500],
+        "source": source,
+        "critical": critical,
+        "high": high,
+        "warning": warning,
+        "suggestion": suggestion,
+    }
+    for key in ("path", "line", "comment_id", "updated_at"):
+        if extra.get(key) is not None:
+            entry[key] = extra[key]
+    digest_src = json.dumps(entry, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    entry["comment_hash"] = hashlib.sha256(digest_src.encode("utf-8")).hexdigest()
+    return entry
+
+
+inline = []
+for c in gh_api_list(f"repos/{repo}/pulls/{pr}/comments"):
+    if head_sha and c.get("commit_id", "") != head_sha:
+        continue
+    inline.append(
+        {
+            "path": c.get("path", "?"),
+            "line": c.get("line") or c.get("original_line") or "?",
+            "body": c.get("body", ""),
+            "user": c.get("user", {}).get("login", "?"),
+            "id": c.get("id"),
+            "updated_at": c.get("updated_at"),
+        }
+    )
+
+review_keywords = ["claude-review", "critical", "warning", "suggestion", "pr review", "code review", "lgtm"]
+bot_comments = []
+human_review_comments = []
+for c in gh_api_list(f"repos/{repo}/issues/{pr}/comments"):
+    user = c.get("user", {}).get("login", "")
+    body = c.get("body", "")
+    is_bot = user in ("github-actions[bot]", "claude[bot]", "claude-review[bot]")
+    has_review_keyword = any(kw in body.lower() for kw in review_keywords)
+    entry = {"user": user, "body": body, "id": c.get("id"), "updated_at": c.get("updated_at")}
+    if is_bot:
+        bot_comments.append(entry)
+    elif has_review_keyword:
+        human_review_comments.append(entry)
+
+issue_comments = []
+if bot_comments:
+    issue_comments.append(bot_comments[-1])
+issue_comments.extend(human_review_comments)
+
+for r in gh_api_list(f"repos/{repo}/pulls/{pr}/reviews"):
+    state = r.get("state", "")
+    body = r.get("body", "")
+    if state in ("APPROVED", "CHANGES_REQUESTED", "COMMENTED") and body and body.strip():
+        issue_comments.append(
+            {
+                "user": r.get("user", {}).get("login", "?"),
+                "body": f"[{state}] {body}",
+                "id": r.get("id"),
+                "updated_at": r.get("submitted_at"),
+            }
+        )
+
+raw_comments = []
+for c in inline:
+    raw_comments.append(
+        raw_entry(
+            "inline",
+            c.get("user", "?"),
+            c.get("body", ""),
+            path=c.get("path", "?"),
+            line=c.get("line", "?"),
+            comment_id=c.get("id"),
+            updated_at=c.get("updated_at"),
+        )
+    )
+for c in issue_comments:
+    raw_comments.append(
+        raw_entry(
+            "issue_comment",
+            c.get("user", "?"),
+            c.get("body", ""),
+            comment_id=c.get("id"),
+            updated_at=c.get("updated_at"),
+        )
+    )
+
+digest_src = json.dumps(
+    [
+        {
+            "comment_hash": c.get("comment_hash", ""),
+            "critical": c.get("critical", 0),
+            "high": c.get("high", 0),
+        }
+        for c in raw_comments
+    ],
+    ensure_ascii=False,
+    sort_keys=True,
+    separators=(",", ":"),
+)
+print(hashlib.sha256(digest_src.encode("utf-8")).hexdigest())
+PY

--- a/skills/classify-review/SKILL.md
+++ b/skills/classify-review/SKILL.md
@@ -3,7 +3,7 @@ name: classify-review
 description: "PR review severity を Haiku AI で再分類。regex 偽陽性を除外する片方向ゲート。/classify-review [PR番号] で実行。regex が CRITICAL/HIGH 検出した際の偽陽性チェック専用。"
 user-invocable: true
 argument-hint: "[PR番号]"
-allowed-tools: [Read, Write, Bash, Grep, Agent]
+allowed-tools: [Read, Bash, Grep, Agent]
 ---
 
 # /classify-review — AI Severity Re-classification (False Positive Filter)
@@ -24,7 +24,9 @@ regex ベースの severity 検出が CRITICAL/HIGH を報告した際に、Haik
 `.claude/state/pending-review-comments.json` を Read する。
 なければ `~/.claude/state/pending-review-comments.json` を試す。
 
-必須フィールド: `pr`, `critical`, `high`, `raw_comments`, `head_sha`
+必須フィールド: `pr`, `repo`, `critical`, `high`, `raw_comments`, `head_sha`, `comment_set_hash`
+
+`raw_comments[]` は `index`, `comment_hash`, `critical`, `high`, `body_preview` を確認できる形で Haiku に渡す。
 
 ### Step 2: 分類が必要か判定
 
@@ -67,21 +69,37 @@ Agent(
 ## 出力形式
 各コメントに対して以下の JSON を返してください:
 [
-  { "index": 0, "user": "...", "verdict": "real" | "false_positive", "reasoning": "判定理由を1文で" },
+  {
+    "index": 0,
+    "comment_hash": "...",
+    "verdict": "real" | "false_positive" | "unknown",
+    "reasoning": "判定理由を1文で"
+  },
   ...
 ]
 """
 )
 ```
 
-### Step 4: 判定結果で State File 更新
+### Step 4: 判定結果を正規 updater に渡す
 
-Haiku の判定結果に基づいて `pending-review-comments.json` を Write で更新:
+`pending-review-comments.json` を Write/Edit で直接更新してはいけない。
+Haiku の JSON を1つの shell argument として `classify-review-state.sh` に渡す:
+
+```bash
+VERDICTS_JSON='[{"index":0,"comment_hash":"...","verdict":"false_positive","reasoning":"承認メッセージであり、実指摘ではない"}]'
+bash ~/.claude/scripts/classify-review-state.sh <PR番号> "$VERDICTS_JSON" <OWNER/REPO>
+```
+
+updater は以下を検証してから atomic + flock で state file を更新する:
 
 1. `classification_method` を `"ai"` に変更
-2. 偽陽性と判定されたコメントの severity カウントを除外して再計算
-3. 「本物」「不明」のコメントの severity はそのまま維持
-4. `ai_classification` ブロックに詳細を格納:
+2. PR番号、repo、`head_sha` が現在のGitHub PRと一致することを確認
+3. GitHub から現在のレビューコメント集合を再取得し、`comment_set_hash` が一致することを確認
+4. `comment_hash` が `raw_comments[index]` と一致することを確認
+5. 偽陽性判定かつコメント本文が承認/否定文脈として deterministic に安全な場合だけ severity カウントから除外
+6. 「本物」「不明」、または deterministic severity-negation pattern に合わないコメントの severity はそのまま維持
+7. `ai_classification` ブロックに詳細を格納:
 
 ```json
 {
@@ -97,7 +115,13 @@ Haiku の判定結果に基づいて `pending-review-comments.json` を Write �
 }
 ```
 
-5. トップレベルの `critical`/`high` も AI 判定結果で更新（下流 consumer との互換性維持）
+8. トップレベルの `critical`/`high` も AI 判定結果で更新（下流 consumer との互換性維持）
+
+exit code:
+
+- `0`: 分類保存済み。CRITICAL/HIGH は 0。
+- `1`: 入力不正、stale head、hash mismatch、missing verdict 等。state file は未変更。
+- `2`: 分類保存済み。ただし real/unknown の CRITICAL/HIGH が残るためブロック維持。
 
 ### Step 5: 結果報告
 
@@ -111,7 +135,7 @@ Haiku の判定結果に基づいて `pending-review-comments.json` を Write �
 | 1 | @terisuke | CRITICAL | false_positive | 承認メッセージ内の否定文脈 |
 
 Regex: CRITICAL=1 HIGH=1 → AI: CRITICAL=0 HIGH=0
-State file 更新済み。マージゲートは解除されます。
+classify-review-state.sh による検証済み更新完了。マージゲートは解除されます。
 ```
 
 ## 安全性保証
@@ -119,4 +143,8 @@ State file 更新済み。マージゲートは解除されます。
 - Haiku が 1 つでも `"real"` と判定 → その severity はカウント維持 → ブロック維持
 - Haiku が判定不能/エラー → 全て `"real"` 扱い → ブロック維持
 - `head_sha` が変わったら AI 分類は無効（push 後は再分類必要）
+- `comment_set_hash` が変わったら AI 分類は無効（同一headへのレビュー追加/編集後は再分類必要）
+- `comment_hash` が一致しない判定は無効（state file 未変更）
+- `false_positive` 判定でも、コメント本文自体が承認/否定文脈でない場合は severity を下げない
+- AI/Agent は `pending-review-comments.json` を直接 Write しない
 - 全判定に `reasoning` ログ → 事後監査可能

--- a/tests/test-block-state-file-tampering.sh
+++ b/tests/test-block-state-file-tampering.sh
@@ -94,8 +94,14 @@ echo "=== 2. read-only操作 (ALLOW) ==="
 expect_allow "cat review-status.json" \
   "$(make_input "cat .claude/state/review-status.json")"
 
+expect_allow "cat pending-review-comments.json" \
+  "$(make_input "cat .claude/state/pending-review-comments.json")"
+
 expect_allow "jq -r review-status.json" \
   "$(make_input "jq -r '.branch' .claude/state/review-status.json")"
+
+expect_allow "jq -r pending-review-comments.json" \
+  "$(make_input "jq -r '.critical' .claude/state/pending-review-comments.json")"
 
 expect_allow "head review-status.json" \
   "$(make_input "head -5 .claude/state/review-status.json")"
@@ -125,6 +131,18 @@ echo "=== 3. 書き込み操作 — 単行 (BLOCK) ==="
 
 expect_block "echo > review-status.json" \
   "$(make_input "echo '{}' > .claude/state/review-status.json")"
+
+expect_block "echo > pending-review-comments.json" \
+  "$(make_input "echo '{}' > .claude/state/pending-review-comments.json")"
+
+expect_block "gh api redirect > pending-review-comments.json" \
+  "$(make_input "gh api repos/owner/repo/pulls/1 > .claude/state/pending-review-comments.json")"
+
+expect_block "gh api pipe tee pending-review-comments.json" \
+  "$(make_input "gh api repos/owner/repo/pulls/1 | tee .claude/state/pending-review-comments.json")"
+
+expect_block "gh release download to pending-review-comments.json" \
+  "$(make_input "gh release download v1 --pattern pending-review-comments.json --dir .claude/state --clobber")"
 
 expect_block "tee review-status.json" \
   "$(make_input "echo '{}' | tee .claude/state/review-status.json")"
@@ -204,6 +222,12 @@ expect_block "perl -e での書き込み" \
 expect_block "python3 write (NOT exempted by git rule)" \
   "$(make_input "python3 -c 'import json; json.dump({}, open(\\\"review-status.json\\\",\\\"w\\\"))'")"
 
+expect_block "python3 write pending-review-comments.json" \
+  "$(make_input "python3 -c 'import json; json.dump({}, open(\\\"pending-review-comments.json\\\",\\\"w\\\"))'")"
+
+expect_block "split filename write pending-review-comments.json" \
+  "$(make_input 'p=.claude/state/pending-review-comments; printf {} > $p.json')"
+
 # =========================================================================
 echo ""
 echo "=== 7. パイプ/チェイン/複合コマンド (BLOCK) ==="
@@ -263,6 +287,9 @@ echo "=== 9. 他の保護対象ファイル (BLOCK) ==="
 
 expect_block "pr-review-lock.json 書き込み" \
   "$(make_input "echo '{}' > .claude/state/pr-review-lock.json")"
+
+expect_block "pending-review-comments.json 書き込み" \
+  "$(make_input "echo '{}' > .claude/state/pending-review-comments.json")"
 
 expect_block "context-budget.json 書き込み" \
   "$(make_input "echo '{}' > .claude/state/context-budget.json")"

--- a/tests/test-classify-review-state.sh
+++ b/tests/test-classify-review-state.sh
@@ -1,0 +1,256 @@
+#!/bin/bash
+# test-classify-review-state.sh — verified updater for /classify-review results
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT/scripts/classify-review-state.sh"
+TMP_ROOT="$(mktemp -d)"
+TMP_REPO="$TMP_ROOT/repo"
+TMP_BIN="$TMP_ROOT/bin"
+STATE_FILE="$TMP_REPO/.claude/state/pending-review-comments.json"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_REPO/.claude/state" "$TMP_BIN"
+git -C "$TMP_REPO" init -q
+
+cat > "$TMP_BIN/gh" <<'FAKEGH'
+#!/bin/sh
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/pulls/123" ]; then
+  if [ "${3:-}" = "--jq" ]; then
+    printf '%s\n' "${FAKE_HEAD_SHA:-abc123}"
+    exit 0
+  fi
+  printf '{"head":{"sha":"%s"}}\n' "${FAKE_HEAD_SHA:-abc123}"
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/pulls/123/comments" ]; then
+  if [ "${FAKE_UNSAFE_APPROVAL:-0}" = "1" ]; then
+    cat <<'JSON'
+[
+  {"id":101,"commit_id":"abc123","path":"hooks/example.sh","line":10,"body":"No high findings.\n[HIGH] real auth bypass","user":{"login":"bot"},"updated_at":"2026-06-06T00:00:00Z"}
+]
+JSON
+    exit 0
+  fi
+  if [ "${FAKE_EXTRA_COMMENT:-0}" = "1" ]; then
+    cat <<'JSON'
+[
+  {"id":101,"commit_id":"abc123","path":"hooks/example.sh","line":10,"body":"HIGH: 0 historical heading only","user":{"login":"bot"},"updated_at":"2026-06-06T00:00:00Z"},
+  {"id":102,"commit_id":"abc123","path":"hooks/new.sh","line":20,"body":"[HIGH] new same-head review finding","user":{"login":"bot"},"updated_at":"2026-06-06T00:02:00Z"}
+]
+JSON
+  else
+    cat <<'JSON'
+[
+  {"id":101,"commit_id":"abc123","path":"hooks/example.sh","line":10,"body":"HIGH: 0 historical heading only","user":{"login":"bot"},"updated_at":"2026-06-06T00:00:00Z"}
+]
+JSON
+  fi
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/issues/123/comments" ]; then
+  cat <<'JSON'
+[
+  {"id":201,"body":"CRITICAL: 0 historical heading only","user":{"login":"claude[bot]"},"updated_at":"2026-06-06T00:01:00Z"}
+]
+JSON
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/pulls/123/reviews" ]; then
+  printf '[]\n'
+  exit 0
+fi
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+  printf 'owner/repo\n'
+  exit 0
+fi
+exit 1
+FAKEGH
+chmod +x "$TMP_BIN/gh"
+
+PASSED=0
+FAILED=0
+TOTAL=0
+
+write_state() {
+  (
+    cd "$TMP_REPO"
+    PATH="$TMP_BIN:$PATH" python3 "$ROOT/hooks/inject-claude-review-helper.py" owner/repo 123 >/dev/null 2>/dev/null
+  )
+}
+
+verdicts_json() {
+  local second_verdict="$1"
+  python3 - "$STATE_FILE" "$second_verdict" <<'PY'
+import json
+import sys
+
+path, second_verdict = sys.argv[1], sys.argv[2]
+d = json.load(open(path))
+items = []
+for idx, verdict in [(0, "false_positive"), (1, second_verdict)]:
+    c = d["raw_comments"][idx]
+    items.append(
+        {
+            "index": idx,
+            "comment_hash": c["comment_hash"],
+            "verdict": verdict,
+            "reasoning": "deterministic test verdict",
+        }
+    )
+print(json.dumps(items, separators=(",", ":")))
+PY
+}
+
+state_value() {
+  local expr="$1"
+  python3 - "$STATE_FILE" "$expr" <<'PY'
+import json
+import sys
+
+path, expr = sys.argv[1], sys.argv[2]
+d = json.load(open(path))
+cur = d
+for part in expr.split("."):
+    if isinstance(cur, list):
+        cur = cur[int(part)]
+    else:
+        cur = cur[part]
+print(cur)
+PY
+}
+
+expect_rc() {
+  local desc="$1"
+  local expected="$2"
+  shift 2
+  TOTAL=$((TOTAL + 1))
+  local rc=0
+  set +e
+  "$@" >/dev/null 2>/dev/null
+  rc=$?
+  set -e
+  if [[ "$rc" -eq "$expected" ]]; then
+    PASSED=$((PASSED + 1))
+    echo "  PASS: $desc (exit=$rc)"
+  else
+    FAILED=$((FAILED + 1))
+    echo "  FAIL: $desc (expected exit $expected, got exit $rc)" >&2
+  fi
+}
+
+assert_state() {
+  local desc="$1"
+  local expr="$2"
+  local expected="$3"
+  TOTAL=$((TOTAL + 1))
+  local actual
+  actual="$(state_value "$expr")"
+  if [[ "$actual" == "$expected" ]]; then
+    PASSED=$((PASSED + 1))
+    echo "  PASS: $desc ($actual)"
+  else
+    FAILED=$((FAILED + 1))
+    echo "  FAIL: $desc (expected $expected, got $actual)" >&2
+  fi
+}
+
+run_script() {
+  CLAUDE_PROJECT_DIR="$TMP_REPO" PATH="$TMP_BIN:$PATH" bash "$SCRIPT" "$@"
+}
+
+echo "=== classify-review-state updater ==="
+
+write_state
+ALL_FALSE="$(verdicts_json false_positive)"
+expect_rc "all deterministic false positives unlock gate" 0 run_script 123 "$ALL_FALSE" owner/repo
+assert_state "method is ai" "classification_method" "ai"
+assert_state "critical cleared" "critical" "0"
+assert_state "high cleared" "high" "0"
+assert_state "ai critical cleared" "ai_classification.critical" "0"
+assert_state "ai high cleared" "ai_classification.high" "0"
+
+write_state
+REAL_REMAINS="$(verdicts_json real)"
+expect_rc "real keeps gate closed" 2 run_script 123 "$REAL_REMAINS" owner/repo
+assert_state "method is ai after real classification" "classification_method" "ai"
+assert_state "critical remains for real case" "critical" "1"
+assert_state "high removed for real case" "high" "0"
+assert_state "real verdict persisted" "ai_classification.verdicts.1.verdict" "real"
+
+write_state
+UNKNOWN_REMAINS="$(verdicts_json unknown)"
+expect_rc "unknown keeps gate closed" 2 run_script 123 "$UNKNOWN_REMAINS" owner/repo
+assert_state "method is ai after unknown classification" "classification_method" "ai"
+assert_state "critical remains for unknown case" "critical" "1"
+assert_state "high removed for unknown case" "high" "0"
+assert_state "unknown verdict persisted" "ai_classification.verdicts.1.verdict" "unknown"
+
+write_state
+expect_rc "stale head leaves state unchanged" 1 env FAKE_HEAD_SHA=def456 CLAUDE_PROJECT_DIR="$TMP_REPO" PATH="$TMP_BIN:$PATH" bash "$SCRIPT" 123 "$ALL_FALSE" owner/repo
+assert_state "stale method unchanged" "classification_method" "regex"
+assert_state "stale critical unchanged" "critical" "1"
+assert_state "stale high unchanged" "high" "1"
+
+write_state
+BAD_HASH="$(python3 - "$STATE_FILE" <<'PY'
+import json
+import sys
+
+d = json.load(open(sys.argv[1]))
+items = [
+    {"index": 0, "comment_hash": "wrong", "verdict": "false_positive", "reasoning": "bad hash"},
+    {"index": 1, "comment_hash": d["raw_comments"][1]["comment_hash"], "verdict": "false_positive", "reasoning": "ok"},
+]
+print(json.dumps(items, separators=(",", ":")))
+PY
+)"
+expect_rc "hash mismatch leaves state unchanged" 1 run_script 123 "$BAD_HASH" owner/repo
+assert_state "hash mismatch method unchanged" "classification_method" "regex"
+
+write_state
+MISSING="$(python3 - "$STATE_FILE" <<'PY'
+import json
+import sys
+
+d = json.load(open(sys.argv[1]))
+items = [
+    {"index": 0, "comment_hash": d["raw_comments"][0]["comment_hash"], "verdict": "false_positive", "reasoning": "missing second"}
+]
+print(json.dumps(items, separators=(",", ":")))
+PY
+)"
+expect_rc "missing severity verdict leaves state unchanged" 1 run_script 123 "$MISSING" owner/repo
+assert_state "missing verdict method unchanged" "classification_method" "regex"
+
+write_state
+expect_rc "invalid JSON leaves state unchanged" 1 run_script 123 'not-json' owner/repo
+assert_state "invalid JSON method unchanged" "classification_method" "regex"
+
+write_state
+expect_rc "same-head comment drift leaves state unchanged" 1 env FAKE_EXTRA_COMMENT=1 CLAUDE_PROJECT_DIR="$TMP_REPO" PATH="$TMP_BIN:$PATH" bash "$SCRIPT" 123 "$ALL_FALSE" owner/repo
+assert_state "comment drift method unchanged" "classification_method" "regex"
+
+(
+  cd "$TMP_REPO"
+  FAKE_UNSAFE_APPROVAL=1 PATH="$TMP_BIN:$PATH" python3 "$ROOT/hooks/inject-claude-review-helper.py" owner/repo 123 >/dev/null 2>/dev/null
+)
+UNSAFE_FALSE="$(verdicts_json false_positive)"
+expect_rc "mixed no-high false positive keeps gate closed" 2 env FAKE_UNSAFE_APPROVAL=1 CLAUDE_PROJECT_DIR="$TMP_REPO" PATH="$TMP_BIN:$PATH" bash "$SCRIPT" 123 "$UNSAFE_FALSE" owner/repo
+assert_state "mixed no-high method saved" "classification_method" "ai"
+assert_state "mixed no-high high remains" "high" "1"
+
+echo "Total: $TOTAL  Passed: $PASSED  Failed: $FAILED"
+
+if [[ "$FAILED" -gt 0 ]]; then
+  echo "FAIL: $FAILED test(s) failed" >&2
+  exit 1
+fi
+
+echo "ALL TESTS PASSED"
+exit 0

--- a/tests/test-inject-review-merge-hash.sh
+++ b/tests/test-inject-review-merge-hash.sh
@@ -98,6 +98,19 @@ with open(os.environ["PENDING_FILE"], "w") as f:
 PY
 }
 
+clear_pending_head_sha() {
+  PENDING_FILE="$PENDING_FILE" python3 - <<'PY'
+import json
+import os
+
+path = os.environ["PENDING_FILE"]
+d = json.load(open(path))
+d["head_sha"] = ""
+with open(path, "w") as f:
+    json.dump(d, f)
+PY
+}
+
 run_hook() {
   local command="$1"
   local payload
@@ -147,6 +160,10 @@ expect_rc "T2: same-head comment drift blocks AI-cleared state" 2 "gh pr merge 1
 
 write_pending "$GOOD_HASH" 1 1
 expect_rc "T3: command PR differs from pending state does not use other PR state" 0 "gh pr merge 456 --merge"
+
+write_pending "$GOOD_HASH"
+clear_pending_head_sha
+expect_rc "T4: missing pending head SHA blocks standalone merge hook" 2 "gh pr merge 123 --merge"
 
 echo "Total: $TOTAL  Passed: $PASSED  Failed: $FAILED"
 rm -f /tmp/inject_merge_hash_test.out /tmp/inject_merge_hash_test.err

--- a/tests/test-inject-review-merge-hash.sh
+++ b/tests/test-inject-review-merge-hash.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# test-inject-review-merge-hash.sh — inject-claude-review merge hash guard
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$ROOT/hooks/inject-claude-review-on-checks.sh"
+TMP_ROOT="$(mktemp -d)"
+TMP_HOME="$TMP_ROOT/home"
+TMP_REPO="$TMP_ROOT/repo"
+TMP_BIN="$TMP_ROOT/bin"
+STATE_DIR="$TMP_REPO/.claude/state"
+PENDING_FILE="$STATE_DIR/pending-review-comments.json"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_HOME" "$TMP_BIN" "$STATE_DIR"
+git -C "$TMP_REPO" init -q
+git -C "$TMP_REPO" remote add origin https://github.com/owner/repo.git
+
+cat > "$TMP_BIN/gh" <<'FAKEGH'
+#!/bin/sh
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/pulls/123" ]; then
+  if [ "${3:-}" = "--jq" ]; then
+    printf 'abc123\n'
+    exit 0
+  fi
+  printf '{"head":{"sha":"abc123"}}\n'
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/pulls/123/comments" ]; then
+  if [ "${FAKE_EXTRA_COMMENT:-0}" = "1" ]; then
+    cat <<'JSON'
+[
+  {"id":101,"commit_id":"abc123","path":"hooks/example.sh","line":10,"body":"No high findings.\n[HIGH] historical heading only","user":{"login":"bot"},"updated_at":"2026-06-06T00:00:00Z"},
+  {"id":102,"commit_id":"abc123","path":"hooks/new.sh","line":20,"body":"[HIGH] new same-head review finding","user":{"login":"bot"},"updated_at":"2026-06-06T00:02:00Z"}
+]
+JSON
+  else
+    cat <<'JSON'
+[
+  {"id":101,"commit_id":"abc123","path":"hooks/example.sh","line":10,"body":"No high findings.\n[HIGH] historical heading only","user":{"login":"bot"},"updated_at":"2026-06-06T00:00:00Z"}
+]
+JSON
+  fi
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/issues/123/comments" ]; then
+  cat <<'JSON'
+[
+  {"id":201,"body":"No critical findings.\n[CRITICAL] historical heading only","user":{"login":"claude[bot]"},"updated_at":"2026-06-06T00:01:00Z"}
+]
+JSON
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/pulls/123/reviews" ]; then
+  printf '[]\n'
+  exit 0
+fi
+exit 1
+FAKEGH
+chmod +x "$TMP_BIN/gh"
+
+PASSED=0
+FAILED=0
+TOTAL=0
+
+calc_hash() {
+  PATH="$TMP_BIN:$PATH" bash "$ROOT/scripts/review-comment-set-hash.sh" 123 owner/repo abc123
+}
+
+write_pending() {
+  local hash="$1"
+  local critical="${2:-0}"
+  local high="${3:-0}"
+  HASH="$hash" CRITICAL="$critical" HIGH="$high" PENDING_FILE="$PENDING_FILE" python3 - <<'PY'
+import json
+import os
+
+critical = int(os.environ["CRITICAL"])
+high = int(os.environ["HIGH"])
+state = {
+    "pr": "123",
+    "repo": "owner/repo",
+    "head_sha": "abc123",
+    "comment_set_hash": os.environ["HASH"],
+    "total": 2,
+    "critical": critical,
+    "high": high,
+    "classification_method": "ai",
+    "ai_classification": {"critical": critical, "high": high},
+}
+with open(os.environ["PENDING_FILE"], "w") as f:
+    json.dump(state, f)
+PY
+}
+
+run_hook() {
+  local command="$1"
+  local payload
+  payload=$(printf '{"tool_name":"Bash","tool_input":{"command":%s}}\n' "$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$command")")
+  (
+    cd "$TMP_REPO"
+    HOME="$TMP_HOME" PATH="$TMP_BIN:$PATH" bash "$HOOK" <<<"$payload"
+  )
+}
+
+expect_rc() {
+  local desc="$1"
+  local expected="$2"
+  local command="$3"
+  shift 3
+  local env_pair
+  TOTAL=$((TOTAL + 1))
+  local rc=0
+  set +e
+  for env_pair in "$@"; do
+    export "$env_pair"
+  done
+  run_hook "$command" >/tmp/inject_merge_hash_test.out 2>/tmp/inject_merge_hash_test.err
+  rc=$?
+  for env_pair in "$@"; do
+    unset "${env_pair%%=*}"
+  done
+  set -e
+  if [[ "$rc" -eq "$expected" ]]; then
+    PASSED=$((PASSED + 1))
+    echo "  PASS: $desc (exit=$rc)"
+  else
+    FAILED=$((FAILED + 1))
+    echo "  FAIL: $desc (expected exit $expected, got $rc)" >&2
+    cat /tmp/inject_merge_hash_test.err >&2 || true
+  fi
+}
+
+echo "=== inject review merge hash guard ==="
+
+GOOD_HASH="$(calc_hash)"
+write_pending "$GOOD_HASH"
+expect_rc "T1: matching hash and zero severity allows merge command" 0 "gh pr merge 123 --merge"
+
+write_pending "$GOOD_HASH"
+expect_rc "T2: same-head comment drift blocks AI-cleared state" 2 "gh pr merge 123 --merge" FAKE_EXTRA_COMMENT=1
+
+write_pending "$GOOD_HASH" 1 1
+expect_rc "T3: command PR differs from pending state does not use other PR state" 0 "gh pr merge 456 --merge"
+
+echo "Total: $TOTAL  Passed: $PASSED  Failed: $FAILED"
+rm -f /tmp/inject_merge_hash_test.out /tmp/inject_merge_hash_test.err
+[[ "$FAILED" -eq 0 ]] && exit 0 || exit 1

--- a/tests/test-pre-merge-comment-set-hash.sh
+++ b/tests/test-pre-merge-comment-set-hash.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+# test-pre-merge-comment-set-hash.sh — PRE_MERGE comment_set_hash enforcement
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+TMP_HOME="$TMP_ROOT/home"
+TMP_REPO="$TMP_ROOT/repo"
+TMP_BIN="$TMP_ROOT/bin"
+STATE_DIR="$TMP_REPO/.claude/state"
+PENDING_FILE="$STATE_DIR/pending-review-comments.json"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_HOME" "$TMP_BIN" "$STATE_DIR"
+git -C "$TMP_REPO" init -q
+git -C "$TMP_REPO" config user.email test@example.com
+git -C "$TMP_REPO" config user.name Test
+printf '# test\n' > "$TMP_REPO/README.md"
+git -C "$TMP_REPO" add README.md
+git -C "$TMP_REPO" commit -q -m init
+git -C "$TMP_REPO" branch -M feature
+git -C "$TMP_REPO" remote add origin https://github.com/owner/repo.git
+
+cat > "$TMP_BIN/gh" <<'FAKEGH'
+#!/bin/sh
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/pulls/123" ]; then
+  if [ "${3:-}" = "--jq" ]; then
+    case "${4:-}" in
+      ".head.ref") printf 'feature\n' ;;
+      ".head.sha") printf 'abc123\n' ;;
+      *) printf 'abc123\n' ;;
+    esac
+    exit 0
+  fi
+  printf '{"head":{"sha":"abc123","ref":"feature"}}\n'
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/pulls/123/files" ]; then
+  if [ "${3:-}" = "--jq" ]; then
+    printf 'README.md\n'
+  else
+    printf '[{"filename":"README.md"}]\n'
+  fi
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/commits/abc123/check-runs" ]; then
+  if [ "${3:-}" = "--jq" ]; then
+    printf '0\n'
+  else
+    printf '{"check_runs":[]}\n'
+  fi
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/pulls/123/comments" ]; then
+  cat <<'JSON'
+[
+  {"id":101,"commit_id":"abc123","path":"hooks/example.sh","line":10,"body":"No high findings.\n[HIGH] historical heading only","user":{"login":"bot"},"updated_at":"2026-06-06T00:00:00Z"}
+]
+JSON
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/issues/123/comments" ]; then
+  cat <<'JSON'
+[
+  {"id":201,"body":"No critical findings.\n[CRITICAL] historical heading only","user":{"login":"claude[bot]"},"updated_at":"2026-06-06T00:01:00Z"}
+]
+JSON
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/pulls/123/reviews" ]; then
+  printf '[]\n'
+  exit 0
+fi
+exit 1
+FAKEGH
+chmod +x "$TMP_BIN/gh"
+
+PASSED=0
+FAILED=0
+TOTAL=0
+
+pass() {
+  PASSED=$((PASSED + 1))
+  TOTAL=$((TOTAL + 1))
+  echo "  PASS: $1"
+}
+
+fail() {
+  FAILED=$((FAILED + 1))
+  TOTAL=$((TOTAL + 1))
+  echo "  FAIL: $1" >&2
+}
+
+calc_hash() {
+  PATH="$TMP_BIN:$PATH" bash "$ROOT/scripts/review-comment-set-hash.sh" 123 owner/repo abc123
+}
+
+write_pending() {
+  local hash="$1"
+  local include_hash="${2:-yes}"
+  HASH="$hash" INCLUDE_HASH="$include_hash" PENDING_FILE="$PENDING_FILE" python3 - <<'PY'
+import json
+import os
+
+state = {
+    "pr": "123",
+    "repo": "owner/repo",
+    "head_sha": "abc123",
+    "total": 2,
+    "critical": 0,
+    "high": 0,
+    "classification_method": "ai",
+    "ai_classification": {"critical": 0, "high": 0},
+}
+if os.environ["INCLUDE_HASH"] == "yes":
+    state["comment_set_hash"] = os.environ["HASH"]
+with open(os.environ["PENDING_FILE"], "w") as f:
+    json.dump(state, f)
+PY
+}
+
+write_review_status() {
+  local codex="${1:-false}"
+  CODEX="$codex" python3 - "$STATE_DIR/review-status.json" <<'PY'
+import json
+import os
+import sys
+
+codex = os.environ["CODEX"] == "true"
+with open(sys.argv[1], "w") as f:
+    json.dump({"feature": {"code_review": True, "codex_review": codex}}, f)
+PY
+}
+
+write_verified_lock() {
+  python3 - "$STATE_DIR/pr-review-lock.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "w") as f:
+    json.dump({"123": {"verified": True}}, f)
+PY
+}
+
+reset_state() {
+  rm -f "$STATE_DIR/review-status.json" "$STATE_DIR/pr-review-lock.json"
+  printf '{}\n' > "$STATE_DIR/review-status.json"
+  printf '{}\n' > "$STATE_DIR/pr-review-lock.json"
+}
+
+run_pre_merge() {
+  local payload='{"tool_name":"Bash","tool_input":{"command":"gh pr merge 123 --merge"}}'
+  (
+    cd "$TMP_REPO"
+    HOME="$TMP_HOME" CLAUDE_PROJECT_DIR="$TMP_REPO" PATH="$TMP_BIN:$PATH" \
+      GATE_MODE=PRE_MERGE bash "$ROOT/hooks/pr-ci-review-gate.sh" <<<"$payload"
+  )
+}
+
+expect_rc() {
+  local desc="$1"
+  local expected="$2"
+  TOTAL=$((TOTAL + 1))
+  local rc=0
+  set +e
+  run_pre_merge >/tmp/pre_merge_hash_test.out 2>/tmp/pre_merge_hash_test.err
+  rc=$?
+  set -e
+  if [[ "$rc" -eq "$expected" ]]; then
+    PASSED=$((PASSED + 1))
+    echo "  PASS: $desc (exit=$rc)"
+  else
+    FAILED=$((FAILED + 1))
+    echo "  FAIL: $desc (expected exit $expected, got $rc)" >&2
+    cat /tmp/pre_merge_hash_test.err >&2 || true
+  fi
+}
+
+echo "=== pre-merge comment_set_hash enforcement ==="
+
+GOOD_HASH="$(calc_hash)"
+
+reset_state
+write_pending "$GOOD_HASH"
+expect_rc "T1: matching comment_set_hash allows Pass B" 0
+
+reset_state
+write_pending "stale"
+write_review_status
+expect_rc "T2: stale hash blocks even when Pass A is yes" 2
+
+reset_state
+write_pending "stale"
+write_verified_lock
+expect_rc "T3: stale hash blocks even when Pass C is yes" 2
+
+reset_state
+write_pending "$GOOD_HASH" no
+expect_rc "T4: missing comment_set_hash blocks" 2
+
+reset_state
+write_pending "stale"
+write_review_status true
+expect_rc "T5: stale hash blocks even with Tier 1 LGTM" 2
+
+echo "Total: $TOTAL  Passed: $PASSED  Failed: $FAILED"
+rm -f /tmp/pre_merge_hash_test.out /tmp/pre_merge_hash_test.err
+[[ "$FAILED" -eq 0 ]] && exit 0 || exit 1

--- a/tests/test-resolve-repo.sh
+++ b/tests/test-resolve-repo.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXPECTED_ORIGIN="$(git -C "$SCRIPT_DIR" remote get-url origin | sed 's|.*github.com[:/]||;s|\.git$||')"
 PASS=0
 FAIL=0
 
@@ -45,10 +46,10 @@ test_case "multiple --repo uses first match" "first/repo" "$result"
 # --- Priority 4: origin fallback ---
 echo "--- Priority 4: origin fallback ---"
 result=$(bash -c "source '$SCRIPT_DIR/hooks/gate-modes/common.sh' && resolve_repo ''")
-test_case "fallback to origin" "terisuke/claude-code-skills" "$result"
+test_case "fallback to origin" "$EXPECTED_ORIGIN" "$result"
 
 result=$(bash -c "source '$SCRIPT_DIR/hooks/gate-modes/common.sh' && resolve_repo 'gh pr merge 10 --merge'")
-test_case "no --repo flag falls back to origin" "terisuke/claude-code-skills" "$result"
+test_case "no --repo flag falls back to origin" "$EXPECTED_ORIGIN" "$result"
 
 # --- Summary ---
 echo ""

--- a/tests/test-review-comment-set-hash.sh
+++ b/tests/test-review-comment-set-hash.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# test-review-comment-set-hash.sh — helper/updater hash parity tests
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT/scripts/review-comment-set-hash.sh"
+TMP_ROOT="$(mktemp -d)"
+TMP_REPO="$TMP_ROOT/repo"
+TMP_BIN="$TMP_ROOT/bin"
+STATE_FILE="$TMP_REPO/.claude/state/pending-review-comments.json"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_REPO/.claude/state" "$TMP_BIN"
+git -C "$TMP_REPO" init -q
+
+cat > "$TMP_BIN/gh" <<'FAKEGH'
+#!/bin/sh
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/pulls/123" ]; then
+  if [ "${3:-}" = "--jq" ]; then
+    printf '%s\n' "${FAKE_HEAD_SHA:-abc123}"
+    exit 0
+  fi
+  printf '{"head":{"sha":"%s"}}\n' "${FAKE_HEAD_SHA:-abc123}"
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/pulls/123/comments" ]; then
+  if [ "${FAKE_EXTRA_COMMENT:-0}" = "1" ]; then
+    cat <<'JSON'
+[
+  {"id":99,"commit_id":"oldsha","path":"old.sh","line":1,"body":"[HIGH] old-head finding","user":{"login":"bot"},"updated_at":"2026-06-05T23:59:00Z"},
+  {"id":101,"commit_id":"abc123","path":"hooks/example.sh","line":10,"body":"No high findings.\n[HIGH] historical heading only","user":{"login":"bot"},"updated_at":"2026-06-06T00:00:00Z"},
+  {"id":102,"commit_id":"abc123","path":"hooks/new.sh","line":20,"body":"[HIGH] new same-head review finding","user":{"login":"bot"},"updated_at":"2026-06-06T00:02:00Z"}
+]
+JSON
+  else
+    cat <<'JSON'
+[
+  {"id":99,"commit_id":"oldsha","path":"old.sh","line":1,"body":"[HIGH] old-head finding","user":{"login":"bot"},"updated_at":"2026-06-05T23:59:00Z"},
+  {"id":101,"commit_id":"abc123","path":"hooks/example.sh","line":10,"body":"No high findings.\n[HIGH] historical heading only","user":{"login":"bot"},"updated_at":"2026-06-06T00:00:00Z"}
+]
+JSON
+  fi
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/issues/123/comments" ]; then
+  cat <<'JSON'
+[
+  {"id":201,"body":"No critical findings.\n[CRITICAL] historical heading only","user":{"login":"claude[bot]"},"updated_at":"2026-06-06T00:01:00Z"}
+]
+JSON
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/pulls/123/reviews" ]; then
+  printf '[]\n'
+  exit 0
+fi
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+  printf 'owner/repo\n'
+  exit 0
+fi
+exit 1
+FAKEGH
+chmod +x "$TMP_BIN/gh"
+
+PASSED=0
+FAILED=0
+TOTAL=0
+
+pass() {
+  PASSED=$((PASSED + 1))
+  TOTAL=$((TOTAL + 1))
+  echo "  PASS: $1"
+}
+
+fail() {
+  FAILED=$((FAILED + 1))
+  TOTAL=$((TOTAL + 1))
+  echo "  FAIL: $1" >&2
+}
+
+state_hash() {
+  python3 - "$STATE_FILE" <<'PY'
+import json
+import sys
+
+print(json.load(open(sys.argv[1])).get("comment_set_hash", ""))
+PY
+}
+
+calc_hash() {
+  PATH="$TMP_BIN:$PATH" bash "$SCRIPT" 123 owner/repo abc123
+}
+
+write_state() {
+  (
+    cd "$TMP_REPO"
+    PATH="$TMP_BIN:$PATH" python3 "$ROOT/hooks/inject-claude-review-helper.py" owner/repo 123 >/dev/null 2>/dev/null
+  )
+}
+
+echo "=== review-comment-set-hash parity ==="
+
+write_state
+HELPER_HASH="$(state_hash)"
+SCRIPT_HASH="$(calc_hash)"
+[[ "$HELPER_HASH" == "$SCRIPT_HASH" ]] && pass "T1: hash matches inject helper comment_set_hash" || fail "T1: helper/script hash mismatch"
+
+BASE_HASH="$SCRIPT_HASH"
+OLD_HEAD_HASH="$(calc_hash)"
+[[ "$BASE_HASH" == "$OLD_HEAD_HASH" ]] && pass "T2: old-head inline comments do not affect hash" || fail "T2: old-head comment changed hash"
+
+EXTRA_HASH="$(FAKE_EXTRA_COMMENT=1 calc_hash)"
+[[ "$BASE_HASH" != "$EXTRA_HASH" ]] && pass "T3: same-head new inline comment changes hash" || fail "T3: same-head extra comment did not change hash"
+
+echo "Total: $TOTAL  Passed: $PASSED  Failed: $FAILED"
+[[ "$FAILED" -eq 0 ]] && exit 0 || exit 1

--- a/tests/test-state-file-tampering-write.sh
+++ b/tests/test-state-file-tampering-write.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# test-state-file-tampering-write.sh — Write/Edit state tampering guard
+
+set -euo pipefail
+
+HOOK="$(cd "$(dirname "$0")/.." && pwd)/hooks/block-state-file-tampering.sh"
+PASSED=0
+FAILED=0
+TOTAL=0
+
+make_input() {
+  local path="$1"
+  printf '{"tool_input":{"file_path":"%s"}}' "$path"
+}
+
+expect_allow() {
+  local desc="$1"
+  local input="$2"
+  TOTAL=$((TOTAL + 1))
+  local rc=0
+  echo "$input" | bash "$HOOK" >/dev/null 2>/dev/null || rc=$?
+  if [[ "$rc" -eq 0 ]]; then
+    PASSED=$((PASSED + 1))
+    echo "  PASS: $desc (exit=0)"
+  else
+    FAILED=$((FAILED + 1))
+    echo "  FAIL: $desc (expected exit 0, got exit $rc)" >&2
+  fi
+}
+
+expect_block() {
+  local desc="$1"
+  local input="$2"
+  TOTAL=$((TOTAL + 1))
+  local rc=0
+  echo "$input" | bash "$HOOK" >/dev/null 2>/dev/null || rc=$?
+  if [[ "$rc" -eq 2 ]]; then
+    PASSED=$((PASSED + 1))
+    echo "  PASS: $desc (exit=2)"
+  else
+    FAILED=$((FAILED + 1))
+    echo "  FAIL: $desc (expected exit 2, got exit $rc)" >&2
+  fi
+}
+
+echo "=== Write/Edit state file tampering guard ==="
+
+expect_block "review-status.json" \
+  "$(make_input "/repo/.claude/state/review-status.json")"
+
+expect_block "pending-review-comments.json" \
+  "$(make_input "/repo/.claude/state/pending-review-comments.json")"
+
+expect_block "pr-review-lock.json" \
+  "$(make_input "/repo/.claude/state/pr-review-lock.json")"
+
+expect_block "pr-review-read.json" \
+  "$(make_input "/repo/.claude/state/pr-review-read.json")"
+
+expect_block "context-budget.json" \
+  "$(make_input "/repo/.claude/state/context-budget.json")"
+
+expect_block "factcheck-status.json" \
+  "$(make_input "/repo/.claude/state/factcheck-status.json")"
+
+expect_block "rebase-session.json" \
+  "$(make_input "/repo/.claude/state/rebase-session.json")"
+
+expect_block "pr-gate-diagnostic.log" \
+  "$(make_input "/repo/.claude/state/pr-gate-diagnostic.log")"
+
+expect_allow "unrelated json" \
+  "$(make_input "/repo/tmp/pending-review-comments-backup.json")"
+
+expect_allow "empty file path" \
+  '{"tool_input":{"file_path":""}}'
+
+expect_allow "missing file path" \
+  '{"tool_input":{}}'
+
+echo "Total: $TOTAL  Passed: $PASSED  Failed: $FAILED"
+
+if [[ "$FAILED" -gt 0 ]]; then
+  echo "FAIL: $FAILED test(s) failed" >&2
+  exit 1
+fi
+
+echo "ALL TESTS PASSED"
+exit 0

--- a/tests/test-task-completion-comment-set-hash.sh
+++ b/tests/test-task-completion-comment-set-hash.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# test-task-completion-comment-set-hash.sh — TaskCompleted stale review-state guard
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$ROOT/hooks/task-completion-gate.sh"
+TMP_ROOT="$(mktemp -d)"
+TMP_HOME="$TMP_ROOT/home"
+TMP_REPO="$TMP_ROOT/repo"
+TMP_BIN="$TMP_ROOT/bin"
+STATE_DIR="$TMP_REPO/.claude/state"
+PENDING_FILE="$STATE_DIR/pending-review-comments.json"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_HOME" "$TMP_BIN" "$STATE_DIR"
+git -C "$TMP_REPO" init -q
+git -C "$TMP_REPO" config user.email test@example.com
+git -C "$TMP_REPO" config user.name Test
+printf '# test\n' > "$TMP_REPO/README.md"
+git -C "$TMP_REPO" add README.md
+git -C "$TMP_REPO" commit -q -m init
+git -C "$TMP_REPO" branch -M feature
+git -C "$TMP_REPO" remote add origin https://github.com/owner/repo.git
+
+cat > "$TMP_BIN/gh" <<'FAKEGH'
+#!/bin/sh
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  printf '123\n'
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/pulls/123" ]; then
+  if [ "${3:-}" = "--jq" ]; then
+    printf 'abc123\n'
+    exit 0
+  fi
+  printf '{"head":{"sha":"abc123"}}\n'
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/commits/abc123/check-runs" ]; then
+  if [ "${3:-}" = "--jq" ]; then
+    printf '0\n'
+  else
+    printf '{"check_runs":[]}\n'
+  fi
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/pulls/123/comments" ]; then
+  cat <<'JSON'
+[
+  {"id":101,"commit_id":"abc123","path":"hooks/example.sh","line":10,"body":"No high findings.\n[HIGH] historical heading only","user":{"login":"bot"},"updated_at":"2026-06-06T00:00:00Z"}
+]
+JSON
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/issues/123/comments" ]; then
+  cat <<'JSON'
+[
+  {"id":201,"body":"No critical findings.\n[CRITICAL] historical heading only","user":{"login":"claude[bot]"},"updated_at":"2026-06-06T00:01:00Z"}
+]
+JSON
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "repos/owner/repo/pulls/123/reviews" ]; then
+  printf '[]\n'
+  exit 0
+fi
+exit 1
+FAKEGH
+chmod +x "$TMP_BIN/gh"
+
+PASSED=0
+FAILED=0
+TOTAL=0
+
+calc_hash() {
+  PATH="$TMP_BIN:$PATH" bash "$ROOT/scripts/review-comment-set-hash.sh" 123 owner/repo abc123
+}
+
+write_pending() {
+  local hash="$1"
+  local include_hash="${2:-yes}"
+  HASH="$hash" INCLUDE_HASH="$include_hash" PENDING_FILE="$PENDING_FILE" python3 - <<'PY'
+import json
+import os
+
+state = {
+    "pr": "123",
+    "repo": "owner/repo",
+    "head_sha": "abc123",
+    "total": 2,
+    "critical": 0,
+    "high": 0,
+    "classification_method": "ai",
+    "ai_classification": {"critical": 0, "high": 0},
+}
+if os.environ["INCLUDE_HASH"] == "yes":
+    state["comment_set_hash"] = os.environ["HASH"]
+with open(os.environ["PENDING_FILE"], "w") as f:
+    json.dump(state, f)
+PY
+}
+
+run_hook() {
+  local payload='{"task_subject":"merge PR","task_id":"t1"}'
+  (
+    cd "$TMP_REPO"
+    HOME="$TMP_HOME" CLAUDE_PROJECT_DIR="$TMP_REPO" PATH="$TMP_BIN:$PATH" \
+      bash "$HOOK" <<<"$payload"
+  )
+}
+
+expect_rc() {
+  local desc="$1"
+  local expected="$2"
+  TOTAL=$((TOTAL + 1))
+  local rc=0
+  set +e
+  run_hook >/tmp/task_completion_hash_test.out 2>/tmp/task_completion_hash_test.err
+  rc=$?
+  set -e
+  if [[ "$rc" -eq "$expected" ]]; then
+    PASSED=$((PASSED + 1))
+    echo "  PASS: $desc (exit=$rc)"
+  else
+    FAILED=$((FAILED + 1))
+    echo "  FAIL: $desc (expected exit $expected, got $rc)" >&2
+    cat /tmp/task_completion_hash_test.err >&2 || true
+  fi
+}
+
+echo "=== task-completion comment_set_hash enforcement ==="
+
+GOOD_HASH="$(calc_hash)"
+write_pending "$GOOD_HASH"
+expect_rc "T1: matching comment_set_hash allows completion" 0
+
+write_pending "stale"
+expect_rc "T2: stale comment_set_hash blocks completion" 2
+
+write_pending "$GOOD_HASH" no
+expect_rc "T3: missing comment_set_hash blocks completion" 2
+
+echo "Total: $TOTAL  Passed: $PASSED  Failed: $FAILED"
+rm -f /tmp/task_completion_hash_test.out /tmp/task_completion_hash_test.err
+[[ "$FAILED" -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## ① なぜ

`/classify-review` が `pending-review-comments.json` を AI の `Write` で直接更新する設計になっており、環境によって tamper guard に拒否される、または AI が merge gate を自己解除できる状態でした。

`pending-review-comments.json` が保護対象に含まれていないこと、merge consumer が `classification_method=ai` を head SHA のみで信頼することも重なり、同一 head 上のレビューコメント追加・編集を stale として検出できませんでした。

Closes #235

## ② どう実装したか

- `pending-review-comments.json` を Write/Edit/Bash tamper guard と integrity check の保護対象に追加しました。
- `/classify-review` の state 更新を `scripts/classify-review-state.sh` 経由に変更し、PR/head/repo/comment hash/verdict を検証して atomic + flock で更新するようにしました。
- `scripts/review-comment-set-hash.sh` を追加し、updater と merge/task completion gate が現在の GitHub レビューコメント集合を同じ hash で検証できるようにしました。
- `inject-claude-review-helper.py` が `raw_comments[].comment_hash` と `comment_set_hash` を保存し、top-level severity を raw comment 合計から算出するようにしました。
- `pre-merge`、`inject-claude-review-on-checks`、`task-completion-gate` が stale/missing `comment_set_hash` を fail-closed に扱うようにしました。
- `/classify-review` skill から `Write` を外し、Haiku は verdict JSON 作成のみ、state 更新は検証済み script 呼び出しに限定しました。

## ③ 特にレビューしてほしい点

- `comment_set_hash` の helper/updater/gate 間の一致性。
- 同一 head 上のレビューコメント追加・編集が stale として block されること。
- `PRIMARY_LGTM`、Pass A、Pass C、TaskCompleted の各迂回経路が古い AI 分類を信頼しないこと。
- `false_positive` が混在コメント内の本物の HIGH/CRITICAL を消さないこと。
- `gh` の read/API 免除を残しつつ、ローカル state 書き込み系 subcommand を block できていること。

## ④ テスト内容・確認方法

- `git diff --check`
- `/opt/homebrew/bin/shellcheck -S error hooks/*.sh scripts/*.sh tests/test-*.sh`
- `bash -n hooks/*.sh hooks/gate-modes/*.sh scripts/*.sh tests/test-*.sh setup.sh`
- `python3 -m py_compile hooks/inject-claude-review-helper.py`
- `python3 -m json.tool settings.json`
- `.claude/settings.local.json` は worktree に存在しないため存在時のみ検証する CI 互換ガードで skip
- `bash tests/test-*.sh`（34 suites pass）
- `python3 scripts/delivery_score.py`（74.6/100、既存の `enforce-codex-for-impl.sh` 未登録のみ表示）

実ローカル環境確認:

- `bash setup.sh` は hook/script/skill のコピー完了後、任意 third-party の `ctx7` npm install で `npm: command not found` により exit 127。今回変更対象の deploy は以下で確認済み。
- `cmp` で変更した hook/script/skill が `~/.claude` と一致することを確認。
- 実インストール済み hook に stdin JSON を投げ、`pending-review-comments.json` の Write/Bash/分割 filename/`gh release download` 書き込みが block され、read-only `cat` が allow されることを確認。
- temp `CLAUDE_PROJECT_DIR` と fake `gh` で、実インストール済み `~/.claude/hooks/inject-claude-review-helper.py` と `~/.claude/scripts/classify-review-state.sh` の end-to-end 更新を確認。
