### PR TITLE
fix(hooks): deploy検証の対象repoを限定する

### DIFF
--- a/hooks/enforce-deploy-verify-on-pr.sh
+++ b/hooks/enforce-deploy-verify-on-pr.sh
@@ -7,6 +7,7 @@
 set -euo pipefail
 
 GIT_CONTEXT_DIR="${GIT_CONTEXT_DIR:-}"
+DEFAULT_MANAGED_REPO="cor-incorporated/claude-code-skills"
 
 git_ctx() {
   if [[ -n "${GIT_CONTEXT_DIR:-}" ]]; then
@@ -61,6 +62,84 @@ if top:
 PY
 }
 
+normalize_repo_slug() {
+  local ref="${1:-}"
+  [[ -n "$ref" ]] || return 1
+
+  while [[ "$ref" == */ ]]; do
+    ref="${ref%/}"
+  done
+  ref="${ref%.git}"
+  case "$ref" in
+    git@github.com:*) ref="${ref#git@github.com:}" ;;
+    ssh://git@github.com/*) ref="${ref#ssh://git@github.com/}" ;;
+    https://github.com/*) ref="${ref#https://github.com/}" ;;
+    http://github.com/*) ref="${ref#http://github.com/}" ;;
+    github.com/*) ref="${ref#github.com/}" ;;
+  esac
+
+  if [[ "$ref" =~ ^[^/]+/[^/]+$ ]]; then
+    printf '%s' "$ref" | tr '[:upper:]' '[:lower:]'
+  else
+    return 1
+  fi
+}
+
+repo_remote_matches() {
+  local project_dir="$1"
+  local expected_slug="$2"
+  local remote url slug
+
+  for remote in origin upstream; do
+    url=$(git -C "$project_dir" remote get-url "$remote" 2>/dev/null || true)
+    [[ -n "$url" ]] || continue
+    slug=$(normalize_repo_slug "$url" || true)
+    [[ "$slug" == "$expected_slug" ]] && return 0
+  done
+
+  return 1
+}
+
+project_path_matches() {
+  local project_dir="$1"
+  local repo_ref="$2"
+  local ref_top project_real ref_real project_git ref_git
+
+  [[ -d "$repo_ref" ]] || return 1
+  ref_top=$(git -C "$repo_ref" rev-parse --show-toplevel 2>/dev/null || true)
+  [[ -n "$ref_top" ]] || return 1
+
+  project_real=$(cd "$project_dir" && pwd -P)
+  ref_real=$(cd "$ref_top" && pwd -P)
+  [[ "$project_real" == "$ref_real" ]] && return 0
+
+  project_git=$(git -C "$project_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+  ref_git=$(git -C "$ref_top" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+  [[ -n "$project_git" && -n "$ref_git" ]] || return 1
+
+  project_git=$(cd "$project_git" && pwd -P)
+  ref_git=$(cd "$ref_git" && pwd -P)
+  [[ "$project_git" == "$ref_git" ]]
+}
+
+is_managed_repo() {
+  local project_dir="$1"
+  local override="${CLAUDE_CODE_SKILLS_REPO:-}"
+  local override_slug
+
+  if [[ -n "$override" ]]; then
+    if project_path_matches "$project_dir" "$override"; then
+      return 0
+    fi
+    override_slug=$(normalize_repo_slug "$override" || true)
+    if [[ -n "$override_slug" ]] && repo_remote_matches "$project_dir" "$override_slug"; then
+      return 0
+    fi
+  fi
+
+  repo_remote_matches "$project_dir" "$DEFAULT_MANAGED_REPO"
+}
+
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_name',''))" 2>/dev/null || echo "")
 [[ "$TOOL_NAME" == "Bash" ]] || exit 0
@@ -87,6 +166,8 @@ fi
 
 PROJECT_DIR=$(git_ctx rev-parse --show-toplevel 2>/dev/null || echo "")
 [[ -n "$PROJECT_DIR" ]] || exit 0
+
+is_managed_repo "$PROJECT_DIR" || exit 0
 
 BASE_BRANCH="${DEPLOY_VERIFY_BASE_BRANCH:-$(git_ctx symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || echo "develop")}"
 CHANGED_FILES=$(git_ctx diff --name-only "$BASE_BRANCH"...HEAD 2>/dev/null || git_ctx diff --name-only "$BASE_BRANCH" HEAD 2>/dev/null || echo "")

--- a/tests/test-deploy-verify-scope.sh
+++ b/tests/test-deploy-verify-scope.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# test-deploy-verify-scope.sh -- deploy drift checks only apply to managed repo assets
+set -euo pipefail
+
+PASS=0
+FAIL=0
+TOTAL=0
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { PASS=$((PASS+1)); TOTAL=$((TOTAL+1)); echo -e "${GREEN}  PASS${NC} $1"; }
+fail() { FAIL=$((FAIL+1)); TOTAL=$((TOTAL+1)); echo -e "${RED}  FAIL${NC} $1"; }
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$ROOT/hooks/enforce-deploy-verify-on-pr.sh"
+TMP_DIR=""
+HOOK_OUT=""
+HOOK_EC=0
+
+cleanup() {
+  if [[ -n "$TMP_DIR" ]]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+json_payload() {
+  CMD="$1" python3 - <<'PY'
+import json
+import os
+
+print(json.dumps({
+    "tool_name": "Bash",
+    "tool_input": {"command": os.environ["CMD"]},
+}))
+PY
+}
+
+setup_repo_with_changed_script() {
+  local repo="$1"
+  local script_name="$2"
+  local remote_url="$3"
+
+  git init "$repo" >/dev/null
+  git -C "$repo" config user.email "test@example.com"
+  git -C "$repo" config user.name "Test User"
+  git -C "$repo" checkout -b develop >/dev/null
+  if [[ -n "$remote_url" ]]; then
+    git -C "$repo" remote add origin "$remote_url"
+  fi
+
+  mkdir -p "$repo/scripts"
+  printf '#!/usr/bin/env bash\nprintf "base\\n"\n' > "$repo/scripts/$script_name"
+  git -C "$repo" add "scripts/$script_name"
+  git -C "$repo" commit -m "base" >/dev/null
+
+  git -C "$repo" checkout -b fix/deploy-scope >/dev/null
+  printf '#!/usr/bin/env bash\nprintf "feature\\n"\n' > "$repo/scripts/$script_name"
+  git -C "$repo" add "scripts/$script_name"
+  git -C "$repo" commit -m "change script" >/dev/null
+}
+
+run_hook() {
+  local repo="$1"
+  local home_dir="$2"
+  local command="$3"
+  local payload
+
+  payload=$(json_payload "$command")
+  HOOK_EC=0
+  HOOK_OUT=$(cd "$repo" && HOME="$home_dir" bash "$HOOK" <<<"$payload" 2>&1) || HOOK_EC=$?
+}
+
+run_hook_with_override() {
+  local repo="$1"
+  local home_dir="$2"
+  local command="$3"
+  local override="$4"
+  local payload
+
+  payload=$(json_payload "$command")
+  HOOK_EC=0
+  HOOK_OUT=$(cd "$repo" && HOME="$home_dir" CLAUDE_CODE_SKILLS_REPO="$override" bash "$HOOK" <<<"$payload" 2>&1) || HOOK_EC=$?
+}
+
+expect_exit() {
+  local expected="$1"
+  local label="$2"
+
+  if [[ "$HOOK_EC" -eq "$expected" ]]; then
+    pass "$label"
+  else
+    fail "$label (expected exit $expected, got $HOOK_EC: $HOOK_OUT)"
+  fi
+}
+
+expect_clean_skip_output() {
+  local label="$1"
+
+  if [[ -z "$HOOK_OUT" ]]; then
+    pass "$label"
+  else
+    fail "$label (expected silent skip, got: $HOOK_OUT)"
+  fi
+}
+
+echo "=== deploy verify repo scope tests ==="
+
+TMP_DIR="$(mktemp -d)"
+HOME_DIR="$TMP_DIR/home"
+mkdir -p "$HOME_DIR/.claude/scripts"
+
+FOREIGN_REPO="$TMP_DIR/foreign"
+setup_repo_with_changed_script \
+  "$FOREIGN_REPO" \
+  "grift-project-script.sh" \
+  "git@github.com:Cor-Incorporated/Grift.git"
+run_hook "$FOREIGN_REPO" "$HOME_DIR" "gh pr create --base develop --title 'docs: update' --body 'test'"
+expect_exit 0 "T1: foreign project-local script drift is ignored"
+expect_clean_skip_output "T2: foreign skip is silent"
+
+COLLISION_REPO="$TMP_DIR/collision"
+setup_repo_with_changed_script \
+  "$COLLISION_REPO" \
+  "codex-parallel.sh" \
+  "https://github.com/Cor-Incorporated/Grift.git"
+printf '#!/usr/bin/env bash\nprintf "deployed-other\\n"\n' > "$HOME_DIR/.claude/scripts/codex-parallel.sh"
+run_hook "$COLLISION_REPO" "$HOME_DIR" "gh pr create --base develop --title 'fix: script' --body 'test'"
+expect_exit 0 "T3: foreign basename collision is ignored"
+expect_clean_skip_output "T4: collision skip is silent"
+
+MANAGED_REPO="$TMP_DIR/managed"
+setup_repo_with_changed_script \
+  "$MANAGED_REPO" \
+  "example.sh" \
+  "git@github.com:Cor-Incorporated/claude-code-skills.git"
+rm -f "$HOME_DIR/.claude/scripts/example.sh"
+run_hook "$MANAGED_REPO" "$HOME_DIR" "gh pr create --base develop --title 'fix: managed' --body 'test'"
+expect_exit 2 "T5: managed repo missing deploy is blocked"
+
+cp "$MANAGED_REPO/scripts/example.sh" "$HOME_DIR/.claude/scripts/example.sh"
+run_hook "$MANAGED_REPO" "$HOME_DIR" "gh pr create --base develop --title 'fix: managed' --body 'test'"
+expect_exit 0 "T6: managed repo passes after deploy"
+
+MANAGED_WRONG_OVERRIDE_REPO="$TMP_DIR/managed-wrong-override"
+setup_repo_with_changed_script \
+  "$MANAGED_WRONG_OVERRIDE_REPO" \
+  "wrong-override.sh" \
+  "git@github.com:Cor-Incorporated/claude-code-skills.git"
+run_hook_with_override \
+  "$MANAGED_WRONG_OVERRIDE_REPO" \
+  "$HOME_DIR" \
+  "gh pr create --base develop --title 'fix: managed override' --body 'test'" \
+  "git@github.com:Cor-Incorporated/other-repo.git"
+expect_exit 2 "T7: managed repo is still blocked when override is wrong"
+
+MANAGED_TRAILING_REPO="$TMP_DIR/managed-trailing"
+setup_repo_with_changed_script \
+  "$MANAGED_TRAILING_REPO" \
+  "trailing.sh" \
+  "https://github.com/Cor-Incorporated/claude-code-skills.git/"
+run_hook "$MANAGED_TRAILING_REPO" "$HOME_DIR" "gh pr create --base develop --title 'fix: trailing' --body 'test'"
+expect_exit 2 "T8: managed repo URL with trailing .git slash is blocked"
+
+FORK_REPO="$TMP_DIR/fork"
+setup_repo_with_changed_script \
+  "$FORK_REPO" \
+  "upstream.sh" \
+  "git@github.com:someone/claude-code-skills.git"
+git -C "$FORK_REPO" remote add upstream "git@github.com:Cor-Incorporated/claude-code-skills.git"
+run_hook "$FORK_REPO" "$HOME_DIR" "gh pr create --base develop --title 'fix: upstream' --body 'test'"
+expect_exit 2 "T9: fork with managed upstream is blocked"
+
+PATH_REPO="$TMP_DIR/path-managed"
+PATH_WT="$TMP_DIR/path-managed-worktree"
+setup_repo_with_changed_script \
+  "$PATH_REPO" \
+  "path-override.sh" \
+  ""
+git -C "$PATH_REPO" worktree add --detach "$PATH_WT" fix/deploy-scope >/dev/null
+run_hook_with_override \
+  "$PATH_WT" \
+  "$HOME_DIR" \
+  "gh pr create --base develop --title 'fix: path override' --body 'test'" \
+  "$PATH_REPO"
+expect_exit 2 "T10: path override covers linked worktree"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed (total $TOTAL)"
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1

--- a/tests/test-pr-create-worktree-context.sh
+++ b/tests/test-pr-create-worktree-context.sh
@@ -100,7 +100,7 @@ run_deploy_hook_expect() {
   payload=$(json_payload "$cmd")
 
   local out ec=0
-  out=$(cd "$REPO" && HOME="$HOME_DIR" bash "$DEPLOY_HOOK" <<<"$payload" 2>&1) || ec=$?
+  out=$(cd "$REPO" && HOME="$HOME_DIR" CLAUDE_CODE_SKILLS_REPO="$WT" bash "$DEPLOY_HOOK" <<<"$payload" 2>&1) || ec=$?
   if [[ "$ec" -eq "$expected" ]]; then
     pass "$label"
   else


### PR DESCRIPTION
## ① なぜ

外部 repo の `scripts/*.sh` 変更まで `~/.claude/scripts` への配布対象として扱うため、Grift などの project-local script 更新だけで `gh pr create` が block される問題がありました。

`claude-code-skills/setup.sh` は claude-code-skills が配布する hook/script だけを deploy するため、外部 repo 固有 script の drift は解消できません。この hook の責務は claude-code-skills managed asset の deploy drift 防止に限定します。

Closes #237

## ② どう実装したか

- `enforce-deploy-verify-on-pr.sh` に managed repo 判定を追加しました。
- 通常は `origin` / `upstream` の remote slug が `Cor-Incorporated/claude-code-skills` の場合だけ deploy drift check を実行します。
- `CLAUDE_CODE_SKILLS_REPO` はテスト・特殊環境向けの追加条件として扱い、誤設定されても default managed remote 判定へフォールバックします。
- remote slug 正規化は `git@github.com:` / `https://github.com/` / trailing slash / `.git` を扱い、`owner/repo` 形だけを有効にしました。
- path override は linked worktree でも効くように Git common dir も比較します。
- 外部 repo は stderr なしで `exit 0` し、`setup.sh` や `未デプロイ` の案内を出しません。

## ③ 特にレビューしてほしい点

- 外部 repo skip が claude-code-skills managed repo の deploy guard を弱めていないか。
- `CLAUDE_CODE_SKILLS_REPO` の誤設定時にも default managed remote 判定で block できているか。
- `cd <worktree> && gh pr create ...` の command context が維持されているか。

## ④ テスト内容・確認方法

実行済み:

```bash
git diff --check
/opt/homebrew/bin/shellcheck -S error hooks/*.sh tests/test-*.sh
bash -n hooks/*.sh hooks/gate-modes/*.sh scripts/*.sh tests/test-*.sh setup.sh
python3 -m json.tool settings.json
for t in tests/test-*.sh; do bash "$t"; done
bash tests/enforce-factcheck-github-ops.test.sh
python3 scripts/delivery_score.py
bash setup.sh
cmp hooks/enforce-deploy-verify-on-pr.sh ~/.claude/hooks/enforce-deploy-verify-on-pr.sh
```

追加 regression:

- 外部 repo の `scripts/grift-project-script.sh` drift は `exit 0` かつ silent。
- 外部 repo の basename collision `scripts/codex-parallel.sh` も `exit 0` かつ silent。
- managed repo の missing deploy は `exit 2`。
- managed repo の deploy 後は `exit 0`。
- 誤った `CLAUDE_CODE_SKILLS_REPO` があっても managed remote は `exit 2`。
- trailing `.git/` URL、fork origin + managed upstream、path override + linked worktree を検証。
- 実 installed hook に stdin JSON を投げ、外部 repo script drift は `exit 0` silent、managed stale deploy は `exit 2`、誤 override でも managed stale deploy は `exit 2` を確認。

補足: `delivery_score.py` は 74.6/100 (B-)。今回差分外の既存 `enforce-codex-for-impl.sh` 未登録が指摘されています。
