### PR TITLE
fix(hooks): JSONのsubagent publishを遮断

### DIFF
--- a/hooks/block-subagent-github-write.sh
+++ b/hooks/block-subagent-github-write.sh
@@ -9,16 +9,24 @@
 
 set -euo pipefail
 
-if [[ "${CLAUDE_AGENT_DEPTH:-0}" -lt 1 ]] && [[ -z "${CLAUDE_AGENT_ID:-}" ]]; then
-  exit 0
-fi
-
 input=""
 if [[ ! -t 0 ]]; then
   input=$(cat 2>/dev/null || echo "")
 fi
-[[ -z "$input" ]] && exit 0
 command -v jq &>/dev/null || exit 0
+
+json_agent_id=""
+if [[ -n "$input" ]]; then
+  json_agent_id=$(echo "$input" | jq -r '.agent_id // ""' 2>/dev/null || echo "")
+fi
+
+if [[ "${CLAUDE_AGENT_DEPTH:-0}" -lt 1 ]] \
+   && [[ -z "${CLAUDE_AGENT_ID:-}" ]] \
+   && [[ -z "$json_agent_id" ]]; then
+  exit 0
+fi
+
+[[ -z "$input" ]] && exit 0
 
 tool_name=$(echo "$input" | jq -r '.tool_name // ""' 2>/dev/null || echo "")
 [[ "$tool_name" == "Bash" ]] || exit 0

--- a/tests/test-subagent-github-write-guard.sh
+++ b/tests/test-subagent-github-write-guard.sh
@@ -52,21 +52,32 @@ else
   fail "T4: read-only gh command should not be blocked"
 fi
 
+payload='{"agent_id":"worker-json-only","tool_name":"Bash","tool_input":{"command":"gh pr create --base develop"}}'
+if out=$(echo "$payload" | bash "$HOOK" 2>&1); then
+  fail "T5: JSON agent_id gh pr create should be blocked"
+else
+  if [[ "$out" == *"Git/GitHub 書き込み"* ]]; then
+    pass "T5: JSON agent_id gh pr create blocked"
+  else
+    fail "T5: JSON agent_id block message missing"
+  fi
+fi
+
 payload='{"tool_name":"Bash","tool_input":{"command":"gh pr create --base develop"}}'
 if out=$(echo "$payload" | bash "$HOOK" 2>&1); then
   if [[ -z "$out" ]]; then
-    pass "T5: parent session bypasses hook"
+    pass "T6: parent session bypasses hook"
   else
-    fail "T5: expected no output for parent session"
+    fail "T6: expected no output for parent session"
   fi
 else
-  fail "T5: parent session should not be blocked"
+  fail "T6: parent session should not be blocked"
 fi
 
 if grep -q 'block-subagent-github-write.sh' "$SETTINGS"; then
-  pass "T6: settings.json registers guard hook"
+  pass "T7: settings.json registers guard hook"
 else
-  fail "T6: settings.json missing guard hook registration"
+  fail "T7: settings.json missing guard hook registration"
 fi
 
 echo ""


### PR DESCRIPTION
## ① なぜ

`block-subagent-github-write.sh` は worker/subagent からの `git push` / `gh pr create` を親オーケストレータへ戻すための hook だが、env ではなく stdin JSON の `agent_id` だけで worker 文脈が渡る場合に早期 exit していた。これにより JSON-only の subagent publish がすり抜ける余地があった。

## ② どう実装したか

- hook 入力 JSON を env 判定より先に読み込むように変更
- `CLAUDE_AGENT_DEPTH` / `CLAUDE_AGENT_ID` / JSON `agent_id` のいずれかで subagent と判定
- JSON-only `agent_id` の `gh pr create` 回帰テストを追加
- parent session と read-only `gh pr view` の許可は維持

## ③ レビュー注目点

- parent session の publish を誤ブロックしないこと
- JSON-only worker 文脈だけを追加で block していること
- read-only command の bypass 条件を広げていないこと

## ④ テスト/確認方法

- `bash -n hooks/block-subagent-github-write.sh`
- `bash tests/test-subagent-github-write-guard.sh`
- JSON-only `agent_id` + `git push` payload が exit 2 になることを手動確認

Refs: #240
