### PR TITLE
fix(hooks): 複数messageのcommit解析を修正

### DIFF
--- a/hooks/git-commit-guard.sh
+++ b/hooks/git-commit-guard.sh
@@ -55,28 +55,89 @@ if [[ "$IS_SUBAGENT" == "false" ]]; then
 fi
 
 # --- Extract commit message ---
-commit_msg=""
-if echo "$cmd" | grep -qE "cat\s+<<"; then
-    commit_msg=$(echo "$cmd" | awk '/<<.*EOF/{found=1; next} /EOF/{exit} found && /[a-zA-Z]/{print; exit}' | sed 's/^[[:space:]]*//')
-else
-    commit_msg=$(echo "$cmd" | sed -n 's/.*-m[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
-    [ -z "$commit_msg" ] && commit_msg=$(echo "$cmd" | sed -n "s/.*-m[[:space:]]*'\\([^']*\\)'.*/\\1/p" | head -1)
-fi
+# Git allows multiple -m/--message flags and joins them as paragraphs. The
+# guard must validate the first paragraph as the subject while still accepting
+# issue references in later paragraphs.
+commit_msg=$(CMD="$cmd" python3 - <<'PY'
+import os
+import re
+import shlex
+import sys
+
+cmd = os.environ.get("CMD", "")
+
+def heredoc_message(raw: str) -> str:
+    match = re.search(r"<<-?\s*['\"]?([A-Za-z_][A-Za-z0-9_]*)['\"]?", raw)
+    if not match:
+        return ""
+    marker = match.group(1)
+    lines = raw.splitlines()
+    for i, line in enumerate(lines):
+        if "<<" in line and marker in line:
+            body = []
+            for candidate in lines[i + 1:]:
+                if candidate.strip() == marker:
+                    return "\n".join(body).strip()
+                body.append(candidate)
+            return ""
+    return ""
+
+message = heredoc_message(cmd)
+if message:
+    print(message)
+    sys.exit(0)
+
+try:
+    lexer = shlex.shlex(cmd, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    tokens = list(lexer)
+except Exception:
+    sys.exit(0)
+
+messages = []
+for i in range(len(tokens) - 1):
+    if tokens[i:i + 2] != ["git", "commit"]:
+        continue
+    j = i + 2
+    while j < len(tokens):
+        token = tokens[j]
+        if token in {"&&", "||", ";", "|"}:
+            break
+        if token in {"-m", "--message"} and j + 1 < len(tokens):
+            messages.append(tokens[j + 1])
+            j += 2
+            continue
+        if token.startswith("--message="):
+            messages.append(token.split("=", 1)[1])
+            j += 1
+            continue
+        if token.startswith("-m") and token != "-m":
+            messages.append(token[2:])
+            j += 1
+            continue
+        j += 1
+    break
+
+if messages:
+    print("\n\n".join(messages))
+PY
+)
 
 [ -z "$commit_msg" ] && exit 0
 commit_msg=$(echo "$commit_msg" | sed 's/^[[:space:]]*//')
+commit_subject=$(printf '%s\n' "$commit_msg" | sed -n '/[^[:space:]]/{p; q;}')
 
 # --- 1. Conventional Commit format ---
 VALID_TYPES="feat|fix|refactor|docs|test|chore|perf|ci|release"
-if ! echo "$commit_msg" | grep -qE "^(${VALID_TYPES})(\\(.+\\))?: .+"; then
-    echo "[BLOCKED] Invalid commit format: \"${commit_msg}\"" >&2
+if ! echo "$commit_subject" | grep -qE "^(${VALID_TYPES})(\\(.+\\))?: .+"; then
+    echo "[BLOCKED] Invalid commit format: \"${commit_subject}\"" >&2
     echo "Required: <type>: <description> (feat/fix/refactor/docs/test/chore/perf/ci/release)" >&2
     exit 2
 fi
 
 # --- 2. Issue reference (skip chore/docs/ci/release/merge) ---
-if ! echo "$commit_msg" | grep -qEi "^(chore|docs|ci|release|Merge|initial)"; then
-    if ! echo "$cmd" | grep -qE '#[0-9]+'; then
+if ! echo "$commit_subject" | grep -qEi "^(chore|docs|ci|release|Merge|initial)"; then
+    if ! echo "$commit_msg" | grep -qE '#[0-9]+'; then
         echo "[BLOCKED] Issue reference (#XX) required in commit message" >&2
         echo "Exempt types: chore, docs, ci, release" >&2
         exit 2

--- a/tests/test-git-commit-guard.sh
+++ b/tests/test-git-commit-guard.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Regression tests for hooks/git-commit-guard.sh commit message parsing.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$REPO_DIR/hooks/git-commit-guard.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+TEST_DIR=$(mktemp -d /tmp/git-commit-guard.XXXXXX)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+cd "$TEST_DIR"
+git init >/dev/null
+git config user.email "test@example.com"
+git config user.name "Test User"
+git remote add origin https://github.com/example/test-repo.git
+touch README.md
+git add README.md
+git commit -m "initial commit" >/dev/null
+
+make_input() {
+  local command="$1"
+  jq -nc --arg command "$command" '{"tool_input":{"command":$command}}'
+}
+
+expect_allow() {
+  local desc="$1"
+  local command="$2"
+  TOTAL=$((TOTAL + 1))
+  local rc=0
+  make_input "$command" | bash "$HOOK" >/dev/null 2>/dev/null || rc=$?
+  if [[ "$rc" -eq 0 ]]; then
+    PASS=$((PASS + 1))
+    echo "PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $desc (expected 0, got $rc)" >&2
+  fi
+}
+
+expect_block() {
+  local desc="$1"
+  local command="$2"
+  TOTAL=$((TOTAL + 1))
+  local rc=0
+  make_input "$command" | bash "$HOOK" >/dev/null 2>/dev/null || rc=$?
+  if [[ "$rc" -eq 2 ]]; then
+    PASS=$((PASS + 1))
+    echo "PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $desc (expected 2, got $rc)" >&2
+  fi
+}
+
+expect_allow "複数 -m の本文にあるIssue参照を許可" \
+  'git commit -m "fix(estimate): 根拠不足時のready化を防止" -m "Refs: #687"'
+
+expect_allow "multiline -m の本文にあるIssue参照を許可" \
+  $'git commit -m "fix(estimate): 根拠不足時のready化を防止\n\nRefs: #687"'
+
+expect_allow "--message= 形式のIssue参照を許可" \
+  'git commit --message="fix(estimate): 根拠不足時のready化を防止" --message="Refs: #687"'
+
+expect_block "本文にもIssue参照がないfix commitを拒否" \
+  'git commit -m "fix(estimate): 根拠不足時のready化を防止" -m "no issue reference"'
+
+expect_block "複数 -m の本文をsubject扱いしない" \
+  'git commit -m "fix(estimate): 根拠不足時のready化を防止" -m "Refs issue-687"'
+
+if [[ "$FAIL" -gt 0 ]]; then
+  echo "FAILED: $FAIL/$TOTAL tests" >&2
+  exit 1
+fi
+
+echo "PASSED: $PASS/$TOTAL tests"


### PR DESCRIPTION
## ① なぜ

Claude Code の `git-commit-guard.sh` が `git commit -m "subject" -m "Refs: #687"` のような一般的な複数 message 形式を誤解析し、本文側の `Refs` を subject として扱っていた。

このため、Cursor など外部レーンが正しいコミット形式で作業を返しても、親オーケストレータの publish 前に commit guard が不要にブロックする可能性があった。

## ② どう実装したか

- `git commit` の `-m` / `--message` / `--message=` を shlex ベースで抽出
- 複数 message は Git と同じく段落として結合
- Conventional Commit 判定は先頭 paragraph の subject に限定
- Issue 参照は本文を含む commit message 全体から検出
- heredoc commit message も既存互換として保持
- 回帰テスト `tests/test-git-commit-guard.sh` を追加

## ③ レビュー注目点

- 複数 `-m` の本文を subject と誤判定しないこと
- Issue 参照なしの non-exempt commit は引き続きブロックされること
- subagent の GitHub write block には触れていないこと

## ④ テスト/確認方法

- `bash tests/test-git-commit-guard.sh`
- `bash -n hooks/git-commit-guard.sh tests/test-git-commit-guard.sh`
- `git diff --check`
- live deploy確認: `~/.claude/hooks/git-commit-guard.sh` に反映し、Cursor worktree上で複数 `-m` が ruff gate まで到達することを確認

Refs: Cor-Incorporated/Grift#687
