### PR TITLE
fix(settings): Claude Codeのmodel設定を修正

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -46,7 +46,7 @@
     ],
     "defaultMode": "dontAsk"
   },
-  "model": "opus[1m]",
+  "model": "opus",
   "hooks": {
     "SessionStart": [
       {

--- a/tests/test-settings-config.sh
+++ b/tests/test-settings-config.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# test-settings-config.sh -- Validate repo-owned Claude Code settings.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+TOTAL=0
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); echo -e "${GREEN}  PASS${NC} $1"; }
+fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); echo -e "${RED}  FAIL${NC} $1"; }
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SETTINGS="$ROOT/settings.json"
+
+echo "=== Settings config tests ==="
+
+if python3 -m json.tool "$SETTINGS" >/dev/null; then
+  pass "T1: settings.json is valid JSON"
+else
+  fail "T1: settings.json is invalid JSON"
+fi
+
+model=$(python3 - <<'PY' "$SETTINGS"
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as f:
+    print(json.load(f).get("model", ""))
+PY
+)
+
+if [[ "$model" == "opus" ]]; then
+  pass "T2: model uses the Claude Code opus alias"
+else
+  fail "T2: expected model 'opus', got '$model'"
+fi
+
+if python3 - <<'PY' "$model"
+import re
+import sys
+
+model = sys.argv[1]
+has_control = any(ord(ch) < 32 or ord(ch) == 127 for ch in model)
+has_ansi_escape = bool(re.search(r"\x1b\[[0-9;]*m", model))
+has_rendered_ansi = bool(re.search(r"\[[0-9;]*m", model))
+sys.exit(1 if has_control or has_ansi_escape or has_rendered_ansi else 0)
+PY
+then
+  pass "T3: model contains no ANSI/control fragments"
+else
+  fail "T3: model contains ANSI/control fragments"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed (total $TOTAL)"
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## ① なぜ

`settings.json` の `model` に `opus[1m]` が入っており、Claude Code が `claude-opus-4-8[1m]` のような無効なモデル名として扱っていました。

その結果、Bash や Skill 起動時の安全判定用モデル呼び出しが失敗するため、repo-owned 設定から修正します。

Closes #243

## ② どう実装したか

- `settings.json` の `model` を有効な alias の `opus` に戻しました。
- `tests/test-settings-config.sh` を追加し、JSON 妥当性、`model == "opus"`、ANSI/control 断片の混入なしを検査するようにしました。

## ③ レビュー注目点

- Claude Code の alias として `opus` に固定する判断が妥当か。
- 回帰テストが今回の `\x1b[` / `[1m]` 系混入を十分に検出できるか。

## ④ テスト/確認方法

- `python3 -m json.tool settings.json`
- `bash -n hooks/*.sh scripts/*.sh setup.sh`
- `shellcheck -S error hooks/*.sh`
- `bash tests/test-settings-config.sh`
- `bash tests/test-local-permissions-guard.sh`
- `for t in tests/*.sh; do bash "$t"; done`
- `./setup.sh`
- `jq -r '.model' ~/.claude/settings.json`
- Claude Code 非対話実行で `Bash pwd` が成功し、初期化モデルが `claude-opus-4-8` になることを確認
- Claude Code 非対話実行で `Skill(gws-workspace)` が `Launching skill: gws-workspace` として成功することを確認