### PR TITLE
fix(hooks): UAT証跡必須hookを追加

### DIFF
--- a/hooks/enforce-uat-evidence.sh
+++ b/hooks/enforce-uat-evidence.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# enforce-uat-evidence.sh
+# PreToolUse(Bash): UAT/UX/E2E/browser completion claims need concrete evidence.
+
+set -euo pipefail
+
+input=""
+if [[ ! -t 0 ]]; then
+  input=$(cat 2>/dev/null || echo "")
+fi
+
+if [[ -z "$input" ]]; then
+  exit 0
+fi
+
+COMMAND=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+if [[ -z "$COMMAND" ]]; then
+  exit 0
+fi
+
+FIRST_LINE=$(printf '%s\n' "$COMMAND" | head -n 1)
+
+is_inspection_command() {
+  local cmd="$1"
+
+  [[ "$cmd" != *$'\n'* ]] || return 1
+  if printf '%s' "$cmd" | grep -qE '[;&|`<>]|\$\('; then
+    return 1
+  fi
+  printf '%s' "$cmd" | grep -qE '^[[:space:]]*(rg|grep|egrep|fgrep|cat|head|tail|wc|comm|diff|cut|tr|uniq|jq|ls|which|type|sed|awk|find)\b'
+}
+
+has_uat_trigger() {
+  printf '%s' "$COMMAND" | grep -Eiq '(UAT|UX|E2E|操作テスト|ブラウザ|browser|テスト済み?|完了|β[[:space:]]*Ready|Beta[[:space:]]*Ready|Issue[[:space:]]*close)'
+}
+
+is_github_guarded_operation() {
+  printf '%s' "$COMMAND" | grep -Eiq '(^|[;&|[:space:]])gh[[:space:]]+issue[[:space:]]+(create|comment|close)\b|(^|[;&|[:space:]])gh[[:space:]]+pr[[:space:]]+merge\b'
+}
+
+is_issue_blocker_report() {
+  printf '%s' "$COMMAND" | grep -Eiq '(^|[;&|[:space:]])gh[[:space:]]+issue[[:space:]]+(create|comment)\b' &&
+    printf '%s' "$COMMAND" | grep -Eiq '(未検証|未確認|未完了|未実施|未テスト|blocker|blocked|blocking|unverified|not[[:space:]-]+verified|not[[:space:]-]+tested|cannot[[:space:]-]+verify|要検証|要確認|失敗|failed|failure|NG|red|エラー|不具合|バグ|close不可|クローズ不可)'
+}
+
+is_completion_like_command() {
+  printf '%s' "$COMMAND" | grep -Eiq '(^|[;&|])[[:space:]]*(echo|printf|cat[[:space:]]*<<|tee|pbcopy|osascript)\b'
+}
+
+has_full_evidence() {
+  local has_label=false
+  local has_execution=false
+  local has_artifact=false
+  local has_outcome=false
+
+  if printf '%s' "$COMMAND" | grep -Eiq '(evidence|証拠|根拠|確認結果|検証結果|verification|verified|確認済み?|検証済み?)'; then
+    has_label=true
+  fi
+  if printf '%s' "$COMMAND" | grep -Eiq '(playwright|cypress|selenium|browser|ブラウザ|操作テスト|E2E|UAT|UX|lighthouse|manual|手動|npx|npm[[:space:]]+run|pnpm|yarn|bun|pytest|curl)'; then
+    has_execution=true
+  fi
+  if printf '%s' "$COMMAND" | grep -Eiq '(https?://|screenshot|スクリーンショット|video|録画|trace|artifact|HAR|ログ|log|stdout|標準出力|exit[[:space:]]+0|pass_rate|[^[:space:]]+\.(png|jpe?g|webm|mp4|mov|zip|har|trace|log))'; then
+    has_artifact=true
+  fi
+  if printf '%s' "$COMMAND" | grep -Eiq '(PASS|passed|passing|成功|OK|green|exit[[:space:]]+0|確認済み?|verified|テスト済み?|完了|pass_rate[[:space:]:=]+1(\.0)?)'; then
+    has_outcome=true
+  fi
+
+  [[ "$has_label" == true && "$has_execution" == true && "$has_artifact" == true && "$has_outcome" == true ]]
+}
+
+if ! has_uat_trigger; then
+  exit 0
+fi
+
+if is_inspection_command "$FIRST_LINE"; then
+  exit 0
+fi
+
+if ! is_github_guarded_operation && ! is_completion_like_command; then
+  exit 0
+fi
+
+if is_issue_blocker_report; then
+  exit 0
+fi
+
+if has_full_evidence; then
+  exit 0
+fi
+
+cat >&2 <<'ERRMSG'
+
+🚫 [BLOCKED] UAT/UX/E2E/ブラウザ完了主張に証拠が不足しています
+
+UAT・操作テスト・E2E・ブラウザ確認・β Ready・Issue close などを
+gh issue create/comment/close、gh pr merge、または完了報告系の shell
+command に含める場合は、本文に以下を含めてください:
+
+  - 証拠ラベル: Evidence / 証拠 / 検証結果 / 確認結果
+  - 実行面: Playwright/Cypress/ブラウザ/手動操作テスト/実行コマンド
+  - 具体物: URL、スクリーンショット、録画、trace、log、exit 0 など
+  - 結果: PASS / passed / 成功 / 確認済み
+
+ブロッカー・未検証・失敗を報告する gh issue create/comment は許可されます。
+
+例:
+  Evidence: Playwright browser E2E passed.
+  Command: npx playwright test tests/e2e/login.spec.ts (exit 0)
+  URL: https://example.com
+  Screenshot: artifacts/uat-login.png
+
+ERRMSG
+
+exit 2

