### PR TITLE
fix(hooks): UAT証跡hookの誤検知を修正

### DIFF
--- a/hooks/enforce-uat-evidence.sh
+++ b/hooks/enforce-uat-evidence.sh
@@ -24,23 +24,31 @@ is_inspection_command() {
   local cmd="$1"
 
   [[ "$cmd" != *$'\n'* ]] || return 1
-  if printf '%s' "$cmd" | grep -qE '[;&|`<>]|\$\('; then
+  if printf '%s' "$cmd" | grep -qE '[;&`<>]|\$\('; then
     return 1
   fi
-  printf '%s' "$cmd" | grep -qE '^[[:space:]]*(rg|grep|egrep|fgrep|cat|head|tail|wc|comm|diff|cut|tr|uniq|jq|ls|which|type|sed|awk|find)\b'
+  printf '%s' "$cmd" | grep -qE '^[[:space:]]*(rg|grep|egrep|fgrep|cat|head|tail|wc|comm|diff|cut|tr|uniq|jq|ls|which|type|sed|awk|find|git[[:space:]]+status)\b'
 }
 
-has_uat_trigger() {
-  printf '%s' "$COMMAND" | grep -Eiq '(UAT|UX|E2E|操作テスト|ブラウザ|browser|テスト済み?|完了|β[[:space:]]*Ready|Beta[[:space:]]*Ready|Issue[[:space:]]*close)'
+has_uat_context() {
+  printf '%s' "$COMMAND" | grep -Eiq '(UAT|UX|E2E|操作テスト|ブラウザ|browser|browser[-[:space:]]+test|ユーザー?[[:space:]-]*ジャーニー|UI[[:space:]-]*(proof|evidence|検証|確認)|live[[:space:]-]+verification|ライブ検証|本番検証|β[[:space:]]*Ready|Beta[[:space:]]*Ready)'
+}
+
+has_completion_claim() {
+  printf '%s' "$COMMAND" | grep -Eiq '(完了|完遂|テスト済み?|検証済み?|確認済み?|通過|合格|解決|修正済|close[[:space:]]*可能|ready[[:space:]]+to[[:space:]]+close|ready[[:space:]]+for[[:space:]]+(merge|review)|PR[[:space:]-]*ready|β[[:space:]]*Ready|Beta[[:space:]]*Ready|Issue[[:space:]]*close|クローズ|マージ|merged?|mergeable|completed?|done|resolved|fixed|verified|validated|passed|passing)'
 }
 
 is_github_guarded_operation() {
-  printf '%s' "$COMMAND" | grep -Eiq '(^|[;&|[:space:]])gh[[:space:]]+issue[[:space:]]+(create|comment|close)\b|(^|[;&|[:space:]])gh[[:space:]]+pr[[:space:]]+merge\b'
+  printf '%s' "$COMMAND" | grep -Eiq '(^|[;&|[:space:]])gh[[:space:]]+issue[[:space:]]+(create|comment|close)\b|(^|[;&|[:space:]])gh[[:space:]]+pr[[:space:]]+(create|comment|review|merge|ready)\b'
 }
 
-is_issue_blocker_report() {
-  printf '%s' "$COMMAND" | grep -Eiq '(^|[;&|[:space:]])gh[[:space:]]+issue[[:space:]]+(create|comment)\b' &&
-    printf '%s' "$COMMAND" | grep -Eiq '(未検証|未確認|未完了|未実施|未テスト|blocker|blocked|blocking|unverified|not[[:space:]-]+verified|not[[:space:]-]+tested|cannot[[:space:]-]+verify|要検証|要確認|失敗|failed|failure|NG|red|エラー|不具合|バグ|close不可|クローズ不可)'
+is_terminal_github_operation() {
+  printf '%s' "$COMMAND" | grep -Eiq '(^|[;&|[:space:]])gh[[:space:]]+issue[[:space:]]+close\b|(^|[;&|[:space:]])gh[[:space:]]+pr[[:space:]]+(merge|ready)\b'
+}
+
+is_blocker_or_unverified_status() {
+  ! is_terminal_github_operation &&
+    printf '%s' "$COMMAND" | grep -Eiq '(未検証|未確認|未完了|未実施|未テスト|blocker|blocked|blocking|unverified|not[[:space:]-]+verified|not[[:space:]-]+tested|cannot[[:space:]-]+verify|要検証|要確認|確認待ち|証跡不足|証跡待ち|証跡なし|失敗|failed|failure|NG|red|エラー|不具合|バグ|close不可|クローズ不可)'
 }
 
 is_completion_like_command() {
@@ -69,7 +77,7 @@ has_full_evidence() {
   [[ "$has_label" == true && "$has_execution" == true && "$has_artifact" == true && "$has_outcome" == true ]]
 }
 
-if ! has_uat_trigger; then
+if ! has_uat_context; then
   exit 0
 fi
 
@@ -77,11 +85,15 @@ if is_inspection_command "$FIRST_LINE"; then
   exit 0
 fi
 
-if ! is_github_guarded_operation && ! is_completion_like_command; then
+if is_blocker_or_unverified_status; then
   exit 0
 fi
 
-if is_issue_blocker_report; then
+if ! has_completion_claim && ! is_terminal_github_operation; then
+  exit 0
+fi
+
+if ! is_github_guarded_operation && ! is_completion_like_command; then
   exit 0
 fi
 

--- a/tests/test-uat-evidence-hook.sh
+++ b/tests/test-uat-evidence-hook.sh
@@ -90,5 +90,45 @@ expect_rc \
   0 \
   'rg "UAT完了" docs'
 
+expect_rc \
+  "T9: read-only rg investigation with alternation is allowed" \
+  0 \
+  'rg -n "UAT|UX|E2E|browser|完了|close|merge|PR ready|unverified|blocker" hooks tests'
+
+expect_rc \
+  "T10: read-only find investigation is allowed" \
+  0 \
+  'find hooks tests -maxdepth 2 -type f -name "*uat*"'
+
+expect_rc \
+  "T11: git status investigation is allowed" \
+  0 \
+  'git status --short --branch'
+
+expect_rc \
+  "T12: blocker/unverified shell status is allowed" \
+  0 \
+  'printf "%s\n" "UAT blocker: browser live evidence is unverified; close不可。証跡待ちです"'
+
+expect_rc \
+  "T13: no evidence blocks UAT PR merge" \
+  2 \
+  'gh pr merge 248 --merge --body "UAT/UXブラウザ確認済み。mergeします"'
+
+expect_rc \
+  "T14: no evidence blocks browser PR ready declaration" \
+  2 \
+  'printf "%s\n" "Browser E2E passed. PR ready"'
+
+expect_rc \
+  "T15: no evidence blocks gh pr ready in UAT context" \
+  2 \
+  'gh pr ready 248 # UAT browser complete'
+
+expect_rc \
+  "T16: full evidence allows gh pr ready in UAT context" \
+  0 \
+  'gh pr ready 248 # UAT browser complete. Evidence: Playwright browser E2E passed. Command: npx playwright test tests/e2e/login.spec.ts (exit 0). Screenshot: artifacts/uat-login.png'
+
 echo "Total: $TOTAL  Passed: $PASSED  Failed: $FAILED"
 [[ "$FAILED" -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## なぜ

Closes #250

UAT 証跡 hook が計画・調査・未検証ステータスまで強く扱うと、実装前の調査やブロッカー記録まで止まり、事故再発防止のための運用自体が阻害されるため。

## どう実装したか

- UAT 判定を context と completion claim に分離。
- read-only 調査系コマンドを allow する対象に `rg` alternation、`find`、`git status` を追加。
- blocker/unverified status を完了宣言として扱わないようにした。
- `gh pr ready` / PR ready / PR merge など、完了・merge 系は証跡必須のまま維持。

## レビュー注目点

- blocker/unverified status が issue close / PR merge / PR ready をすり抜けないこと。
- 調査系コマンドだけが allow され、書き込み系の完了宣言は block されること。

## テスト/確認方法

- PASS `bash tests/test-uat-evidence-hook.sh` 16/16
- PASS `bash tests/test-settings-config.sh` 3/3
- PASS `bash -n hooks/enforce-uat-evidence.sh tests/test-uat-evidence-hook.sh`
- PASS `git diff --check`
- PASS `cmp hooks/enforce-uat-evidence.sh ~/.claude/hooks/enforce-uat-evidence.sh`

## ローカル deploy 証跡

- `~/.claude/hooks/enforce-uat-evidence.sh` へ単体 deploy 済み
- drift check: `claude-hook-in-sync`
- 証跡ログ: `/private/tmp/claude-code-skills-uat-hook-20260624/`