--- a/settings.json
+++ b/settings.json
@@ -224,6 +224,12 @@
           },
           {
             "type": "command",
+            "command": "bash ~/.claude/hooks/enforce-uat-evidence.sh",
+            "timeout": 10,
+            "statusMessage": "Checking UAT/UX/E2E/browser evidence..."
+          },
+          {
+            "type": "command",
             "command": "bash ~/.claude/hooks/enforce-factcheck-github-ops.sh",
             "timeout": 10,
             "statusMessage": "Checking factcheck before GitHub write operation..."

--- a/tests/test-uat-evidence-hook.sh
+++ b/tests/test-uat-evidence-hook.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# test-uat-evidence-hook.sh — UAT/UX/E2E/browser evidence gate
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$ROOT/hooks/enforce-uat-evidence.sh"
+
+PASSED=0
+FAILED=0
+TOTAL=0
+
+make_input() {
+  local command="$1"
+  jq -nc --arg command "$command" '{"tool_input":{"command":$command}}'
+}
+
+run_hook() {
+  local command="$1"
+  make_input "$command" | bash "$HOOK" >/tmp/uat_evidence_test.out 2>/tmp/uat_evidence_test.err
+}
+
+expect_rc() {
+  local desc="$1"
+  local expected="$2"
+  local command="$3"
+  local rc=0
+
+  TOTAL=$((TOTAL + 1))
+  set +e
+  run_hook "$command"
+  rc=$?
+  set -e
+
+  if [[ "$rc" -eq "$expected" ]]; then
+    PASSED=$((PASSED + 1))
+    echo "  PASS: $desc (exit=$rc)"
+  else
+    FAILED=$((FAILED + 1))
+    echo "  FAIL: $desc (expected exit $expected, got $rc)" >&2
+    echo "  command: $command" >&2
+    cat /tmp/uat_evidence_test.err >&2 || true
+  fi
+}
+
+cleanup() {
+  rm -f /tmp/uat_evidence_test.out /tmp/uat_evidence_test.err
+}
+trap cleanup EXIT
+
+echo "=== UAT evidence hook ==="
+
+expect_rc \
+  "T1: no evidence blocks UAT completion issue comment" \
+  2 \
+  'gh issue comment 123 --body "UAT完了。ブラウザ操作テスト済。Issue close可能です"'
+
+expect_rc \
+  "T2: full evidence allows UAT completion issue comment" \
+  0 \
+  'gh issue comment 123 --body "UAT完了。Evidence: Playwright browser E2E passed. Command: npx playwright test tests/e2e/login.spec.ts (exit 0). URL: https://example.com. Screenshot: artifacts/uat-login.png"'
+
+expect_rc \
+  "T3: blocker/unverified issue creation is allowed" \
+  0 \
+  'gh issue create --title "UAT blocker: ブラウザ未検証" --body "E2E is unverified because login fails; blocker report, not completion."'
+
+expect_rc \
+  "T4: non-UAT GitHub write is non-interfering" \
+  0 \
+  'gh issue comment 123 --body "Docs updated; no runtime claim."'
+
+expect_rc \
+  "T5: E2E test command is non-interfering" \
+  0 \
+  'npm run test:e2e'
+
+expect_rc \
+  "T6: completion-like shell claim without evidence blocks" \
+  2 \
+  'printf "%s\n" "β Ready 完了"'
+
+expect_rc \
+  "T7: completion-like shell claim with evidence allows" \
+  0 \
+  'printf "%s\n" "β Ready 完了。Evidence: Playwright browser E2E passed. Command: npx playwright test tests/e2e/login.spec.ts (exit 0). Screenshot: artifacts/uat-login.png"'
+
+expect_rc \
+  "T8: read-only inspection mentioning UAT is non-interfering" \
+  0 \
+  'rg "UAT完了" docs'
+
+echo "Total: $TOTAL  Passed: $PASSED  Failed: $FAILED"
+[[ "$FAILED" -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## なぜ
BenevolentDirector の 2026-06-23 UAT failure を受け、コード完成やmock確認だけで UAT/UX/E2E/ブラウザ完了を名乗らないようにするためです。

Closes #246
Refs #245

## どう実装したか
- Bash PreToolUse に `enforce-uat-evidence.sh` を追加
- `gh issue create/comment/close`、`gh pr merge`、完了報告系shell command の UAT/UX/E2E/ブラウザ文脈を検査
- 証跡不足はblockし、blocker/未検証報告とread-only検査は許可

## レビュー注目点
- 完了主張だけを止め、調査・失敗報告・未検証blockerを止めすぎないこと
- 既存の issue close / factcheck / PR gate hook と競合しないこと

## テスト/確認方法
- `bash tests/test-uat-evidence-hook.sh`
- `bash tests/test-settings-config.sh`
- `bash tests/test-cleanup-prunes-pending.sh`
- `bash tests/test-enforce-review-reading-merged.sh`
- `jq empty settings.json`
- `git diff --check`